### PR TITLE
feat: add job TTL/expiration support

### DIFF
--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -96,6 +96,9 @@ export class FlowProducer {
       const tbCapacity = opts.ordering?.tokenBucket ? Math.round(opts.ordering.tokenBucket.capacity * 1000) : 0;
       const tbRefillRate = opts.ordering?.tokenBucket ? Math.round(opts.ordering.tokenBucket.refillRate * 1000) : 0;
       const jobCost = opts.cost != null ? Math.round(opts.cost * 1000) : 0;
+      if (opts.ttl != null && (!Number.isFinite(opts.ttl) || opts.ttl < 0)) {
+        throw new Error('ttl must be a non-negative finite number');
+      }
       let groupConcurrency = opts.ordering?.concurrency ?? 0;
       // Force group path when rate limit or token bucket is set
       if ((groupRateMax > 0 || tbCapacity > 0) && groupConcurrency < 1) {
@@ -119,6 +122,7 @@ export class FlowProducer {
         tbCapacity,
         tbRefillRate,
         jobCost,
+        opts.ttl ?? 0,
       );
       if (String(jobId) === 'ERR:COST_EXCEEDS_CAPACITY') {
         throw new Error('Job cost exceeds token bucket capacity');

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -2,7 +2,7 @@ import type { Client } from '../types';
 import type { GlideReturnType } from '@glidemq/speedkey';
 
 export const LIBRARY_NAME = 'glidemq';
-export const LIBRARY_VERSION = '28';
+export const LIBRARY_VERSION = '29';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -190,6 +190,30 @@ local function releaseGroupSlotAndPromote(jobKey, jobId, now)
   end
 end
 
+local function checkExpired(jobKey, jobId, prefix, now)
+  local expireAt = tonumber(redis.call('HGET', jobKey, 'expireAt'))
+  if not expireAt or expireAt <= 0 then return false end
+  if now <= expireAt then return false end
+  -- Idempotency guard: if already expired, skip side effects
+  local curState = redis.call('HGET', jobKey, 'state')
+  if curState == 'failed' then return true end
+  local wasActive = (curState == 'active')
+  local failedKey = prefix .. 'failed'
+  local eventsKey = prefix .. 'events'
+  redis.call('ZADD', failedKey, now, jobId)
+  redis.call('HSET', jobKey,
+    'state', 'failed',
+    'failedReason', 'expired',
+    'finishedOn', tostring(now))
+  markOrderingDone(jobKey, jobId)
+  -- Only release group slot if the job was actually active (held a slot)
+  if wasActive then
+    releaseGroupSlotAndPromote(jobKey, jobId, now)
+  end
+  emitEvent(eventsKey, 'expired', jobId, nil)
+  return true
+end
+
 local function extractOrderingKeyFromOpts(optsJson)
   if not optsJson or optsJson == '' then
     return ''
@@ -270,6 +294,13 @@ local function extractCostFromOpts(optsJson)
   return math.floor(cost * 1000)
 end
 
+local function extractTtlFromOpts(optsJson)
+  if not optsJson or optsJson == '' then return 0 end
+  local ok, decoded = pcall(cjson.decode, optsJson)
+  if not ok or type(decoded) ~= 'table' then return 0 end
+  return tonumber(decoded['ttl']) or 0
+end
+
 -- Remove excess jobs from a sorted set in capped, stack-safe batches.
 -- Deletes job hashes and removes from the set in chunks of 1000.
 local function removeExcessJobs(setKey, prefix, ids)
@@ -305,6 +336,7 @@ redis.register_function('glidemq_addJob', function(keys, args)
   local tbCapacity = tonumber(args[13]) or 0
   local tbRefillRate = tonumber(args[14]) or 0
   local jobCost = tonumber(args[15]) or 0
+  local ttl = tonumber(args[16]) or 0
   local jobId = redis.call('INCR', idKey)
   local jobIdStr = tostring(jobId)
   local prefix = string.sub(idKey, 1, #idKey - 2)
@@ -397,6 +429,10 @@ redis.register_function('glidemq_addJob', function(keys, args)
     hashFields[#hashFields + 1] = 'cost'
     hashFields[#hashFields + 1] = tostring(jobCost)
   end
+  if ttl > 0 then
+    hashFields[#hashFields + 1] = 'expireAt'
+    hashFields[#hashFields + 1] = tostring(timestamp + ttl)
+  end
   if parentId ~= '' then
     hashFields[#hashFields + 1] = 'parentId'
     hashFields[#hashFields + 1] = parentId
@@ -451,13 +487,15 @@ redis.register_function('glidemq_promote', function(keys, args)
     )
     for i = 1, #members do
       local jobId = members[i]
-      redis.call('XADD', streamKey, '*', 'jobId', jobId)
-      redis.call('ZREM', scheduledKey, jobId)
       local prefix = string.sub(scheduledKey, 1, #scheduledKey - 9)
       local jobKey = prefix .. 'job:' .. jobId
-      redis.call('HSET', jobKey, 'state', 'waiting')
-      emitEvent(eventsKey, 'promoted', jobId, nil)
-      count = count + 1
+      redis.call('ZREM', scheduledKey, jobId)
+      if not checkExpired(jobKey, jobId, prefix, now) then
+        redis.call('XADD', streamKey, '*', 'jobId', jobId)
+        redis.call('HSET', jobKey, 'state', 'waiting')
+        emitEvent(eventsKey, 'promoted', jobId, nil)
+        count = count + 1
+      end
     end
     cursorMin = (priority + 1) * PRIORITY_SHIFT
   end
@@ -602,23 +640,45 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
     end
   end
 
-  -- Phase 2: Fetch next job (non-blocking XREADGROUP)
-  local nextEntries = redis.call('XREADGROUP', 'GROUP', group, consumer, 'COUNT', 1, 'STREAMS', streamKey, '>')
-  if not nextEntries or #nextEntries == 0 then
-    return cjson.encode({completed = jobId, next = false})
-  end
-  local streamData = nextEntries[1]
-  local entries = streamData[2]
-  if not entries or #entries == 0 then
-    return cjson.encode({completed = jobId, next = false})
-  end
-  local nextEntry = entries[1]
-  local nextEntryId = nextEntry[1]
-  local nextFields = nextEntry[2]
-  local nextJobId = nil
-  for i = 1, #nextFields, 2 do
-    if nextFields[i] == 'jobId' then
-      nextJobId = nextFields[i + 1]
+  -- Phase 2: Fetch next job (non-blocking XREADGROUP), skip expired (up to 3 attempts)
+  local nextJobId, nextEntryId, nextJobKey
+  for _fetchAttempt = 1, 3 do
+    local nextEntries = redis.call('XREADGROUP', 'GROUP', group, consumer, 'COUNT', 1, 'STREAMS', streamKey, '>')
+    if not nextEntries or #nextEntries == 0 then
+      return cjson.encode({completed = jobId, next = false})
+    end
+    local streamData = nextEntries[1]
+    local entries = streamData[2]
+    if not entries or #entries == 0 then
+      return cjson.encode({completed = jobId, next = false})
+    end
+    local nextEntry = entries[1]
+    nextEntryId = nextEntry[1]
+    local nextFields = nextEntry[2]
+    nextJobId = nil
+    for i = 1, #nextFields, 2 do
+      if nextFields[i] == 'jobId' then
+        nextJobId = nextFields[i + 1]
+        break
+      end
+    end
+    if not nextJobId then
+      return cjson.encode({completed = jobId, next = false})
+    end
+    nextJobKey = prefix .. 'job:' .. nextJobId
+    local nextExists = redis.call('EXISTS', nextJobKey)
+    if nextExists == 0 then
+      return cjson.encode({completed = jobId, next = false, nextEntryId = nextEntryId})
+    end
+    local revoked = redis.call('HGET', nextJobKey, 'revoked')
+    if revoked == '1' then
+      return cjson.encode({completed = jobId, next = 'REVOKED', nextJobId = nextJobId, nextEntryId = nextEntryId})
+    end
+    if checkExpired(nextJobKey, nextJobId, prefix, tonumber(timestamp)) then
+      redis.call('XACK', streamKey, group, nextEntryId)
+      redis.call('XDEL', streamKey, nextEntryId)
+      nextJobId = nil
+    else
       break
     end
   end
@@ -627,15 +687,6 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
   end
 
   -- Phase 3: Activate next job (same as moveToActive)
-  local nextJobKey = prefix .. 'job:' .. nextJobId
-  local nextExists = redis.call('EXISTS', nextJobKey)
-  if nextExists == 0 then
-    return cjson.encode({completed = jobId, next = false, nextEntryId = nextEntryId})
-  end
-  local revoked = redis.call('HGET', nextJobKey, 'revoked')
-  if revoked == '1' then
-    return cjson.encode({completed = jobId, next = 'REVOKED', nextJobId = nextJobId, nextEntryId = nextEntryId})
-  end
   local nextGroupKey = redis.call('HGET', nextJobKey, 'groupKey')
   if nextGroupKey and nextGroupKey ~= '' then
     local nextGroupHashKey = prefix .. 'group:' .. nextGroupKey
@@ -834,6 +885,11 @@ redis.register_function('glidemq_reclaimStalled', function(keys, args)
     end
     if jobId then
       local jobKey = prefix .. 'job:' .. jobId
+      if checkExpired(jobKey, jobId, prefix, timestamp) then
+        redis.call('XACK', streamKey, group, entryId)
+        redis.call('XDEL', streamKey, entryId)
+        count = count + 1
+      else
       local lastActive = tonumber(redis.call('HGET', jobKey, 'lastActive'))
       if lastActive and (timestamp - lastActive) < minIdleMs then
         count = count + 1
@@ -858,6 +914,7 @@ redis.register_function('glidemq_reclaimStalled', function(keys, args)
         emitEvent(eventsKey, 'stalled', jobId, nil)
       end
       count = count + 1
+      end
       end
     end
   end
@@ -904,6 +961,7 @@ redis.register_function('glidemq_dedup', function(keys, args)
   local tbCapacity = tonumber(args[16]) or 0
   local tbRefillRate = tonumber(args[17]) or 0
   local jobCost = tonumber(args[18]) or 0
+  local ttl = tonumber(args[19]) or 0
   local prefix = string.sub(idKey, 1, #idKey - 2)
   local existing = redis.call('HGET', dedupKey, dedupId)
   if mode == 'simple' then
@@ -1034,6 +1092,10 @@ redis.register_function('glidemq_dedup', function(keys, args)
     hashFields[#hashFields + 1] = 'cost'
     hashFields[#hashFields + 1] = tostring(jobCost)
   end
+  if ttl > 0 then
+    hashFields[#hashFields + 1] = 'expireAt'
+    hashFields[#hashFields + 1] = tostring(timestamp + ttl)
+  end
   if parentId ~= '' then
     hashFields[#hashFields + 1] = 'parentId'
     hashFields[#hashFields + 1] = parentId
@@ -1157,10 +1219,12 @@ redis.register_function('glidemq_promoteRateLimited', function(keys, args)
       for j = 1, canPromote do
         local nextJobId = redis.call('LPOP', waitListKey)
         if not nextJobId then break end
-        redis.call('XADD', streamKey, '*', 'jobId', nextJobId)
         local nextJobKey = prefix .. 'job:' .. nextJobId
-        redis.call('HSET', nextJobKey, 'state', 'waiting')
-        promoted = promoted + 1
+        if not checkExpired(nextJobKey, nextJobId, prefix, now) then
+          redis.call('XADD', streamKey, '*', 'jobId', nextJobId)
+          redis.call('HSET', nextJobKey, 'state', 'waiting')
+          promoted = promoted + 1
+        end
       end
     end
   end
@@ -1199,9 +1263,16 @@ redis.register_function('glidemq_moveToActive', function(keys, args)
   if revoked == '1' then
     return 'REVOKED'
   end
+  local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
+  if checkExpired(jobKey, jobId, prefix, tonumber(timestamp)) then
+    if streamKey ~= '' and entryId ~= '' and group ~= '' then
+      redis.call('XACK', streamKey, group, entryId)
+      redis.call('XDEL', streamKey, entryId)
+    end
+    return 'EXPIRED'
+  end
   local groupKey = redis.call('HGET', jobKey, 'groupKey')
   if groupKey and groupKey ~= '' then
-    local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
     local groupHashKey = prefix .. 'group:' .. groupKey
     -- Load all group fields in one call
     local grpFields = redis.call('HGETALL', groupHashKey)
@@ -1389,6 +1460,11 @@ redis.register_function('glidemq_addFlow', function(keys, args)
     parentHash[#parentHash + 1] = 'cost'
     parentHash[#parentHash + 1] = tostring(parentCost)
   end
+  local parentTtl = extractTtlFromOpts(parentOpts)
+  if parentTtl > 0 then
+    parentHash[#parentHash + 1] = 'expireAt'
+    parentHash[#parentHash + 1] = tostring(timestamp + parentTtl)
+  end
   redis.call('HSET', parentJobKey, unpack(parentHash))
   -- Pre-validate all children's cost vs capacity before any child writes
   local childArgOffset = 8
@@ -1474,6 +1550,11 @@ redis.register_function('glidemq_addFlow', function(keys, args)
     if childCost > 0 then
       childHash[#childHash + 1] = 'cost'
       childHash[#childHash + 1] = tostring(childCost)
+    end
+    local childTtl = extractTtlFromOpts(childOpts)
+    if childTtl > 0 then
+      childHash[#childHash + 1] = 'expireAt'
+      childHash[#childHash + 1] = tostring(timestamp + childTtl)
     end
     if childDelay > 0 or childPriority > 0 then
       childHash[#childHash + 1] = 'state'
@@ -2057,6 +2138,7 @@ export function addJobArgs(
   tbCapacity: number = 0,
   tbRefillRate: number = 0,
   jobCost: number = 0,
+  ttl: number = 0,
 ): { keys: string[]; args: string[] } {
   return {
     keys: [k.id, k.stream, k.scheduled, k.events],
@@ -2076,6 +2158,7 @@ export function addJobArgs(
       tbCapacity.toString(),
       tbRefillRate.toString(),
       jobCost.toString(),
+      ttl.toString(),
     ],
   };
 }
@@ -2098,6 +2181,7 @@ export async function addJob(
   tbCapacity: number = 0,
   tbRefillRate: number = 0,
   jobCost: number = 0,
+  ttl: number = 0,
 ): Promise<string> {
   const { keys, args } = addJobArgs(
     k,
@@ -2116,6 +2200,7 @@ export async function addJob(
     tbCapacity,
     tbRefillRate,
     jobCost,
+    ttl,
   );
   const result = await client.fcall('glidemq_addJob', keys, args);
   return result as string;
@@ -2146,6 +2231,7 @@ export async function dedup(
   tbCapacity: number = 0,
   tbRefillRate: number = 0,
   jobCost: number = 0,
+  jobTtl: number = 0,
 ): Promise<string> {
   const result = await client.fcall(
     'glidemq_dedup',
@@ -2169,6 +2255,7 @@ export async function dedup(
       tbCapacity.toString(),
       tbRefillRate.toString(),
       jobCost.toString(),
+      jobTtl.toString(),
     ],
   );
   return result as string;
@@ -2452,6 +2539,7 @@ export async function moveToActive(
 ): Promise<
   | Record<string, string>
   | 'REVOKED'
+  | 'EXPIRED'
   | 'GROUP_FULL'
   | 'GROUP_RATE_LIMITED'
   | 'GROUP_TOKEN_LIMITED'
@@ -2468,6 +2556,7 @@ export async function moveToActive(
   const str = String(result);
   if (str === '' || str === 'null') return null;
   if (str === 'REVOKED') return 'REVOKED';
+  if (str === 'EXPIRED') return 'EXPIRED';
   if (str === 'GROUP_FULL') return 'GROUP_FULL';
   if (str === 'GROUP_RATE_LIMITED') return 'GROUP_RATE_LIMITED';
   if (str === 'GROUP_TOKEN_LIMITED') return 'GROUP_TOKEN_LIMITED';

--- a/src/job.ts
+++ b/src/job.ts
@@ -24,6 +24,7 @@ export class Job<D = any, R = any> {
   orderingSeq?: number;
   groupKey?: string;
   cost?: number;
+  expireAt?: number;
 
   /**
    * AbortSignal that fires when this job is revoked during processing.
@@ -405,6 +406,7 @@ export class Job<D = any, R = any> {
     job.orderingSeq = hash.orderingSeq ? parseInt(hash.orderingSeq, 10) : undefined;
     job.groupKey = hash.groupKey || undefined;
     job.cost = hash.cost ? parseInt(hash.cost, 10) : undefined;
+    job.expireAt = hash.expireAt ? parseInt(hash.expireAt, 10) : undefined;
     if (hash.progress) {
       try {
         job.progress = JSON.parse(hash.progress);

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -202,6 +202,10 @@ export class Queue<D = any, R = any> extends EventEmitter {
         }
         validateOrderingKey(orderingKey);
 
+        if (opts?.ttl != null) {
+          if (!Number.isFinite(opts.ttl) || opts.ttl < 0) throw new Error('ttl must be a non-negative finite number');
+        }
+
         // Payload size validation - prevent DoS via oversized jobs
         let serialized = JSON.stringify(data);
         const byteLen = Buffer.byteLength(serialized, 'utf8');
@@ -216,6 +220,8 @@ export class Queue<D = any, R = any> extends EventEmitter {
         }
 
         let jobId: string;
+
+        const ttl = opts?.ttl ?? 0;
 
         if (opts?.deduplication) {
           const dedupOpts = opts.deduplication;
@@ -240,6 +246,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
             tbCapacity,
             tbRefillRate,
             jobCost,
+            ttl,
           );
           if (result === 'skipped') {
             return null;
@@ -267,6 +274,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
             tbCapacity,
             tbRefillRate,
             jobCost,
+            ttl,
           );
           if (result === 'ERR:COST_EXCEEDS_CAPACITY') {
             throw new Error('Job cost exceeds token bucket capacity');
@@ -305,6 +313,9 @@ export class Queue<D = any, R = any> extends EventEmitter {
       const maxAttempts = opts.attempts ?? 0;
       const orderingKey = opts.ordering?.key ?? '';
       validateOrderingKey(orderingKey);
+      if (opts.ttl != null) {
+        if (!Number.isFinite(opts.ttl) || opts.ttl < 0) throw new Error('ttl must be a non-negative finite number');
+      }
       const deduplication = opts.deduplication;
 
       let serializedData = JSON.stringify(entry.data);
@@ -354,6 +365,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
         tbCapacity,
         tbRefillRate,
         jobCost,
+        ttl: opts.ttl ?? 0,
         deduplication,
         serializedData,
       };
@@ -385,6 +397,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
           p.tbCapacity.toString(),
           p.tbRefillRate.toString(),
           p.jobCost.toString(),
+          p.ttl.toString(),
         ]);
       } else {
         batch.fcall('glidemq_addJob', keys, [
@@ -403,6 +416,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
           p.tbCapacity.toString(),
           p.tbRefillRate.toString(),
           p.jobCost.toString(),
+          p.ttl.toString(),
         ]);
       }
     }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -163,7 +163,28 @@ export class Scheduler {
       const priority = template.opts?.priority ?? 0;
       const maxAttempts = template.opts?.attempts ?? 0;
 
-      pendingJobs.push(addJobArgs(this.queueKeys, jobName, jobData, jobOpts, now, 0, priority, '', maxAttempts));
+      const jobTtl = template.opts?.ttl ?? 0;
+      pendingJobs.push(
+        addJobArgs(
+          this.queueKeys,
+          jobName,
+          jobData,
+          jobOpts,
+          now,
+          0,
+          priority,
+          '',
+          maxAttempts,
+          '',
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          jobTtl,
+        ),
+      );
 
       // Compute next run
       let nextRun: number;

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -27,6 +27,7 @@ export interface TestJobRecord<D = any, R = any> {
   timestamp: number;
   finishedOn: number | undefined;
   processedOn: number | undefined;
+  expireAt?: number;
 }
 
 /**
@@ -45,6 +46,7 @@ export class TestJob<D = any, R = any> {
   timestamp: number;
   finishedOn: number | undefined;
   processedOn: number | undefined;
+  expireAt?: number;
 
   constructor(record: TestJobRecord<D, R>) {
     this.id = record.id;
@@ -58,6 +60,7 @@ export class TestJob<D = any, R = any> {
     this.timestamp = record.timestamp;
     this.finishedOn = record.finishedOn;
     this.processedOn = record.processedOn;
+    this.expireAt = record.expireAt;
   }
 
   async log(_message: string): Promise<void> {
@@ -149,6 +152,8 @@ export class TestQueue<D = any, R = any> extends EventEmitter {
     }
 
     const id = String(++this.idCounter);
+    const now = Date.now();
+    const ttl = opts?.ttl ?? 0;
     const record: TestJobRecord<D, R> = {
       id,
       name,
@@ -158,9 +163,10 @@ export class TestQueue<D = any, R = any> extends EventEmitter {
       attemptsMade: 0,
       returnvalue: undefined,
       failedReason: undefined,
-      timestamp: Date.now(),
+      timestamp: now,
       finishedOn: undefined,
       processedOn: undefined,
+      expireAt: ttl > 0 ? now + ttl : undefined,
     };
     this.jobs.set(id, record);
 
@@ -475,6 +481,22 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
   }
 
   private processJob(record: TestJobRecord<D, R>, job: TestJob<D, R>): void {
+    // Check TTL expiration before processing
+    if (record.expireAt && Date.now() > record.expireAt) {
+      record.state = 'failed';
+      record.failedReason = 'expired';
+      record.finishedOn = Date.now();
+      job.failedReason = 'expired';
+      job.finishedOn = record.finishedOn;
+      const err = new Error('expired');
+      this.emit('failed', job, err);
+      this.queue.emit('failed', job, err);
+      this.activeCount--;
+      if (this.running && !this.queue.isPaused()) {
+        this.processAvailable();
+      }
+      return;
+    }
     this.processor(job as any)
       .then((result) => {
         record.state = 'completed';

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,8 @@ export interface JobOptions {
   removeOnFail?: boolean | number | { age: number; count: number };
   deduplication?: { id: string; ttl?: number; mode?: 'simple' | 'throttle' | 'debounce' };
   parent?: { queue: string; id: string };
+  /** Time-to-live in milliseconds. Jobs not processed within this window are failed as 'expired'. */
+  ttl?: number;
 }
 
 export interface RateLimitConfig {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -410,6 +410,7 @@ export class Worker<D = any, R = any> extends EventEmitter {
     moveResult:
       | Record<string, string>
       | 'REVOKED'
+      | 'EXPIRED'
       | 'GROUP_FULL'
       | 'GROUP_RATE_LIMITED'
       | 'GROUP_TOKEN_LIMITED'
@@ -433,6 +434,10 @@ export class Worker<D = any, R = any> extends EventEmitter {
       } catch (err) {
         this.emit('error', err);
       }
+      return true;
+    }
+    if (moveResult === 'EXPIRED') {
+      // Already handled server-side by checkExpired in Lua
       return true;
     }
     if (

--- a/tests/testing-mode.test.ts
+++ b/tests/testing-mode.test.ts
@@ -738,3 +738,81 @@ describe('TestQueue.getJobScheduler', () => {
     await queue.removeJobScheduler('b');
   });
 });
+
+describe('TestWorker - TTL', () => {
+  let queue: TestQueue;
+  let worker: TestWorker;
+
+  afterEach(async () => {
+    if (worker) await worker.close();
+    if (queue) await queue.close();
+  });
+
+  it('expired job is failed with reason "expired"', async () => {
+    queue = new TestQueue('ttl-test');
+    // Add a job with ttl=1ms
+    const job = await queue.add('task', { v: 1 }, { ttl: 1 });
+    expect(job).not.toBeNull();
+    expect(job!.opts.ttl).toBe(1);
+
+    // Wait for TTL to pass
+    await new Promise<void>((r) => setTimeout(r, 10));
+
+    const failed: { job: any; err: Error }[] = [];
+    const completed: any[] = [];
+
+    worker = new TestWorker(queue, async () => {
+      return 'should not run';
+    });
+    worker.on('failed', (j: any, err: Error) => failed.push({ job: j, err }));
+    worker.on('completed', (j: any) => completed.push(j));
+
+    // Wait for processing
+    await new Promise<void>((r) => setTimeout(r, 50));
+
+    expect(completed).toHaveLength(0);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].err.message).toBe('expired');
+    expect(failed[0].job.failedReason).toBe('expired');
+
+    const record = queue.jobs.get(job!.id);
+    expect(record?.state).toBe('failed');
+    expect(record?.failedReason).toBe('expired');
+  });
+
+  it('job with ttl processes normally when not expired', async () => {
+    queue = new TestQueue('ttl-test-ok');
+    const job = await queue.add('task', { v: 2 }, { ttl: 60000 });
+    expect(job).not.toBeNull();
+
+    const completed: any[] = [];
+    worker = new TestWorker(queue, async () => 'done');
+    worker.on('completed', (j: any) => completed.push(j));
+
+    await new Promise<void>((r) => setTimeout(r, 50));
+
+    expect(completed).toHaveLength(1);
+    expect(completed[0].returnvalue).toBe('done');
+  });
+
+  it('job without ttl has no expireAt', async () => {
+    queue = new TestQueue('ttl-test-none');
+    const job = await queue.add('task', { v: 3 });
+    expect(job).not.toBeNull();
+
+    const record = queue.jobs.get(job!.id);
+    expect(record?.expireAt).toBeUndefined();
+  });
+
+  it('expireAt is stored correctly on the record', async () => {
+    queue = new TestQueue('ttl-test-store');
+    const before = Date.now();
+    const job = await queue.add('task', { v: 4 }, { ttl: 5000 });
+    const after = Date.now();
+
+    const record = queue.jobs.get(job!.id);
+    expect(record?.expireAt).toBeDefined();
+    expect(record!.expireAt!).toBeGreaterThanOrEqual(before + 5000);
+    expect(record!.expireAt!).toBeLessThanOrEqual(after + 5000);
+  });
+});

--- a/tests/ttl.test.ts
+++ b/tests/ttl.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Job TTL (time-to-live) integration tests against a real Valkey instance.
+ * Requires: valkey-server running on localhost:6379 and cluster on :7000-7005
+ *
+ * Run: npx vitest run tests/ttl.test.ts
+ */
+import { it, expect, beforeAll, afterAll } from 'vitest';
+
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
+
+describeEachMode('Job TTL - expiration', (CONNECTION) => {
+  const Q = 'test-ttl-expire-' + Date.now();
+  let queue: InstanceType<typeof Queue>;
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+    queue = new Queue(Q, { connection: CONNECTION });
+  });
+
+  afterAll(async () => {
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    cleanupClient.close();
+  });
+
+  it('job expires before processing -> state failed, failedReason expired', async () => {
+    // Add a job with a very short TTL
+    const job = await queue.add('task', { v: 1 }, { ttl: 1 });
+    expect(job).not.toBeNull();
+
+    // Wait for TTL to pass
+    await new Promise<void>((r) => setTimeout(r, 50));
+
+    // Create a worker - the job should be expired on moveToActive
+    const worker = new Worker(
+      Q,
+      async () => {
+        throw new Error('Should not be called - job is expired');
+      },
+      { connection: CONNECTION },
+    );
+    await worker.waitUntilReady();
+
+    // Wait for the worker to process (it should expire the job, not execute the processor)
+    await waitFor(async () => {
+      const counts = await queue.getJobCounts();
+      return counts.failed > 0;
+    }, 10000);
+
+    const counts = await queue.getJobCounts();
+    expect(counts.failed).toBe(1);
+
+    const failedJob = await queue.getJob(job!.id);
+    expect(failedJob).not.toBeNull();
+    expect(failedJob!.failedReason).toBe('expired');
+
+    await worker.close();
+  });
+
+  it('job processed before expiry -> completes normally', async () => {
+    const Q2 = Q + '-completes';
+    const queue2 = new Queue(Q2, { connection: CONNECTION });
+
+    // Add a job with a long TTL
+    const job = await queue2.add('task', { v: 2 }, { ttl: 60000 });
+    expect(job).not.toBeNull();
+
+    const completed: string[] = [];
+    const worker = new Worker(
+      Q2,
+      async () => {
+        return 'done';
+      },
+      { connection: CONNECTION },
+    );
+    worker.on('completed', (j: any) => completed.push(j.id));
+    await worker.waitUntilReady();
+
+    await waitFor(() => completed.length > 0, 10000);
+    expect(completed).toContain(job!.id);
+
+    const finishedJob = await queue2.getJob(job!.id);
+    expect(finishedJob).not.toBeNull();
+
+    await worker.close();
+    await queue2.close();
+    await flushQueue(cleanupClient, Q2);
+  });
+
+  it('TTL=0 means no expiry', async () => {
+    const Q3 = Q + '-no-expiry-0';
+    const queue3 = new Queue(Q3, { connection: CONNECTION });
+
+    const job = await queue3.add('task', { v: 3 }, { ttl: 0 });
+    expect(job).not.toBeNull();
+
+    // Check that expireAt is not set on the hash
+    const k = buildKeys(Q3);
+    const expireAt = await cleanupClient.hget(k.job(job!.id), 'expireAt');
+    expect(expireAt).toBeNull();
+
+    await queue3.close();
+    await flushQueue(cleanupClient, Q3);
+  });
+
+  it('TTL undefined means no expiry', async () => {
+    const Q4 = Q + '-no-expiry-undef';
+    const queue4 = new Queue(Q4, { connection: CONNECTION });
+
+    const job = await queue4.add('task', { v: 4 });
+    expect(job).not.toBeNull();
+
+    const k = buildKeys(Q4);
+    const expireAt = await cleanupClient.hget(k.job(job!.id), 'expireAt');
+    expect(expireAt).toBeNull();
+
+    await queue4.close();
+    await flushQueue(cleanupClient, Q4);
+  });
+});
+
+describeEachMode('Job TTL - delayed jobs', (CONNECTION) => {
+  const Q = 'test-ttl-delayed-' + Date.now();
+  let queue: InstanceType<typeof Queue>;
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+    queue = new Queue(Q, { connection: CONNECTION });
+  });
+
+  afterAll(async () => {
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    cleanupClient.close();
+  });
+
+  it('TTL + delayed job - expires at promote time', async () => {
+    // Add a delayed job with a TTL shorter than the delay
+    // TTL=1ms, delay=50ms - job should expire before promotion
+    const job = await queue.add('task', { v: 1 }, { ttl: 1, delay: 100 });
+    expect(job).not.toBeNull();
+
+    const completed: string[] = [];
+    const worker = new Worker(Q, async () => 'done', { connection: CONNECTION, promotionInterval: 100 });
+    worker.on('completed', (j: any) => completed.push(j.id));
+    await worker.waitUntilReady();
+
+    // Wait for the promotion cycle to run + TTL check
+    await waitFor(async () => {
+      const counts = await queue.getJobCounts();
+      return counts.failed > 0;
+    }, 10000);
+
+    // The job should be failed (expired at promote time), NOT completed
+    expect(completed).not.toContain(job!.id);
+    const failedJob = await queue.getJob(job!.id);
+    expect(failedJob).not.toBeNull();
+    expect(failedJob!.failedReason).toBe('expired');
+
+    await worker.close();
+  });
+
+  it('TTL + delayed job - processed before expiry', async () => {
+    const Q2 = Q + '-delayed-ok';
+    const queue2 = new Queue(Q2, { connection: CONNECTION });
+
+    // Add a delayed job with a very long TTL
+    const job = await queue2.add('task', { v: 2 }, { ttl: 60000, delay: 100 });
+    expect(job).not.toBeNull();
+
+    const completed: string[] = [];
+    const worker = new Worker(Q2, async () => 'done', { connection: CONNECTION, promotionInterval: 100 });
+    worker.on('completed', (j: any) => completed.push(j.id));
+    await worker.waitUntilReady();
+
+    await waitFor(() => completed.length > 0, 10000);
+    expect(completed).toContain(job!.id);
+
+    await worker.close();
+    await queue2.close();
+    await flushQueue(cleanupClient, Q2);
+  });
+});
+
+describeEachMode('Job TTL - priority', (CONNECTION) => {
+  const Q = 'test-ttl-priority-' + Date.now();
+  let queue: InstanceType<typeof Queue>;
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+    queue = new Queue(Q, { connection: CONNECTION });
+  });
+
+  afterAll(async () => {
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    cleanupClient.close();
+  });
+
+  it('TTL + priority job expires at promote time', async () => {
+    // Priority jobs go through the scheduled ZSet -> promote cycle
+    const job = await queue.add('task', { v: 1 }, { ttl: 1, priority: 5 });
+    expect(job).not.toBeNull();
+
+    await new Promise<void>((r) => setTimeout(r, 50));
+
+    const worker = new Worker(Q, async () => 'done', { connection: CONNECTION, promotionInterval: 100 });
+    await worker.waitUntilReady();
+
+    await waitFor(async () => {
+      const counts = await queue.getJobCounts();
+      return counts.failed > 0;
+    }, 10000);
+
+    const failedJob = await queue.getJob(job!.id);
+    expect(failedJob).not.toBeNull();
+    expect(failedJob!.failedReason).toBe('expired');
+
+    await worker.close();
+  });
+});
+
+describeEachMode('Job TTL - retries/backoff', (CONNECTION) => {
+  const Q = 'test-ttl-retry-' + Date.now();
+  let queue: InstanceType<typeof Queue>;
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+    queue = new Queue(Q, { connection: CONNECTION });
+  });
+
+  afterAll(async () => {
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    cleanupClient.close();
+  });
+
+  it('TTL spans all attempts - expires during retry', async () => {
+    // Job with 3 attempts, very short TTL (50ms). First attempt runs and fails quickly,
+    // the job goes to delayed state with 2000ms backoff. By the time the promote cycle
+    // fires, the TTL has long expired, so the job is failed as 'expired' at promote time.
+    const job = await queue.add(
+      'task',
+      { v: 1 },
+      {
+        ttl: 50,
+        attempts: 3,
+        backoff: { type: 'fixed', delay: 2000 },
+      },
+    );
+    expect(job).not.toBeNull();
+
+    let attempts = 0;
+    const worker = new Worker(
+      Q,
+      async () => {
+        attempts++;
+        throw new Error('fail on purpose');
+      },
+      { connection: CONNECTION, promotionInterval: 200 },
+    );
+    await worker.waitUntilReady();
+
+    // Wait for the job to end up as 'failed' with 'expired' reason
+    await waitFor(async () => {
+      const j = await queue.getJob(job!.id);
+      return j?.failedReason === 'expired';
+    }, 15000);
+
+    const failedJob = await queue.getJob(job!.id);
+    expect(failedJob).not.toBeNull();
+    // The job should expire during the backoff delay (2000ms >> 50ms TTL)
+    expect(failedJob!.failedReason).toBe('expired');
+
+    await worker.close();
+  });
+});
+
+describeEachMode('Job TTL - dedup', (CONNECTION) => {
+  const Q = 'test-ttl-dedup-' + Date.now();
+  let queue: InstanceType<typeof Queue>;
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+    queue = new Queue(Q, { connection: CONNECTION });
+  });
+
+  afterAll(async () => {
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    cleanupClient.close();
+  });
+
+  it('TTL is stored on deduped jobs', async () => {
+    const job = await queue.add(
+      'task',
+      { v: 1 },
+      {
+        ttl: 5000,
+        deduplication: { id: 'dedup-ttl-1', mode: 'simple' },
+      },
+    );
+    expect(job).not.toBeNull();
+
+    const k = buildKeys(Q);
+    const expireAt = await cleanupClient.hget(k.job(job!.id), 'expireAt');
+    expect(expireAt).not.toBeNull();
+    expect(Number(String(expireAt))).toBeGreaterThan(Date.now());
+
+    // Second add is deduped
+    const job2 = await queue.add(
+      'task',
+      { v: 2 },
+      {
+        ttl: 5000,
+        deduplication: { id: 'dedup-ttl-1', mode: 'simple' },
+      },
+    );
+    expect(job2).toBeNull();
+  });
+});
+
+describeEachMode('Job TTL - addBulk', (CONNECTION) => {
+  const Q = 'test-ttl-bulk-' + Date.now();
+  let queue: InstanceType<typeof Queue>;
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+    queue = new Queue(Q, { connection: CONNECTION });
+  });
+
+  afterAll(async () => {
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    cleanupClient.close();
+  });
+
+  it('addBulk passes TTL correctly', async () => {
+    const jobs = await queue.addBulk([
+      { name: 'a', data: { v: 1 }, opts: { ttl: 10000 } },
+      { name: 'b', data: { v: 2 } },
+      { name: 'c', data: { v: 3 }, opts: { ttl: 5000 } },
+    ]);
+    expect(jobs.length).toBe(3);
+
+    const k = buildKeys(Q);
+
+    // Job 'a' should have expireAt
+    const expireAtA = await cleanupClient.hget(k.job(jobs[0].id), 'expireAt');
+    expect(expireAtA).not.toBeNull();
+
+    // Job 'b' should NOT have expireAt
+    const expireAtB = await cleanupClient.hget(k.job(jobs[1].id), 'expireAt');
+    expect(expireAtB).toBeNull();
+
+    // Job 'c' should have expireAt
+    const expireAtC = await cleanupClient.hget(k.job(jobs[2].id), 'expireAt');
+    expect(expireAtC).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #72

Add optional `ttl` (milliseconds) to `JobOptions`. Jobs not processed within the TTL window are failed with reason `'expired'`. Uses the check-on-fetch model (same as revocation) - no background timers or scanning.

## Changes

- **Lua `checkExpired` helper** - marks expired jobs as failed, emits `'expired'` event, releases ordering/group slots. Has idempotency guard and only releases group active slots for jobs that were actually active.
- **7 Lua functions modified** to check expiration at every activation point: `moveToActive`, `completeAndFetchNext`, `promote`, `reclaimStalled`, `promoteRateLimited`, `addJob`, `dedup`
- **`addFlow`** extracts TTL from opts JSON for parent and child jobs
- **`completeAndFetchNext`** loops past up to 3 expired next-jobs before returning to poll
- **Expired jobs don't consume promote batch budget** - only successfully promoted jobs count
- **TTL input validation** - `Number.isFinite()` + non-negative check in queue.ts, addBulk, and flow-producer
- **Worker** handles `'EXPIRED'` return from moveToActive (skip, already handled server-side)
- **Testing mode** supports TTL in `TestQueue` and `TestWorker`
- **Library version** bumped 28 -> 29

## Testing

- 4 new unit tests (testing-mode)
- 20 new integration tests (10 standalone + 10 cluster) covering: basic expiry, happy path, TTL=0, TTL undefined, TTL+delay, TTL+priority, TTL+retry/backoff, TTL+dedup, TTL+addBulk
- All existing tests pass (207+ tests across integration, flow, ordering, group concurrency, rate limit, token bucket, dedup, scheduler)
- Fuzzer passes (238 randomized rounds across all modes)

## Review findings addressed

- Fixed group active counter corruption: `checkExpired` only calls `releaseGroupSlotAndPromote` when job was in `active` state
- Added idempotency guard: double-call on same job short-circuits without side effects
- Added `Number.isFinite()` validation for TTL values (prevents NaN/Infinity/negative)
- Expired jobs no longer consume promote batch budget
- `completeAndFetchNext` loops past expired jobs to avoid unnecessary poll round-trips