### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix prototype pollution in hashDataToRecord

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - [Security Enhancements to Utilities]
+**Vulnerability:** `hashDataToRecord` instantiated a standard object `{}` which could be vulnerable to prototype pollution if a `__proto__` key is received from the datastore.
+**Learning:** Deserialization of key-value pairs from external stores must use prototype-less objects (`Object.create(null)`) to prevent prototype pollution attacks. Note: Changing backoff jitter to CSPRNG is unnecessary security theater and causes performance regressions.
+**Prevention:** Always use `Object.create(null)` when building dictionaries from external data.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,7 +127,7 @@ export function hashDataToRecord(
   hashData: { field?: unknown; key?: unknown; value: unknown }[] | null,
 ): Record<string, string> | null {
   if (!hashData || hashData.length === 0) return null;
-  const record: Record<string, string> = {};
+  const record: Record<string, string> = Object.create(null);
   for (const entry of hashData) {
     // Batch hgetall returns {key, value}; direct hgetall returns {field, value}
     const k = entry.field ?? entry.key;

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -379,9 +379,7 @@ describe('Queue', () => {
       mockClient.fcall.mockResolvedValueOnce(LIBRARY_VERSION);
       const queue = new Queue('test-queue', connOpts);
       const oversized = { data: 'x'.repeat(MAX_JOB_DATA_SIZE) };
-      await expect(
-        queue.addBulk([{ name: 'test', data: oversized }]),
-      ).rejects.toThrow('Job data exceeds maximum size');
+      await expect(queue.addBulk([{ name: 'test', data: oversized }])).rejects.toThrow('Job data exceeds maximum size');
     });
 
     it('add enforces byte length not character count', async () => {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `hashDataToRecord` instantiated a standard object `{}` which could be vulnerable to prototype pollution if a `__proto__` key is received from the datastore.
🎯 Impact: An attacker could potentially send manipulated payloads with `__proto__` fields which could pollute the constructed job hash objects or the global prototype depending on its downstream usage.
🔧 Fix: Updated dictionary object initialization from `{}` to `Object.create(null)`.
✅ Verification: Ran unit tests via `bun test` and `pnpm test` (with `npm test`) to ensure functionality behaves exactly identically while being robust against prototype pollution. Also formatted via `npm run format`.

---
*PR created automatically by Jules for task [660513792605093672](https://jules.google.com/task/660513792605093672) started by @avifenesh*