### PR TITLE
⚡ Bolt: Process multiple independent job flows concurrently in `addBulk`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glide-mq",
-  "version": "0.8.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glide-mq",
-      "version": "0.8.1",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@glidemq/speedkey": "^0.2.0"

--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -84,14 +84,12 @@ export class FlowProducer {
 
   /**
    * Add multiple independent flows.
+   * Uses Promise.all to process independent flow trees concurrently,
+   * eliminating sequential I/O bottlenecks when adding many flows.
    */
   async addBulk(flows: FlowJob[]): Promise<JobNode[]> {
     const client = await this.getClient();
-    const results: JobNode[] = [];
-    for (const flow of flows) {
-      results.push(await this.addFlowRecursive(client, flow));
-    }
-    return results;
+    return Promise.all(flows.map((flow) => this.addFlowRecursive(client, flow)));
   }
 
   /**


### PR DESCRIPTION
💡 **What:** Refactored `addBulk` in `FlowProducer` to use `Promise.all` instead of a sequential `for...of` loop with `await`.
🎯 **Why:** To eliminate sequential I/O bottlenecks when adding multiple independent flow trees. Creating independent flows doesn't require waiting for the previous flow to finish before starting the next one.
📊 **Impact:** Significantly speeds up the processing of adding many job flows in bulk by allowing concurrent network requests, reducing the total duration bound by sequential roundtrips.
🔬 **Measurement:** Verify by timing the execution of `flowProducer.addBulk` with a large number of independent flow items before and after the change; there should be a measurable decrease in execution time.

---
*PR created automatically by Jules for task [15759898512104241481](https://jules.google.com/task/15759898512104241481) started by @avifenesh*