### PR TITLE
fix: harden serializer error handling and size validation

### DIFF
--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -1,7 +1,7 @@
 import type { FlowProducerOptions, FlowJob, Client, Serializer } from './types';
 import { JSON_SERIALIZER } from './types';
 import { Job } from './job';
-import { buildKeys, keyPrefix } from './utils';
+import { buildKeys, keyPrefix, MAX_JOB_DATA_SIZE } from './utils';
 import { createClient, ensureFunctionLibrary, ensureFunctionLibraryOnce, isClusterClient } from './connection';
 import { GlideMQError } from './errors';
 import { LIBRARY_SOURCE, addFlow, addJob } from './functions/index';
@@ -107,11 +107,18 @@ export class FlowProducer {
       if ((groupRateMax > 0 || tbCapacity > 0) && groupConcurrency < 1) {
         groupConcurrency = 1;
       }
+      const serializedData = this.serializer.serialize(flow.data);
+      const dataByteLen = Buffer.byteLength(serializedData, 'utf8');
+      if (dataByteLen > MAX_JOB_DATA_SIZE) {
+        throw new Error(
+          `Job data exceeds maximum size (${dataByteLen} bytes > ${MAX_JOB_DATA_SIZE} bytes). Use smaller payloads or store large data externally.`,
+        );
+      }
       const jobId = await addJob(
         client,
         parentKeys,
         flow.name,
-        this.serializer.serialize(flow.data),
+        serializedData,
         JSON.stringify(opts),
         timestamp,
         opts.delay ?? 0,
@@ -149,9 +156,16 @@ export class FlowProducer {
       .filter((_, i) => !childNodeMap.has(i))
       .map((child) => {
         const childOpts = child.opts ?? {};
+        const childData = this.serializer.serialize(child.data);
+        const childByteLen = Buffer.byteLength(childData, 'utf8');
+        if (childByteLen > MAX_JOB_DATA_SIZE) {
+          throw new Error(
+            `Job data exceeds maximum size (${childByteLen} bytes > ${MAX_JOB_DATA_SIZE} bytes). Use smaller payloads or store large data externally.`,
+          );
+        }
         return {
           name: child.name,
-          data: this.serializer.serialize(child.data),
+          data: childData,
           opts: JSON.stringify(childOpts),
           delay: childOpts.delay ?? 0,
           priority: childOpts.priority ?? 0,
@@ -172,11 +186,18 @@ export class FlowProducer {
     const timestamp = Date.now();
     const parentOpts = flow.opts ?? {};
 
+    const parentData = this.serializer.serialize(flow.data);
+    const parentByteLen = Buffer.byteLength(parentData, 'utf8');
+    if (parentByteLen > MAX_JOB_DATA_SIZE) {
+      throw new Error(
+        `Job data exceeds maximum size (${parentByteLen} bytes > ${MAX_JOB_DATA_SIZE} bytes). Use smaller payloads or store large data externally.`,
+      );
+    }
     const ids = await addFlow(
       client,
       parentKeys,
       flow.name,
-      this.serializer.serialize(flow.data),
+      parentData,
       JSON.stringify(parentOpts),
       timestamp,
       parentOpts.delay ?? 0,

--- a/src/job.ts
+++ b/src/job.ts
@@ -41,6 +41,13 @@ export class Job<D = any, R = any> {
   discarded = false;
 
   /**
+   * Set to true when data or returnvalue could not be deserialized from Valkey.
+   * This typically indicates a serializer mismatch between the producer and consumer.
+   * When true, `data` is set to `{} as D` and `returnvalue` to `undefined`.
+   */
+  deserializationFailed = false;
+
+  /**
    * Stream entry ID assigned when the job was added to the stream.
    * Used by Worker to XACK after processing.
    * @internal
@@ -396,10 +403,12 @@ export class Job<D = any, R = any> {
     let data: D;
     let opts: JobOptions;
     let returnvalue: R | undefined;
+    let deserializationFailed = false;
     try {
-      data = s.deserialize(decompress(hash.data || '{}')) as D;
+      data = hash.data ? (s.deserialize(decompress(hash.data)) as D) : ({} as D);
     } catch {
       data = {} as D;
+      deserializationFailed = true;
     }
     try {
       opts = JSON.parse(hash.opts || '{}');
@@ -410,9 +419,11 @@ export class Job<D = any, R = any> {
       returnvalue = hash.returnvalue ? (s.deserialize(hash.returnvalue) as R) : undefined;
     } catch {
       returnvalue = undefined;
+      deserializationFailed = true;
     }
 
-    const job = new Job<D, R>(client, queueKeys, id, hash.name || '', data, opts, serializer);
+    const job = new Job<D, R>(client, queueKeys, id, hash.name || '', data, opts, s);
+    job.deserializationFailed = deserializationFailed;
     job.attemptsMade = parseInt(hash.attemptsMade || '0', 10);
     job.timestamp = parseInt(hash.timestamp || '0', 10);
     job.processedOn = hash.processedOn ? parseInt(hash.processedOn, 10) : undefined;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -3,7 +3,7 @@ import type { Client, SchedulerEntry, Serializer } from './types';
 import { JSON_SERIALIZER } from './types';
 import { CONSUMER_GROUP, promote, promoteRateLimited, reclaimStalled, addJobArgs, nextDueAt } from './functions/index';
 import type { buildKeys } from './utils';
-import { nextCronOccurrence } from './utils';
+import { nextCronOccurrence, MAX_JOB_DATA_SIZE } from './utils';
 import { isClusterClient } from './connection';
 
 export interface SchedulerOptions {
@@ -233,7 +233,16 @@ export class Scheduler {
       // Compute the job name and data from the template
       const template = config.template ?? {};
       const jobName = template.name ?? schedulerName;
-      const jobData = template.data !== undefined ? this.serializer.serialize(template.data) : '{}';
+      let jobData: string;
+      try {
+        jobData = template.data !== undefined ? this.serializer.serialize(template.data) : '{}';
+      } catch {
+        continue; // Skip entry if serializer fails
+      }
+      const byteLen = Buffer.byteLength(jobData, 'utf8');
+      if (byteLen > MAX_JOB_DATA_SIZE) {
+        continue; // Skip oversized entries
+      }
       const jobOpts = template.opts ? JSON.stringify(template.opts) : '{}';
       const priority = template.opts?.priority ?? 0;
       const maxAttempts = template.opts?.attempts ?? 0;

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -131,7 +131,7 @@ function matchesData(data: Record<string, unknown>, filter: Record<string, unkno
 export interface TestQueueOptions {
   /** Enable deduplication in 'simple' mode. */
   dedup?: boolean;
-  /** Custom serializer for job data. When provided, data is roundtripped through serialize/deserialize to match production behavior. */
+  /** Custom serializer for job data and return values. When provided, values are roundtripped through serialize/deserialize to match production behavior. */
   serializer?: Serializer;
 }
 
@@ -142,7 +142,7 @@ export class TestQueue<D = any, R = any> extends EventEmitter {
   private idCounter = 0;
   private paused = false;
   private opts: TestQueueOptions;
-  private serializer: Serializer;
+  /** @internal */ readonly serializer: Serializer;
 
   /** Workers register themselves here so we can notify on add. */
   /** @internal */ readonly workers: Set<TestWorker<D, R>> = new Set();
@@ -519,13 +519,16 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
     }
     this.processor(job as any)
       .then((result) => {
+        // Roundtrip returnvalue through serializer to match production behavior
+        const s = this.queue.serializer;
+        const roundtripped = result !== undefined ? (s.deserialize(s.serialize(result)) as R) : result;
         record.state = 'completed';
-        record.returnvalue = result;
+        record.returnvalue = roundtripped;
         record.finishedOn = Date.now();
-        job.returnvalue = result;
+        job.returnvalue = roundtripped;
         job.finishedOn = record.finishedOn;
-        this.emit('completed', job, result);
-        this.queue.emit('completed', job, result);
+        this.emit('completed', job, roundtripped);
+        this.queue.emit('completed', job, roundtripped);
       })
       .catch((err: Error) => {
         record.attemptsMade++;

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,14 @@ export interface QueueOptions {
   deadLetterQueue?: DeadLetterQueueOptions;
   /** Enable transparent compression of job data. Default: 'none'. */
   compression?: 'none' | 'gzip';
-  /** Custom serializer for job data and return values. Default: JSON. */
+  /**
+   * Custom serializer for job data and return values. Default: JSON.
+   *
+   * **Important**: The same serializer must be used across all Queue, Worker,
+   * and FlowProducer instances that operate on the same queue. A mismatch
+   * causes silent data corruption - the consumer will see `{}` and the job's
+   * `deserializationFailed` flag will be `true`.
+   */
   serializer?: Serializer;
 }
 
@@ -156,6 +163,16 @@ export interface TokenBucketConfig {
   refillRate: number;
 }
 
+/**
+ * Custom serializer for job data and return values.
+ *
+ * Implementations must satisfy the roundtrip invariant:
+ * `deserialize(serialize(value))` must produce a value equivalent to `value`
+ * for all values the application stores in jobs.
+ *
+ * Both methods must be synchronous. If `serialize` throws, the job is treated
+ * as a processor failure (in Worker) or skipped (in Scheduler).
+ */
 export interface Serializer {
   /** Serialize a value to a string for storage in Valkey. */
   serialize(data: unknown): string;
@@ -192,7 +209,12 @@ export interface FlowProducerOptions {
    */
   client?: Client;
   prefix?: string;
-  /** Custom serializer for job data and return values. Default: JSON. */
+  /**
+   * Custom serializer for job data and return values. Default: JSON.
+   *
+   * **Important**: Must match the serializer used by the corresponding Queue
+   * and Worker. A mismatch causes silent data corruption.
+   */
   serializer?: Serializer;
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,7 +5,14 @@ import { TimeUnit } from '@glidemq/speedkey';
 import type { WorkerOptions, Processor, Client, Serializer } from './types';
 import { JSON_SERIALIZER } from './types';
 import { Job } from './job';
-import { buildKeys, calculateBackoff, keyPrefix, nextReconnectDelay, reconnectWithBackoff } from './utils';
+import {
+  buildKeys,
+  calculateBackoff,
+  keyPrefix,
+  nextReconnectDelay,
+  reconnectWithBackoff,
+  MAX_JOB_DATA_SIZE,
+} from './utils';
 import { createSandboxedProcessor } from './sandbox';
 import {
   createClient,
@@ -657,7 +664,31 @@ export class Worker<D = any, R = any> extends EventEmitter {
 
       if (!this.commandClient) return;
 
-      const returnvalue = processResult !== undefined ? this.serializer.serialize(processResult) : 'null';
+      let returnvalue: string;
+      try {
+        returnvalue = processResult !== undefined ? this.serializer.serialize(processResult) : 'null';
+      } catch (serializeErr) {
+        const err = serializeErr instanceof Error ? serializeErr : new Error(String(serializeErr));
+        await this.handleJobFailure(
+          job,
+          currentJobId,
+          currentEntryId,
+          new Error(`Serializer failed on return value: ${err.message}`),
+        );
+        return;
+      }
+      const byteLen = Buffer.byteLength(returnvalue, 'utf8');
+      if (byteLen > MAX_JOB_DATA_SIZE) {
+        await this.handleJobFailure(
+          job,
+          currentJobId,
+          currentEntryId,
+          new Error(
+            `Return value exceeds maximum size (${byteLen} bytes > ${MAX_JOB_DATA_SIZE} bytes). Use smaller return values or store large data externally.`,
+          ),
+        );
+        return;
+      }
       const parentInfo = this.buildParentInfo(job, currentJobId);
 
       const fetchResult = await completeAndFetchNext(
@@ -757,6 +788,10 @@ export class Worker<D = any, R = any> extends EventEmitter {
     const dlqName = this.opts.deadLetterQueue.name;
     const dlqKeys = buildKeys(dlqName, this.opts.prefix);
     try {
+      // DLQ envelope is always JSON. The data field is the already-deserialized
+      // job.data embedded directly - this means non-JSON types (Date, Map, Set)
+      // undergo lossy JSON conversion. BigInt will throw, caught by outer catch.
+      // A future major version could change this to use the queue's serializer.
       const dlqData = JSON.stringify({
         originalQueue: this.name,
         originalJobId: job.id,


### PR DESCRIPTION
## Summary
Addresses review findings from multi-agent code review of the pluggable serializers feature (#73, PRs #96 and #97).

### HIGH fixes
- **try/catch on serialize() in hot paths**: Worker returnvalue serialization (`worker.ts:660`) now catches serializer errors and treats them as processor failures instead of leaving jobs stuck in active state. Scheduler (`scheduler.ts:236`) skips entries on serializer failure.
- **MAX_JOB_DATA_SIZE validation**: Added byte-length checks after every `serialize()` call in Worker returnvalue, FlowProducer (3 sites), and Scheduler - matching the existing guard in `Queue.add()`.

### MEDIUM fixes
- **`Job.deserializationFailed` flag**: `fromHash` now sets this boolean when data or returnvalue deserialization fails, enabling runtime detection of serializer mismatches. Previously failed silently with `data = {} as D`.
- **Serializer mismatch documentation**: Enhanced JSDoc on `QueueOptions.serializer` and `FlowProducerOptions.serializer` with prominent warnings about mismatch consequences.
- **TestWorker returnvalue roundtrip**: `TestWorker` now roundtrips return values through `serialize/deserialize` to match production behavior.
- **DLQ envelope**: Documented the limitation that DLQ envelopes always use JSON (non-JSON types undergo lossy conversion). Pre-serialization approach was prototyped but reverted due to backward-compat impact on `getJobs()` consumers.

### LOW fixes
- `fromHash` now passes resolved serializer `s` to Job constructor (was passing possibly-undefined `serializer`)
- `fromHash` checks `hash.data` existence before deserializing (no more feeding `'{}'` to custom serializers)
- `Serializer` interface JSDoc documents the roundtrip invariant and error behavior
- `TestQueueOptions.serializer` doc updated to say "job data and return values"

Closes #73 (final review hardening).