### PR TITLE
⚡ Bolt: Optimize FlowProducer.addBulk with concurrent chunks

### DIFF
--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -88,9 +88,14 @@ export class FlowProducer {
   async addBulk(flows: FlowJob[]): Promise<JobNode[]> {
     const client = await this.getClient();
     const results: JobNode[] = [];
-    for (const flow of flows) {
-      results.push(await this.addFlowRecursive(client, flow));
+    const chunkSize = 100;
+
+    for (let i = 0; i < flows.length; i += chunkSize) {
+      const chunk = flows.slice(i, i + chunkSize);
+      const chunkResults = await Promise.all(chunk.map((flow) => this.addFlowRecursive(client, flow)));
+      results.push(...chunkResults);
     }
+
     return results;
   }
 


### PR DESCRIPTION
💡 What: Modified `addBulk` method in `FlowProducer` to process input flows concurrently using a chunked `Promise.all` approach (chunk size of 100), rather than awaiting them one-by-one.

🎯 Why: The previous sequential `for...of` loop resulted in N network round-trips that could not overlap, creating a severe performance bottleneck for bulk flow insertions. Concurrent requests allow better utilization of network bandwidth and the Redis server.

📊 Impact: Reduces total time for `addBulk` operations roughly by a factor of the chunk size (up to 100x), bounded by network capability and server throughput.

🔬 Measurement: Observe the execution time of `flowProducer.addBulk()` with a large number of flows (e.g., 500+) before and after the change; the improvement will be clearly visible.

---
*PR created automatically by Jules for task [13311499362736079350](https://jules.google.com/task/13311499362736079350) started by @avifenesh*