### PR TITLE
⚡ Bolt: Use Promise.all for concurrent flow processing in addBulk

### DIFF
--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -87,11 +87,7 @@ export class FlowProducer {
    */
   async addBulk(flows: FlowJob[]): Promise<JobNode[]> {
     const client = await this.getClient();
-    const results: JobNode[] = [];
-    for (const flow of flows) {
-      results.push(await this.addFlowRecursive(client, flow));
-    }
-    return results;
+    return Promise.all(flows.map((flow) => this.addFlowRecursive(client, flow)));
   }
 
   /**


### PR DESCRIPTION
💡 **What:** Replaced the sequential `for...of` loop in `FlowProducer.addBulk` with a concurrent `Promise.all` + `map`.

🎯 **Why:** To eliminate sequential I/O latency when dispatching large batches of independent jobs/flows. 

📊 **Impact:** This transforms $O(N)$ sequential network operations into a single concurrent batch execution phase, dramatically speeding up `addBulk` and eliminating a significant bottleneck on the Node.js event loop.

🔬 **Measurement:** This can be verified by observing a lower overall turnaround time during large bulk ingestion via benchmarking against the previous loop-based implementation.

---
*PR created automatically by Jules for task [13750477624577637836](https://jules.google.com/task/13750477624577637836) started by @avifenesh*