### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix prototype pollution in JSON parser

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { GlideClient, GlideClusterClient, ReadFrom } from '@glidemq/speedkey';
+import { jsonReviver } from './utils';
 
 export type Client = GlideClient | GlideClusterClient;
 
@@ -250,7 +251,7 @@ export interface Serializer {
 /** Default JSON serializer used when no custom serializer is provided. */
 export const JSON_SERIALIZER: Serializer = {
   serialize: (data) => JSON.stringify(data),
-  deserialize: (raw) => JSON.parse(raw),
+  deserialize: (raw) => JSON.parse(raw, jsonReviver),
 };
 
 export interface JobData {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,6 +47,17 @@ export function isPlainStepPayload(value: unknown): value is Record<string, unkn
   return Object.getPrototypeOf(value) === Object.prototype;
 }
 
+/**
+ * A JSON reviver function that prevents prototype pollution by dropping
+ * dangerous keys like `__proto__`, `constructor`, and `prototype`.
+ */
+export function jsonReviver(key: string, value: unknown): unknown {
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    return undefined;
+  }
+  return value;
+}
+
 // ---- Compression helpers ----
 
 const COMPRESSED_PREFIX = 'gz:';


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The default `JSON_SERIALIZER` utilized `JSON.parse(raw)` directly without a reviver function. This exposed the queue to potential prototype pollution attacks when deserializing user-controlled job payloads containing dangerous keys like `__proto__`, `constructor`, or `prototype`.
🎯 Impact: An attacker could inject malicious properties into the global Object prototype, leading to application crashes, logic bypasses, or potential remote code execution (RCE) in vulnerable downstream flows.
🔧 Fix: Implemented an exported `jsonReviver` function in `src/utils.ts` to explicitly drop dangerous keys during instantiation. Updated `JSON_SERIALIZER` in `src/types.ts` to pass this reviver to `JSON.parse()`. Added a journal entry detailing the vulnerability and learning.
✅ Verification: Ran unit tests via `pnpm run build && pnpm test` successfully. Checked `JSON_SERIALIZER` manually to ensure it uses the new reviver correctly.

---
*PR created automatically by Jules for task [1767796011899575493](https://jules.google.com/task/1767796011899575493) started by @avifenesh*