### PR TITLE
fix: flaky CI tests - replace hardcoded sleeps with waitFor polling

### DIFF
--- a/tests/compat-reliability.test.ts
+++ b/tests/compat-reliability.test.ts
@@ -1021,12 +1021,11 @@ describeEachMode('Memory and resource management', (CONNECTION) => {
     await Promise.all(addPromises);
 
     // Wait for all to be processed
-    const start = Date.now();
-    while (completedCount.value < jobCount && Date.now() - start < 30000) {
-      await new Promise((r) => setTimeout(r, 200));
-    }
+    await waitFor(() => completedCount.value >= jobCount, 30000, 200);
 
-    // Access activePromises via the private property to check it's bounded
+    // Wait for activePromises cleanup (finally() blocks are async)
+    await waitFor(() => ((worker as any).activePromises?.size ?? 0) === 0, 5000, 50);
+
     const activePromisesSize = (worker as any).activePromises?.size ?? 0;
     expect(activePromisesSize).toBe(0);
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `setTimeout` waits with `waitFor` polling in two flaky integration tests
- Both tests failed intermittently in CI (Node 22, cluster mode) due to scheduler timing variance

## Changes

**bulletproof.test.ts** - "20 stalled jobs all move to failed"
- Replaced 5s hardcoded sleep with `waitFor` that polls actual job states until all 20 are `'failed'` (15s timeout)

**compat-reliability.test.ts** - "100 rapid add+process cycles"
- Added `waitFor` to wait for `activePromises` cleanup before asserting `size === 0`
- The `finally()` blocks that clean up `activePromises` execute asynchronously

## Test Plan

- [x] Build passes
- [x] 53 local tests pass (job.test.ts + testing-mode.test.ts)
- [ ] CI integration tests pass on Node 20 and Node 22