### PR TITLE
fix: chunk pipeline batches to prevent event loop blocking

### DIFF
--- a/src/queue.ts
+++ b/src/queue.ts
@@ -61,6 +61,7 @@ import type { QueueKeys } from './functions/index';
 import { withSpan } from './telemetry';
 
 const MAX_ORDERING_KEY_LENGTH = 256;
+const PIPELINE_CHUNK_SIZE = 1000;
 const SCHEDULER_LOCK_TTL_MS = 5000;
 const SCHEDULER_LOCK_RETRY_DELAY_MS = 25;
 const SCHEDULER_LOCK_MAX_ATTEMPTS = Math.ceil(SCHEDULER_LOCK_TTL_MS / SCHEDULER_LOCK_RETRY_DELAY_MS);
@@ -1212,14 +1213,17 @@ export class Queue<D = any, R = any> extends EventEmitter {
     }
 
     if (jobIds.length === 0) return [];
-    const batch = this.newBatch();
-    for (const id of jobIds) (batch as any).hgetall(this.keys.job(id));
-    const batchResults = await client.exec(batch as any, false);
     const jobs: Job<D, R>[] = [];
-    if (batchResults) {
-      for (let i = 0; i < batchResults.length; i++) {
-        const hash = hashDataToRecord(batchResults[i] as any);
-        if (hash) jobs.push(Job.fromHash<D, R>(client, this.keys, jobIds[i], hash, this.serializer));
+    for (let offset = 0; offset < jobIds.length; offset += PIPELINE_CHUNK_SIZE) {
+      const chunk = jobIds.slice(offset, offset + PIPELINE_CHUNK_SIZE);
+      const batch = this.newBatch();
+      for (const id of chunk) (batch as any).hgetall(this.keys.job(id));
+      const batchResults = await client.exec(batch as any, false);
+      if (batchResults) {
+        for (let i = 0; i < batchResults.length; i++) {
+          const hash = hashDataToRecord(batchResults[i] as any);
+          if (hash) jobs.push(Job.fromHash<D, R>(client, this.keys, chunk[i], hash, this.serializer));
+        }
       }
     }
     return jobs;
@@ -1508,17 +1512,20 @@ export class Queue<D = any, R = any> extends EventEmitter {
     const jobIds = extractJobIdsFromStreamEntries(entries);
     const sliced = jobIds.slice(start, end >= 0 ? end + 1 : undefined);
     if (sliced.length === 0) return [];
-    const batch = this.newBatch();
-    for (const id of sliced) (batch as any).hgetall(dlqKeys.job(id));
-    const batchResults = await client.exec(batch as any, false);
     const jobs: Job<D, R>[] = [];
-    if (batchResults) {
-      for (let i = 0; i < batchResults.length; i++) {
-        const hash = hashDataToRecord(batchResults[i] as any);
-        if (!hash) continue;
-        // DLQ envelope is always JSON (written by Worker.moveToDLQ with JSON.stringify),
-        // regardless of the queue's custom serializer.
-        jobs.push(Job.fromHash<D, R>(client, dlqKeys, sliced[i], hash));
+    for (let offset = 0; offset < sliced.length; offset += PIPELINE_CHUNK_SIZE) {
+      const chunk = sliced.slice(offset, offset + PIPELINE_CHUNK_SIZE);
+      const batch = this.newBatch();
+      for (const id of chunk) (batch as any).hgetall(dlqKeys.job(id));
+      const batchResults = await client.exec(batch as any, false);
+      if (batchResults) {
+        for (let i = 0; i < batchResults.length; i++) {
+          const hash = hashDataToRecord(batchResults[i] as any);
+          if (!hash) continue;
+          // DLQ envelope is always JSON (written by Worker.moveToDLQ with JSON.stringify),
+          // regardless of the queue's custom serializer.
+          jobs.push(Job.fromHash<D, R>(client, dlqKeys, chunk[i], hash));
+        }
       }
     }
     return jobs;


### PR DESCRIPTION
## Summary

Chunks large pipeline batches in `getJobs` and `getDeadLetterJobs` into groups of 1000 to prevent event loop blocking and OOM on large queues.

- Extract `PIPELINE_CHUNK_SIZE = 1000` constant
- Chunk `getJobs` hgetall pipeline
- Chunk `getDeadLetterJobs` hgetall pipeline

Clean reimplementation of #93 (removed Bolt branding comments, shared constant).

Supersedes #93.

## Test Plan

- [x] `npm run build` compiles
- [x] Integration tests pass (26/26)