### PR TITLE
⚡ Bolt: [performance improvement] Optimize proxy bulk job addition

### DIFF
--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -253,7 +253,9 @@ export function createRoutes(
       }
 
       const queue = await getQueue(param(req, 'name'));
-      const results = await Promise.all(jobs.map((j) => queue.add(j.name, j.data ?? null, j.opts)));
+      // Use native addBulk instead of Promise.all(queue.add) to batch all jobs
+      // into a single Valkey round trip via the GLIDE Batch API (O(1) network latency)
+      const results = await queue.addBulk(jobs.map((j) => ({ name: j.name, data: j.data ?? null, opts: j.opts })));
 
       const responseJobs: (AddJobResponse | AddJobSkippedResponse)[] = results.map((job) =>
         job ? { id: job.id, name: job.name, timestamp: job.timestamp } : { skipped: true },


### PR DESCRIPTION
Replaced sequential `queue.add` calls inside a `Promise.all` mapping with the native `queue.addBulk` method in the `/queues/:name/jobs/bulk` proxy endpoint. This prevents N+1 query bottlenecks and leverages the GLIDE Batch API to dispatch all add commands in a single network round-trip, significantly reducing latency and overhead for bulk insertions.

Also added `.jules/bolt.md` to record the performance insight that looping `Promise.all(add)` should be avoided in favor of `addBulk` wherever possible.

---
*PR created automatically by Jules for task [9391799178293279018](https://jules.google.com/task/9391799178293279018) started by @avifenesh*