### PR TITLE
⚡ Bolt: [performance improvement] Optimize stream entry parsing by breaking early

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -259,6 +259,7 @@ export function extractJobIdsFromStreamEntries(entries: Record<string, [unknown,
       const value = fieldPairs[i][1];
       if (String(field) === 'jobId') {
         jobIds.push(String(value));
+        break; // Stop parsing remaining large fields once we found jobId
       }
     }
   }


### PR DESCRIPTION
💡 What: Added an early `break` statement in `extractJobIdsFromStreamEntries` once the `jobId` field is matched.
🎯 Why: A Redis stream entry represents a single message, so `jobId` will only appear once per message. Continuing to iterate through the rest of the fields (which might contain large stringified payloads or objects) after finding the `jobId` is unnecessary and wastes CPU cycles.
📊 Impact: Reduces unnecessary iterations and typecasting in a frequently called utility function, slightly improving performance, especially when job payloads have many fields or large sizes.
🔬 Measurement: Verified with existing unit tests that the behavior is completely unchanged, as `jobId` is expected to be present at most once per stream entry map.

---
*PR created automatically by Jules for task [16612606038219045695](https://jules.google.com/task/16612606038219045695) started by @avifenesh*