### PR TITLE
feat: add cron timezone support (#74)

### DIFF
--- a/src/queue.ts
+++ b/src/queue.ts
@@ -20,6 +20,7 @@ import {
   keyPrefix,
   keyPrefixPattern,
   nextCronOccurrence,
+  validateTimezone,
   hashDataToRecord,
   extractJobIdsFromStreamEntries,
   compress,
@@ -599,9 +600,13 @@ export class Queue<D = any, R = any> extends EventEmitter {
     const client = await this.getClient();
     const now = Date.now();
 
+    if (schedule.tz) {
+      validateTimezone(schedule.tz);
+    }
+
     let nextRun: number;
     if (schedule.pattern) {
-      nextRun = nextCronOccurrence(schedule.pattern, now);
+      nextRun = nextCronOccurrence(schedule.pattern, now, schedule.tz);
     } else if (schedule.every) {
       nextRun = now + schedule.every;
     } else {
@@ -611,6 +616,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
     const entry: SchedulerEntry = {
       pattern: schedule.pattern,
       every: schedule.every,
+      tz: schedule.tz,
       template,
       nextRun,
     };

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -189,7 +189,7 @@ export class Scheduler {
       // Compute next run
       let nextRun: number;
       if (config.pattern) {
-        nextRun = nextCronOccurrence(config.pattern, now);
+        nextRun = nextCronOccurrence(config.pattern, now, config.tz);
       } else if (config.every) {
         nextRun = now + config.every;
       } else {

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import os from 'os';
 import type { JobOptions, JobCounts, Processor, WorkerInfo, SchedulerEntry, ScheduleOpts, JobTemplate } from './types';
 import { GlideMQError, UnrecoverableError } from './errors';
-import { nextCronOccurrence } from './utils';
+import { nextCronOccurrence, validateTimezone } from './utils';
 
 // ---- Lightweight in-memory Job representation ----
 
@@ -348,11 +348,15 @@ export class TestQueue<D = any, R = any> extends EventEmitter {
     if (!schedule.pattern && !schedule.every) {
       throw new Error('Schedule must have either pattern (cron) or every (ms interval)');
     }
+    if (schedule.tz) {
+      validateTimezone(schedule.tz);
+    }
     const now = Date.now();
-    const nextRun = schedule.pattern ? nextCronOccurrence(schedule.pattern, now) : now + schedule.every!;
+    const nextRun = schedule.pattern ? nextCronOccurrence(schedule.pattern, now, schedule.tz) : now + schedule.every!;
     const entry: SchedulerEntry = {
       pattern: schedule.pattern,
       every: schedule.every,
+      tz: schedule.tz,
       template,
       nextRun,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,8 @@ export interface ScheduleOpts {
   pattern?: string;
   /** Repeat interval in milliseconds */
   every?: number;
+  /** IANA timezone for cron patterns (e.g. 'America/New_York'). Defaults to UTC. */
+  tz?: string;
 }
 
 export interface JobTemplate {
@@ -206,6 +208,8 @@ export interface JobTemplate {
 export interface SchedulerEntry {
   pattern?: string;
   every?: number;
+  /** IANA timezone for cron patterns (e.g. 'America/New_York'). Defaults to UTC. */
+  tz?: string;
   template?: JobTemplate;
   lastRun?: number;
   nextRun: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -263,11 +263,121 @@ function parseCronField(field: string, min: number, max: number): number[] {
 const MAX_SEARCH_YEARS = 10;
 
 /**
+ * Validate an IANA timezone string. Throws if invalid.
+ */
+export function validateTimezone(tz: string): void {
+  try {
+    Intl.DateTimeFormat('en-US', { timeZone: tz });
+  } catch {
+    throw new Error(`Invalid timezone: ${tz}`);
+  }
+}
+
+// Cache DateTimeFormat instances per timezone for performance
+const dtfCache = new Map<string, Intl.DateTimeFormat>();
+
+function getFormatter(tz: string): Intl.DateTimeFormat {
+  let f = dtfCache.get(tz);
+  if (!f) {
+    f = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      hour12: false,
+    });
+    dtfCache.set(tz, f);
+  }
+  return f;
+}
+
+interface TzParts {
+  year: number;
+  month: number; // 1-12
+  day: number;
+  hour: number;
+  minute: number;
+  dayOfWeek: number; // 0=Sunday
+}
+
+/**
+ * Get wall-clock parts for a UTC epoch in the given timezone.
+ */
+function utcToTzParts(epochMs: number, tz: string): TzParts {
+  const f = getFormatter(tz);
+  const parts = f.formatToParts(new Date(epochMs));
+  const p: Record<string, string> = {};
+  for (const part of parts) {
+    p[part.type] = part.value;
+  }
+  const year = parseInt(p.year, 10);
+  const month = parseInt(p.month, 10);
+  const day = parseInt(p.day, 10);
+  // hour12:false can return '24' for midnight in some locales; normalize to 0
+  let hour = parseInt(p.hour, 10);
+  if (hour === 24) hour = 0;
+  const minute = parseInt(p.minute, 10);
+  // Compute day of week from a UTC date constructed from these parts
+  const dow = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+  return { year, month, day, hour, minute, dayOfWeek: dow };
+}
+
+/**
+ * Convert wall-clock parts in a timezone to a UTC epoch.
+ * For spring-forward gaps (wall-clock time doesn't exist), returns -1.
+ * For fall-back overlaps (ambiguous), returns the first (earlier) UTC instant.
+ */
+function tzPartsToUtc(year: number, month: number, day: number, hour: number, minute: number, tz: string): number {
+  // Start with a naive UTC estimate using the same wall-clock components
+  const naive = Date.UTC(year, month - 1, day, hour, minute, 0, 0);
+  // Get the actual wall-clock time at our naive estimate to compute the offset
+  const naiveParts = utcToTzParts(naive, tz);
+  // Compute the offset in ms: how much the timezone differs from UTC at this point
+  const naiveWall = Date.UTC(
+    naiveParts.year,
+    naiveParts.month - 1,
+    naiveParts.day,
+    naiveParts.hour,
+    naiveParts.minute,
+    0,
+    0,
+  );
+  const offsetMs = naiveWall - naive;
+  // Apply offset to get a candidate
+  const candidate = naive - offsetMs;
+  const cp = utcToTzParts(candidate, tz);
+  if (cp.year === year && cp.month === month && cp.day === day && cp.hour === hour && cp.minute === minute) {
+    return candidate;
+  }
+  // Offset might be wrong near DST transitions - try +/- 1 hour
+  for (const delta of [-3600000, 3600000, -7200000, 7200000]) {
+    const alt = candidate + delta;
+    const ap = utcToTzParts(alt, tz);
+    if (ap.year === year && ap.month === month && ap.day === day && ap.hour === hour && ap.minute === minute) {
+      return alt;
+    }
+  }
+  // Wall-clock time doesn't exist (spring-forward gap)
+  return -1;
+}
+
+/**
  * Compute the next occurrence of a cron pattern after `afterMs` (epoch ms).
  * Supports standard 5-field cron: minute hour dayOfMonth month dayOfWeek.
- * Returns epoch ms of the next matching time.
+ * When `tz` is provided, the cron expression is evaluated in that IANA timezone.
+ * Returns epoch ms of the next matching time (always in UTC).
  */
-export function nextCronOccurrence(pattern: string, afterMs: number): number {
+export function nextCronOccurrence(pattern: string, afterMs: number, tz?: string): number {
+  if (tz) {
+    return nextCronOccurrenceTz(pattern, afterMs, tz);
+  }
+  return nextCronOccurrenceUtc(pattern, afterMs);
+}
+
+function nextCronOccurrenceUtc(pattern: string, afterMs: number): number {
   const fields = pattern.trim().split(/\s+/);
   if (fields.length !== 5) {
     throw new Error(`Invalid cron pattern: expected 5 fields, got ${fields.length}`);
@@ -337,6 +447,152 @@ export function nextCronOccurrence(pattern: string, afterMs: number): number {
     }
 
     return d.getTime();
+  }
+
+  throw new Error(`No cron match found within ${MAX_SEARCH_YEARS} years for pattern: ${pattern}`);
+}
+
+/**
+ * Timezone-aware cron search. Evaluates the cron expression in wall-clock time
+ * of the specified timezone, then converts the result to UTC epoch.
+ *
+ * DST handling:
+ * - Spring-forward: if a candidate wall-clock time doesn't exist (gap), skip to next candidate
+ * - Fall-back: if a wall-clock time is ambiguous (overlap), pick the first (earlier) UTC instant
+ */
+function nextCronOccurrenceTz(pattern: string, afterMs: number, tz: string): number {
+  const fields = pattern.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    throw new Error(`Invalid cron pattern: expected 5 fields, got ${fields.length}`);
+  }
+
+  const minutes = parseCronField(fields[0], 0, 59);
+  const hours = parseCronField(fields[1], 0, 23);
+  const daysOfMonth = parseCronField(fields[2], 1, 31);
+  const months = parseCronField(fields[3], 1, 12);
+  const daysOfWeek = parseCronField(fields[4], 0, 6);
+
+  // Get the wall-clock time in the target timezone for "afterMs + 1 minute"
+  const startParts = utcToTzParts(afterMs, tz);
+  // Advance by 1 minute in wall-clock time
+  let year = startParts.year;
+  let month = startParts.month;
+  let day = startParts.day;
+  let hour = startParts.hour;
+  let minute = startParts.minute + 1;
+
+  // Normalize overflow
+  if (minute >= 60) {
+    minute = 0;
+    hour++;
+    if (hour >= 24) {
+      hour = 0;
+      // Advance day via UTC date arithmetic for correctness
+      const tmp = new Date(Date.UTC(year, month - 1, day + 1));
+      year = tmp.getUTCFullYear();
+      month = tmp.getUTCMonth() + 1;
+      day = tmp.getUTCDate();
+    }
+  }
+
+  const endYear = year + MAX_SEARCH_YEARS;
+
+  while (year <= endYear) {
+    // 1. Month check
+    if (!months.includes(month)) {
+      const nextMonth = months.find((m) => m > month);
+      if (nextMonth != null) {
+        month = nextMonth;
+        day = 1;
+        hour = 0;
+        minute = 0;
+      } else {
+        year++;
+        month = months[0];
+        day = 1;
+        hour = 0;
+        minute = 0;
+      }
+      continue;
+    }
+
+    // 2. Day check - use UTC Date for day-of-week and month-length
+    const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+    if (day > daysInMonth) {
+      // Overflowed month
+      month++;
+      day = 1;
+      hour = 0;
+      minute = 0;
+      if (month > 12) {
+        month = 1;
+        year++;
+      }
+      continue;
+    }
+    const dow = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+    if (!daysOfMonth.includes(day) || !daysOfWeek.includes(dow)) {
+      day++;
+      hour = 0;
+      minute = 0;
+      continue;
+    }
+
+    // 3. Hour check
+    if (!hours.includes(hour)) {
+      const nextHour = hours.find((h) => h > hour);
+      if (nextHour != null) {
+        hour = nextHour;
+        minute = 0;
+      } else {
+        day++;
+        hour = 0;
+        minute = 0;
+      }
+      continue;
+    }
+
+    // 4. Minute check
+    if (!minutes.includes(minute)) {
+      const nextMinute = minutes.find((m) => m > minute);
+      if (nextMinute != null) {
+        minute = nextMinute;
+      } else {
+        hour++;
+        minute = 0;
+        continue;
+      }
+    }
+
+    // Found a candidate wall-clock time - convert to UTC
+    const utcMs = tzPartsToUtc(year, month, day, hour, minute, tz);
+    if (utcMs === -1) {
+      // Spring-forward gap: this wall-clock time doesn't exist, advance 1 minute
+      minute++;
+      if (minute >= 60) {
+        minute = 0;
+        hour++;
+        if (hour >= 24) {
+          hour = 0;
+          day++;
+        }
+      }
+      continue;
+    }
+    // Ensure the result is strictly after afterMs
+    if (utcMs > afterMs) {
+      return utcMs;
+    }
+    // Edge case: the UTC result is not after afterMs (possible during fall-back overlap)
+    minute++;
+    if (minute >= 60) {
+      minute = 0;
+      hour++;
+      if (hour >= 24) {
+        hour = 0;
+        day++;
+      }
+    }
   }
 
   throw new Error(`No cron match found within ${MAX_SEARCH_YEARS} years for pattern: ${pattern}`);

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -157,4 +157,67 @@ describeEachMode('Job schedulers', (CONNECTION) => {
 
     await cleanupClient.hdel(k.schedulers, ['corrupt']);
   });
+
+  // --- Timezone support (#74) ---
+
+  it('upsertJobScheduler stores tz in scheduler entry', async () => {
+    await queue.upsertJobScheduler('tz-cron', { pattern: '0 9 * * *', tz: 'America/New_York' });
+
+    const k = buildKeys(Q);
+    const raw = await cleanupClient.hget(k.schedulers, 'tz-cron');
+    expect(raw).not.toBeNull();
+
+    const config = JSON.parse(String(raw));
+    expect(config.pattern).toBe('0 9 * * *');
+    expect(config.tz).toBe('America/New_York');
+    expect(config.nextRun).toBeGreaterThan(0);
+
+    await queue.removeJobScheduler('tz-cron');
+  });
+
+  it('upsertJobScheduler without tz does not store tz field', async () => {
+    await queue.upsertJobScheduler('no-tz-cron', { pattern: '0 9 * * *' });
+
+    const k = buildKeys(Q);
+    const raw = await cleanupClient.hget(k.schedulers, 'no-tz-cron');
+    expect(raw).not.toBeNull();
+
+    const config = JSON.parse(String(raw));
+    expect(config.tz).toBeUndefined();
+
+    await queue.removeJobScheduler('no-tz-cron');
+  });
+
+  it('upsertJobScheduler rejects invalid timezone', async () => {
+    await expect(queue.upsertJobScheduler('bad-tz', { pattern: '0 9 * * *', tz: 'Fake/Zone' })).rejects.toThrow(
+      'Invalid timezone',
+    );
+  });
+
+  it('getJobScheduler returns tz for timezone-aware scheduler', async () => {
+    await queue.upsertJobScheduler('tz-lookup', { pattern: '30 14 * * *', tz: 'Asia/Tokyo' });
+
+    const result = await queue.getJobScheduler('tz-lookup');
+    expect(result).not.toBeNull();
+    expect(result!.pattern).toBe('30 14 * * *');
+    expect(result!.tz).toBe('Asia/Tokyo');
+
+    await queue.removeJobScheduler('tz-lookup');
+  });
+
+  it('tz is ignored for every-based schedulers (no effect on interval)', async () => {
+    // tz should be stored but has no effect on interval-based schedulers
+    const before = Date.now();
+    await queue.upsertJobScheduler('tz-every', { every: 5000, tz: 'America/New_York' });
+
+    const k = buildKeys(Q);
+    const raw = await cleanupClient.hget(k.schedulers, 'tz-every');
+    const config = JSON.parse(String(raw));
+    // nextRun should be roughly now + 5000ms (interval), not affected by tz
+    expect(config.nextRun).toBeGreaterThanOrEqual(before + 4000);
+    expect(config.nextRun).toBeLessThanOrEqual(before + 7000);
+    expect(config.tz).toBe('America/New_York');
+
+    await queue.removeJobScheduler('tz-every');
+  });
 });

--- a/tests/testing-mode.test.ts
+++ b/tests/testing-mode.test.ts
@@ -737,6 +737,39 @@ describe('TestQueue.getJobScheduler', () => {
     await queue.removeJobScheduler('a');
     await queue.removeJobScheduler('b');
   });
+
+  // --- Timezone support (#74) ---
+
+  it('upsertJobScheduler stores tz for cron scheduler', async () => {
+    queue = new TestQueue('sched-tz');
+    await queue.upsertJobScheduler('tz-cron', { pattern: '0 9 * * *', tz: 'America/New_York' });
+
+    const entry = await queue.getJobScheduler('tz-cron');
+    expect(entry).not.toBeNull();
+    expect(entry!.pattern).toBe('0 9 * * *');
+    expect(entry!.tz).toBe('America/New_York');
+    expect(entry!.nextRun).toBeGreaterThan(0);
+
+    await queue.removeJobScheduler('tz-cron');
+  });
+
+  it('upsertJobScheduler without tz does not include tz in entry', async () => {
+    queue = new TestQueue('sched-no-tz');
+    await queue.upsertJobScheduler('no-tz', { pattern: '0 9 * * *' });
+
+    const entry = await queue.getJobScheduler('no-tz');
+    expect(entry).not.toBeNull();
+    expect(entry!.tz).toBeUndefined();
+
+    await queue.removeJobScheduler('no-tz');
+  });
+
+  it('upsertJobScheduler rejects invalid timezone', async () => {
+    queue = new TestQueue('sched-bad-tz');
+    await expect(queue.upsertJobScheduler('bad', { pattern: '0 9 * * *', tz: 'Fake/Zone' })).rejects.toThrow(
+      'Invalid timezone',
+    );
+  });
 });
 
 describe('TestWorker - TTL', () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { gzipSync } from 'zlib';
-import { nextCronOccurrence, decompress, MAX_JOB_DATA_SIZE } from '../src/utils';
+import { nextCronOccurrence, validateTimezone, decompress, MAX_JOB_DATA_SIZE } from '../src/utils';
 
 describe('decompress', () => {
   it('rejects decompression bombs exceeding MAX_JOB_DATA_SIZE', () => {
@@ -125,5 +125,114 @@ describe('nextCronOccurrence', () => {
     const now = new Date('2024-01-01T10:00:00Z').getTime();
     const next = nextCronOccurrence('30 * * * *', now);
     expect(new Date(next).toISOString()).toBe('2024-01-01T10:30:00.000Z');
+  });
+});
+
+describe('validateTimezone', () => {
+  it('accepts valid IANA timezone', () => {
+    expect(() => validateTimezone('America/New_York')).not.toThrow();
+    expect(() => validateTimezone('Europe/London')).not.toThrow();
+    expect(() => validateTimezone('Asia/Tokyo')).not.toThrow();
+    expect(() => validateTimezone('UTC')).not.toThrow();
+  });
+
+  it('rejects invalid timezone string', () => {
+    expect(() => validateTimezone('Fake/Timezone')).toThrow('Invalid timezone: Fake/Timezone');
+    expect(() => validateTimezone('')).toThrow('Invalid timezone');
+    expect(() => validateTimezone('Not_A_Zone')).toThrow('Invalid timezone');
+  });
+});
+
+describe('nextCronOccurrence with timezone', () => {
+  // America/New_York is UTC-5 in winter (EST), UTC-4 in summer (EDT)
+  // Asia/Tokyo is always UTC+9 (no DST)
+
+  it('evaluates cron in the specified timezone (EST winter)', () => {
+    // "0 9 * * *" in America/New_York = 9:00 AM EST = 14:00 UTC
+    // afterMs: 2024-01-15T13:00:00Z (8:00 AM in New York - before 9:00 AM)
+    const now = new Date('2024-01-15T13:00:00Z').getTime();
+    const next = nextCronOccurrence('0 9 * * *', now, 'America/New_York');
+    expect(new Date(next).toISOString()).toBe('2024-01-15T14:00:00.000Z');
+  });
+
+  it('evaluates cron in the specified timezone (EDT summer)', () => {
+    // "0 9 * * *" in America/New_York = 9:00 AM EDT = 13:00 UTC
+    // afterMs: 2024-07-15T12:00:00Z (8:00 AM in New York - before 9:00 AM)
+    const now = new Date('2024-07-15T12:00:00Z').getTime();
+    const next = nextCronOccurrence('0 9 * * *', now, 'America/New_York');
+    expect(new Date(next).toISOString()).toBe('2024-07-15T13:00:00.000Z');
+  });
+
+  it('evaluates cron in Asia/Tokyo (UTC+9, no DST)', () => {
+    // "0 9 * * *" in Asia/Tokyo = 9:00 JST = 00:00 UTC
+    // afterMs: 2024-06-01T14:00:00Z (23:00 JST June 1 - before 9:00 AM JST June 2)
+    const now = new Date('2024-06-01T14:00:00Z').getTime();
+    const next = nextCronOccurrence('0 9 * * *', now, 'Asia/Tokyo');
+    expect(new Date(next).toISOString()).toBe('2024-06-02T00:00:00.000Z');
+  });
+
+  it('wraps to next day in target timezone', () => {
+    // "0 9 * * *" in America/New_York, afterMs when it's already past 9 AM in New York
+    // 2024-01-15T15:00:00Z = 10:00 AM EST (already past 9 AM)
+    const now = new Date('2024-01-15T15:00:00Z').getTime();
+    const next = nextCronOccurrence('0 9 * * *', now, 'America/New_York');
+    // Next occurrence is Jan 16 at 9:00 AM EST = 14:00 UTC
+    expect(new Date(next).toISOString()).toBe('2024-01-16T14:00:00.000Z');
+  });
+
+  it('without tz parameter, cron runs in UTC', () => {
+    // "0 9 * * *" without tz = 09:00 UTC
+    const now = new Date('2024-01-15T08:00:00Z').getTime();
+    const next = nextCronOccurrence('0 9 * * *', now);
+    expect(new Date(next).toISOString()).toBe('2024-01-15T09:00:00.000Z');
+  });
+
+  // --- DST transitions ---
+
+  it('spring-forward: skips nonexistent wall-clock time', () => {
+    // In America/New_York, 2024-03-10: clocks spring forward 2:00 AM -> 3:00 AM
+    // "30 2 * * *" = 2:30 AM - does not exist on March 10
+    // Next valid occurrence is March 11 at 2:30 AM EDT = 06:30 UTC
+    const now = new Date('2024-03-10T06:00:00Z').getTime(); // 1:00 AM EST
+    const next = nextCronOccurrence('30 2 * * *', now, 'America/New_York');
+    // March 10 2:30 AM doesn't exist, so it should fire March 11 at 2:30 AM EDT
+    // March 11 2:30 AM EDT = 06:30 UTC
+    expect(new Date(next).toISOString()).toBe('2024-03-11T06:30:00.000Z');
+  });
+
+  it('fall-back: picks first (earlier) UTC instant for ambiguous time', () => {
+    // In America/New_York, 2024-11-03: clocks fall back 2:00 AM -> 1:00 AM
+    // "30 1 * * *" = 1:30 AM - this time occurs twice (EDT and EST)
+    // We should pick the first (EDT) occurrence: 1:30 AM EDT = 05:30 UTC
+    // afterMs: right before the DST transition
+    const now = new Date('2024-11-03T04:00:00Z').getTime(); // midnight EDT
+    const next = nextCronOccurrence('30 1 * * *', now, 'America/New_York');
+    // 1:30 AM EDT = 05:30 UTC (the earlier of the two possible interpretations)
+    expect(new Date(next).toISOString()).toBe('2024-11-03T05:30:00.000Z');
+  });
+
+  it('midnight cron in positive-offset timezone', () => {
+    // "0 0 * * *" in Asia/Kolkata (UTC+5:30) = previous day 18:30 UTC
+    const now = new Date('2024-06-15T17:00:00Z').getTime(); // 22:30 IST
+    const next = nextCronOccurrence('0 0 * * *', now, 'Asia/Kolkata');
+    // Next midnight IST = June 16 00:00 IST = June 15 18:30 UTC
+    expect(new Date(next).toISOString()).toBe('2024-06-15T18:30:00.000Z');
+  });
+
+  it('handles day-of-week matching in timezone', () => {
+    // "0 9 * * 1" = 9:00 AM on Mondays in America/Chicago (UTC-6 CST / UTC-5 CDT)
+    // 2024-01-15 is a Monday
+    // afterMs: 2024-01-14T00:00:00Z (Sunday in Chicago)
+    const now = new Date('2024-01-14T00:00:00Z').getTime();
+    const next = nextCronOccurrence('0 9 * * 1', now, 'America/Chicago');
+    // Monday Jan 15 at 9:00 AM CST = 15:00 UTC
+    expect(new Date(next).toISOString()).toBe('2024-01-15T15:00:00.000Z');
+  });
+
+  it('validates invalid timezone via nextCronOccurrence dispatch', () => {
+    const now = Date.now();
+    // nextCronOccurrenceTz uses getFormatter which calls Intl.DateTimeFormat
+    // An invalid tz string will throw
+    expect(() => nextCronOccurrence('0 9 * * *', now, 'Invalid/Zone')).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- Add optional `tz` parameter to `ScheduleOpts` for cron-based job schedulers
- When specified, cron expressions are evaluated in the given IANA timezone instead of UTC
- Uses Node.js built-in `Intl.DateTimeFormat` - zero new dependencies

## Changes

- `src/types.ts`: Added `tz?: string` to `ScheduleOpts` and `SchedulerEntry`
- `src/utils.ts`: Added `validateTimezone()`, `utcToTzParts()`, `tzPartsToUtc()`, `nextCronOccurrenceTz()` with `Intl.DateTimeFormat` caching
- `src/queue.ts`: Validate tz at upsert, pass to `nextCronOccurrence()`, store in entry
- `src/scheduler.ts`: Pass `config.tz` through in `runSchedulers()` tick loop
- `src/testing.ts`: Same tz handling as production Queue for parity

## DST Handling

- **Spring-forward gaps**: Nonexistent wall-clock times are skipped (e.g., 2:30 AM on March 10 in New York)
- **Fall-back overlaps**: Ambiguous times resolve to the first (earlier) UTC instant

## Tests

20 new tests across 3 files:
- `tests/utils.test.ts`: 12 tests - timezone validation, EST/EDT/JST/IST offsets, DST transitions, day-of-week matching
- `tests/scheduler.test.ts`: 5 integration tests - tz stored in Valkey hash, persisted across get/set, invalid tz rejected
- `tests/testing-mode.test.ts`: 3 tests - TestQueue parity for tz storage and validation

## Usage

```typescript
await queue.upsertJobScheduler('daily-report', {
  pattern: '0 9 * * *',       // 9:00 AM
  tz: 'America/New_York',     // in Eastern time
}, { name: 'generate-report' });
```

Closes #74