### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Zip Bomb DoS in `gunzipSync`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,7 @@ export function decompress(data: string): string {
     return data;
   }
   const buf = Buffer.from(data.slice(COMPRESSED_PREFIX.length), 'base64');
-  return gunzipSync(buf).toString('utf8');
+  return gunzipSync(buf, { maxOutputLength: MAX_JOB_DATA_SIZE }).toString('utf8');
 }
 
 // Valkey SCAN glob special characters that must be escaped in key patterns


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Zip Bomb DoS in `gunzipSync`

- **Severity:** MEDIUM
- **Vulnerability:** Unbounded memory allocation during Gzip decompression (Zip Bomb).
- **Impact:** An attacker could cause a Denial of Service (DoS) by sending a highly compressed payload that expands to consume excessive memory.
- **Fix:** Added `{ maxOutputLength: MAX_JOB_DATA_SIZE }` to `gunzipSync` in `src/utils.ts` to limit the decompression size.
- **Verification:** Ran test suite to ensure the fix doesn't break existing functionality and `maxOutputLength` limits the memory consumption.

---
*PR created automatically by Jules for task [10234728885978146851](https://jules.google.com/task/10234728885978146851) started by @avifenesh*