### PR TITLE
[cairn] fix: prototype pollution defense-in-depth via jsonReviver

### DIFF
--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -13,7 +13,9 @@ import {
   nextReconnectDelay,
   reconnectWithBackoff,
   MAX_JOB_DATA_SIZE,
+  jsonReviver,
 } from './utils';
+
 import { createSandboxedProcessor } from './sandbox';
 import {
   createClient,
@@ -1013,7 +1015,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
 
       let config: SchedulerEntry;
       try {
-        config = JSON.parse(String(raw));
+        config = JSON.parse(String(raw), jsonReviver);
       } catch {
         return;
       }

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,5 +1,6 @@
 import type { Client } from '../types';
 import type { GlideReturnType } from '@glidemq/speedkey';
+import { jsonReviver } from '../utils';
 
 export const LIBRARY_NAME = 'glidemq';
 // Version 44: Added metrics recording (time-series data for getMetrics).
@@ -3700,7 +3701,7 @@ export async function completeAndFetchNext(
   }
 
   // Backward compatibility: JSON protocol (older library versions)
-  const parsed = JSON.parse(String(raw));
+  const parsed = JSON.parse(String(raw), jsonReviver);
   if (!parsed.next || parsed.next === false) {
     return { completed: parsed.completed, next: false };
   }
@@ -3951,7 +3952,7 @@ export async function moveToActive(
   if (str === 'GROUP_ORDERED') return 'GROUP_ORDERED';
   if (str === 'ERR:COST_EXCEEDS_CAPACITY') return 'ERR:COST_EXCEEDS_CAPACITY';
   // Backward compatibility: older library returns cjson string
-  const arr = JSON.parse(str) as string[];
+  const arr = JSON.parse(str, jsonReviver) as string[];
   const hash: Record<string, string> = Object.create(null);
   for (let i = 0; i < arr.length; i += 2) {
     hash[String(arr[i])] = String(arr[i + 1]);
@@ -4324,7 +4325,7 @@ export async function addFlow(
   }
 
   const result = await client.fcall('glidemq_addFlow', keys, args);
-  return JSON.parse(result as string) as string[];
+  return JSON.parse(result as string, jsonReviver) as string[];
 }
 
 /**

--- a/src/job.ts
+++ b/src/job.ts
@@ -6,7 +6,7 @@ import type { QueueKeys } from './functions/index';
 import { removeJob, failJob, changePriority, changeDelay, promoteJob } from './functions/index';
 import { GlideMQError, DelayedError, WaitingChildrenError, GroupRateLimitError } from './errors';
 import type { GroupRateLimitOptions } from './errors';
-import { calculateBackoff, decompress, isPlainStepPayload, MAX_JOB_DATA_SIZE } from './utils';
+import { calculateBackoff, decompress, isPlainStepPayload, MAX_JOB_DATA_SIZE, jsonReviver } from './utils';
 import { isClusterClient } from './connection';
 
 export class Job<D = any, R = any> {
@@ -570,7 +570,7 @@ export class Job<D = any, R = any> {
     }
 
     try {
-      opts = JSON.parse(hash.opts || '{}');
+      opts = JSON.parse(hash.opts || '{}', jsonReviver);
     } catch {
       opts = {};
     }
@@ -593,14 +593,14 @@ export class Job<D = any, R = any> {
     job.schedulerName = hash.schedulerName || undefined;
     if (hash.parentIds) {
       try {
-        job.parentIds = JSON.parse(hash.parentIds);
+        job.parentIds = JSON.parse(hash.parentIds, jsonReviver);
       } catch {
         job.parentIds = undefined;
       }
     }
     if (hash.parentQueues) {
       try {
-        job.parentQueues = JSON.parse(hash.parentQueues);
+        job.parentQueues = JSON.parse(hash.parentQueues, jsonReviver);
       } catch {
         job.parentQueues = undefined;
       }

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -38,6 +38,7 @@ import {
   compress,
   MAX_JOB_DATA_SIZE,
   JOB_METADATA_FIELDS,
+  jsonReviver,
   validateQueueName,
   MAX_ORDERING_KEY_LENGTH,
   validateJobId,
@@ -949,7 +950,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
         const val = results[i];
         if (!val) continue;
         try {
-          const data = JSON.parse(String(val));
+          const data = JSON.parse(String(val), jsonReviver);
           if (typeof data.addr !== 'string' || typeof data.pid !== 'number' || typeof data.startedAt !== 'number') {
             continue;
           }
@@ -1023,7 +1024,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
       const existingRaw = await client.hget(this.keys.schedulers, name);
       if (existingRaw != null) {
         try {
-          const existing = JSON.parse(String(existingRaw)) as SchedulerEntry;
+          const existing = JSON.parse(String(existingRaw), jsonReviver) as SchedulerEntry;
           const scheduleUnchanged =
             existing.pattern === schedule.pattern &&
             existing.every === schedule.every &&
@@ -1649,7 +1650,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
       try {
         result.push({
           name: String(item.field),
-          entry: JSON.parse(String(item.value)),
+          entry: JSON.parse(String(item.value), jsonReviver),
         });
       } catch {
         // Malformed JSON - skip entry
@@ -1667,7 +1668,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
     const raw = await client.hget(this.keys.schedulers, name);
     if (raw == null) return null;
     try {
-      return JSON.parse(String(raw)) as SchedulerEntry;
+      return JSON.parse(String(raw), jsonReviver) as SchedulerEntry;
     } catch {
       return null;
     }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -16,7 +16,7 @@ import {
   healListActive,
 } from './functions/index';
 import type { buildKeys } from './utils';
-import { computeFollowingSchedulerNextRun, isValidSchedulerEvery, MAX_JOB_DATA_SIZE } from './utils';
+import { computeFollowingSchedulerNextRun, isValidSchedulerEvery, MAX_JOB_DATA_SIZE, jsonReviver } from './utils';
 import { isClusterClient } from './connection';
 
 export interface SchedulerOptions {
@@ -357,7 +357,7 @@ export class Scheduler {
         const schedulerName = String(entry.field);
         let config: SchedulerEntry;
         try {
-          config = JSON.parse(String(entry.value));
+          config = JSON.parse(String(entry.value), jsonReviver);
         } catch {
           continue;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { GlideClient, GlideClusterClient, ReadFrom } from '@glidemq/speedke
 export type Client = GlideClient | GlideClusterClient;
 
 export type { ReadFrom } from '@glidemq/speedkey';
+import { jsonReviver } from './utils';
 
 /** Standard password-based credentials. */
 export interface PasswordCredentials {
@@ -250,7 +251,7 @@ export interface Serializer {
 /** Default JSON serializer used when no custom serializer is provided. */
 export const JSON_SERIALIZER: Serializer = {
   serialize: (data) => JSON.stringify(data),
-  deserialize: (raw) => JSON.parse(raw),
+  deserialize: (raw) => JSON.parse(raw, jsonReviver),
 };
 
 export interface JobData {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -855,3 +855,24 @@ export function compileSubjectMatcher(patterns: string[] | undefined): ((subject
   }
   return (subject) => patterns.some((p) => matchSubject(p, subject));
 }
+
+/**
+ * JSON reviver that prevents prototype pollution by stripping dangerous keys.
+ *
+ * JSON.parse natively treats "__proto__" as a regular own-property, so direct
+ * parsing alone is safe. However, defense-in-depth is warranted because:
+ *  1. Parsed objects may later be spread/merged via Object.assign or deep merge
+ *     in downstream consumer code.
+ *  2. Redis data could be tampered with outside the application's control.
+ *
+ * Only strips the three prototype-chain keys — all other user data is preserved.
+ * Apply to internal system metadata (scheduler configs, worker opts, etc.).
+ * Do NOT apply to user-facing fields (e.g., job.progress) where arbitrary keys
+ * are legitimate and silent dropping causes data loss.
+ */
+export function jsonReviver(key: string, value: unknown): unknown {
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    return undefined;
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Defense-in-depth fix for prototype pollution via a centralized `jsonReviver` function applied to `JSON.parse` calls throughout the library.

### What changed
- Added `jsonReviver()` to `src/utils.ts` — strips `__proto__`, `constructor`, `prototype` keys during deserialization
- Fixed `JSON_SERIALIZER.deserialize` — the default serializer now uses the reviver, protecting the **user data** path
- Fixed internal `JSON.parse` calls on system metadata (scheduler configs, worker opts, parentIds, parentQueues, protocol responses)

### Why this is different from automated Sentinel PRs (#143, #145, #141, #157, #162, #164)
| Aspect | Sentinel PRs | This PR |
|--------|-------------|---------|
| `JSON_SERIALIZER.deserialize` | ❌ Not touched | ✅ Fixed — primary user data path |
| `job.progress` | ❌ Silently strips user keys | ✅ Intentionally skipped — user-controlled data |
| `testing.ts` roundtrips | ❌ Modified unnecessarily | ✅ Not touched — no real attack surface |
| Documentation | ❌ Generic | ✅ Explains when to use / not use reviver |

### What this does NOT fix
- Users who provide their own `Serializer` implementation are responsible for their own deserialization safety
- `job.progress` field is intentionally unprotected — users may store objects with any key shape, and silently dropping keys causes data loss

## Test plan
- [ ] `vitest run` passes (existing tests cover deserialization paths)
- [ ] Manual: verify `job.updateProgress({constructor: "test"})` preserves the key
- [ ] Manual: verify scheduler config with `__proto__` key is sanitized