### PR TITLE
feat: per-job streaming channel (job.stream / queue.readStream)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ Run `npm run bench` locally or `npx tsx benchmarks/elasticache-head-to-head.ts` 
 - **BroadcastWorker** -- independent consumer groups with own retries, concurrency, and backpressure ([Usage](docs/USAGE.md#broadcast--broadcastworker))
 - **Subject filtering** -- NATS-style patterns (`*` one segment, `>` trailing wildcard) for topic-based routing ([Usage](docs/USAGE.md#broadcast--broadcastworker))
 
+### AI-native
+
+- **Job metadata** -- `job.reportUsage()` persists model, provider, tokens, cost, and latency; `queue.getFlowUsage()` aggregates across parent and child jobs ([Usage](docs/USAGE.md#ai-native-primitives))
+- **Job streaming channel** -- `job.stream(chunk)` appends output chunks during processing; `queue.readStream(jobId)` reads them back; SSE endpoint `GET /queues/:name/jobs/:id/stream` for real-time consumers ([Usage](docs/USAGE.md#ai-native-primitives))
+
 ### Serverless
 
 - **Producer** -- enqueue without EventEmitter overhead, returns plain string IDs ([Usage](docs/USAGE.md))
@@ -193,7 +198,7 @@ curl -X POST http://localhost:3000/queues/emails/jobs \
   -d '{"name": "send-email", "data": {"to": "user@example.com"}}'
 ```
 
-Endpoints: `POST /queues/:name/jobs`, `POST /queues/:name/jobs/bulk`, `GET /queues/:name/jobs/:id`, `POST /queues/:name/pause`, `POST /queues/:name/resume`, `GET /queues/:name/counts`, `GET /health`.
+Endpoints: `POST /queues/:name/jobs`, `POST /queues/:name/jobs/bulk`, `GET /queues/:name/jobs/:id`, `GET /queues/:name/jobs/:id/stream` (SSE), `POST /queues/:name/pause`, `POST /queues/:name/resume`, `GET /queues/:name/counts`, `GET /health`.
 
 For zero-overhead integration, call Valkey Server Functions directly from any language with a Valkey client. See [Wire Protocol](docs/WIRE_PROTOCOL.md) for FCALL signatures, key layout, and examples in Python and Go.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -606,3 +606,63 @@ const worker = new Worker(
 ```
 
 The job is marked as permanently failed regardless of the `attempts` configuration. This is equivalent to calling `job.discard()` and then throwing, but more explicit.
+
+## AI-native Primitives
+
+### Job Metadata (reportUsage / getFlowUsage)
+
+Track token usage, cost, and latency per job for cost attribution and observability.
+
+```typescript
+import { Worker, Queue } from 'glide-mq';
+
+const worker = new Worker('llm-tasks', async (job) => {
+  const result = await callLLM(job.data.prompt);
+
+  await job.reportUsage({
+    model: 'gpt-4o',
+    provider: 'openai',
+    inputTokens: result.usage.prompt_tokens,
+    outputTokens: result.usage.completion_tokens,
+    costUsd: result.usage.total_cost,
+    latencyMs: result.latencyMs,
+  });
+
+  return result.text;
+}, { connection });
+
+// Aggregate usage for a job flow (parent + all children)
+const usage = await queue.getFlowUsage(parentJobId);
+console.log(usage.totalTokens, usage.costUsd);
+```
+
+`reportUsage()` persists usage to the job hash in Valkey. `job.usage` is populated when the job is fetched via `getJob()`. `getFlowUsage()` walks the DAG upward and sums all fields.
+
+### Job Streaming Channel (stream / readStream)
+
+Stream incremental output from a processor - useful for LLM token-by-token output or progress chunks.
+
+```typescript
+import { Worker, Queue } from 'glide-mq';
+
+// Producer side: emit chunks from inside the processor
+const worker = new Worker('llm-stream', async (job) => {
+  for await (const chunk of callLLMStreaming(job.data.prompt)) {
+    await job.stream({ token: chunk.text });
+  }
+  return 'done';
+}, { connection });
+
+// Consumer side: read back all chunks after completion
+const entries = await queue.readStream(jobId);
+// entries: [{ id: '1-0', fields: { token: 'Hello' } }, ...]
+
+// Resume from a known position
+const more = await queue.readStream(jobId, { lastId: entries[entries.length - 1].id });
+```
+
+**SSE endpoint** (proxy): `GET /queues/:name/jobs/:id/stream` streams chunks as Server-Sent Events while the job is active, then drains remaining chunks and closes. Supports the `Last-Event-ID` header and `?lastId` query param for resume.
+
+Stream keys are automatically cleaned up when a job is removed via `job.remove()`, `queue.clean()`, or `queue.drain()`.
+
+**Testing mode**: `TestJob.stream()` and `TestQueue.readStream()` provide full parity with no Valkey dependency.

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -33,7 +33,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 71: Step-job slot retention, returning step-job bypass, GROUP_ORDERED sentinel.
 // Version 72: Runtime per-group rate limiting: glidemq_rateLimitGroup + glidemq_rateLimitGroupExternal.
 // Version 73: Fix review findings: groupqScore string ID fallback, promoteRateLimited loop, step-job gates in Phase 1/3, retry slot retention, addFlow routing.
-export const LIBRARY_VERSION = '73';
+// Version 74: glidemq_removeJob/clean/drain delete per-job streaming channel keys (jstream:).
+export const LIBRARY_VERSION = '74';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -2526,10 +2527,12 @@ redis.register_function('glidemq_removeJob', function(keys, args)
   redis.call('ZREM', completedKey, jobId)
   redis.call('ZREM', failedKey, jobId)
   markOrderingDone(jobKey, jobId)
-  -- Clean up DAG parents SET
+  -- Clean up DAG parents SET and per-job streaming channel
   local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
   local parentsKey = prefix .. 'parents:' .. jobId
+  local jstreamKey = prefix .. 'jstream:' .. jobId
   redis.call('DEL', parentsKey)
+  redis.call('DEL', jstreamKey)
   redis.call('DEL', jobKey)
   redis.call('DEL', logKey)
   emitEvent(eventsKey, 'removed', jobId, nil)
@@ -2549,7 +2552,7 @@ redis.register_function('glidemq_clean', function(keys, args)
     return {}
   end
   for i = 1, #ids do
-    redis.call('DEL', prefix .. 'job:' .. ids[i], prefix .. 'log:' .. ids[i], prefix .. 'deps:' .. ids[i], prefix .. 'parents:' .. ids[i])
+    redis.call('DEL', prefix .. 'job:' .. ids[i], prefix .. 'log:' .. ids[i], prefix .. 'deps:' .. ids[i], prefix .. 'parents:' .. ids[i], prefix .. 'jstream:' .. ids[i])
   end
   for i = 1, #ids, 1000 do
     redis.call('ZREM', setKey, unpack(ids, i, math.min(i + 999, #ids)))
@@ -3126,7 +3129,7 @@ redis.register_function('glidemq_drain', function(keys, args)
         for j = 1, #fields, 2 do
           if fields[j] == 'jobId' and fields[j + 1] ~= '' then
             local jobId = fields[j + 1]
-            redis.call('DEL', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId)
+            redis.call('DEL', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId, prefix .. 'jstream:' .. jobId)
             removed = removed + 1
             break
           end
@@ -3158,6 +3161,7 @@ redis.register_function('glidemq_drain', function(keys, args)
         batch[#batch + 1] = prefix .. 'job:' .. jobId
         batch[#batch + 1] = prefix .. 'log:' .. jobId
         batch[#batch + 1] = prefix .. 'deps:' .. jobId
+        batch[#batch + 1] = prefix .. 'jstream:' .. jobId
       end
       redis.call('DEL', unpack(batch))
       removed = removed + #scheduled
@@ -3171,7 +3175,7 @@ redis.register_function('glidemq_drain', function(keys, args)
     local lifoIds = redis.call('LRANGE', lifoKey, 0, -1)
     for i = 1, #lifoIds do
       local jobId = lifoIds[i]
-      redis.call('DEL', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId)
+      redis.call('DEL', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId, prefix .. 'jstream:' .. jobId)
       removed = removed + 1
     end
     redis.call('DEL', lifoKey)
@@ -3182,7 +3186,7 @@ redis.register_function('glidemq_drain', function(keys, args)
     local priorityIds = redis.call('LRANGE', priorityKey, 0, -1)
     for i = 1, #priorityIds do
       local jobId = priorityIds[i]
-      redis.call('DEL', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId)
+      redis.call('DEL', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId, prefix .. 'jstream:' .. jobId)
       removed = removed + 1
     end
     redis.call('DEL', priorityKey)

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ export type {
   DAGNode,
   DAGFlow,
   JobUsage,
+  ReadStreamOptions,
 } from './types';
 
 export { JSON_SERIALIZER } from './types';

--- a/src/job.ts
+++ b/src/job.ts
@@ -203,6 +203,30 @@ export class Job<D = any, R = any> {
   }
 
   /**
+   * Append a chunk to this job's streaming channel.
+   * Each chunk is a flat string-keyed object appended via XADD to a per-job stream.
+   * Returns the Valkey stream entry ID.
+   */
+  async stream(chunk: Record<string, string>): Promise<string> {
+    const fieldNames = Object.keys(chunk);
+    if (fieldNames.length === 0) {
+      throw new Error('Stream chunk must not be empty');
+    }
+    const entries: [string, string][] = [];
+    let totalBytes = 0;
+    for (const key of fieldNames) {
+      const val = chunk[key];
+      totalBytes += Buffer.byteLength(key, 'utf8') + Buffer.byteLength(val, 'utf8');
+      entries.push([key, val]);
+    }
+    if (totalBytes > MAX_JOB_DATA_SIZE) {
+      throw new Error(`Stream chunk exceeds maximum size (${totalBytes} bytes > ${MAX_JOB_DATA_SIZE})`);
+    }
+    const entryId = await this.client.xadd(this.queueKeys.jstream(this.id), entries);
+    return String(entryId);
+  }
+
+  /**
    * Mark this job so it will not be retried on failure.
    * Call inside the processor before throwing to skip all remaining attempts.
    */

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -301,6 +301,58 @@ export function createRoutes(
     }
   });
 
+  router.get('/queues/:name/jobs/:id/stream', async (req: Request, res: Response) => {
+    try {
+      if (!checkAllowlist(req, res)) return;
+
+      const queue = await getQueue(param(req, 'name'));
+      const jobId = param(req, 'id');
+
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      });
+
+      let lastId = (req.headers['last-event-id'] as string) || (req.query.lastId as string) || undefined;
+      let closed = false;
+
+      req.on('close', () => {
+        closed = true;
+      });
+
+      while (!closed) {
+        const entries = await queue.readStream(jobId, { lastId, count: 100 });
+        for (const entry of entries) {
+          res.write(`id: ${entry.id}\ndata: ${JSON.stringify(entry.fields)}\n\n`);
+          lastId = entry.id;
+        }
+
+        const job = await queue.getJob(jobId);
+        if (!job) break;
+        const state = await job.getState();
+        if (state === 'completed' || state === 'failed') {
+          const trailing = await queue.readStream(jobId, { lastId, count: 100 });
+          for (const entry of trailing) {
+            res.write(`id: ${entry.id}\ndata: ${JSON.stringify(entry.fields)}\n\n`);
+          }
+          break;
+        }
+
+        await new Promise<void>((r) => setTimeout(r, 500));
+      }
+
+      res.end();
+    } catch (err) {
+      if (!res.headersSent) {
+        const { status, message } = errorResponse(err);
+        res.status(status).json({ error: message });
+      } else {
+        res.end();
+      }
+    }
+  });
+
   router.post('/queues/:name/pause', async (req: Request, res: Response) => {
     try {
       if (!checkAllowlist(req, res)) return;

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -16,6 +16,7 @@ import type {
   JobCounts,
   SearchJobsOptions,
   GetJobsOptions,
+  ReadStreamOptions,
   RateLimitConfig,
   WorkerInfo,
   Serializer,
@@ -1757,6 +1758,39 @@ export class Queue<D = any, R = any> extends EventEmitter {
     }
 
     return agg;
+  }
+
+  /**
+   * Read entries from a job's streaming channel.
+   * Uses XRANGE for non-blocking reads. Pass lastId to resume from a known position.
+   */
+  async readStream(
+    jobId: string,
+    opts?: ReadStreamOptions,
+  ): Promise<{ id: string; fields: Record<string, string> }[]> {
+    const client = await this.getClient();
+    const lastId = opts?.lastId;
+    const count = opts?.count ?? 100;
+    const start = lastId
+      ? ({ value: lastId, isInclusive: false } as const)
+      : InfBoundary.NegativeInfinity;
+    const entries = await client.xrange(
+      this.keys.jstream(jobId),
+      start,
+      InfBoundary.PositiveInfinity,
+      { count },
+    );
+    if (!entries) return [];
+    const result: { id: string; fields: Record<string, string> }[] = [];
+    for (const entryId of Object.keys(entries)) {
+      const pairs = entries[entryId];
+      const fields: Record<string, string> = Object.create(null);
+      for (const [k, v] of pairs) {
+        fields[String(k)] = String(v);
+      }
+      result.push({ id: entryId, fields });
+    }
+    return result;
   }
 
   /**

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -59,6 +59,10 @@ export interface TestJobRecord<D = any, R = any> {
   finishedOn: number | undefined;
   processedOn: number | undefined;
   expireAt?: number;
+  /** @internal Per-job streaming channel chunks. */
+  streamChunks?: { id: string; fields: Record<string, string> }[];
+  /** @internal Counter for synthetic stream entry IDs. */
+  streamCounter?: number;
 }
 
 /**
@@ -79,8 +83,10 @@ export class TestJob<D = any, R = any> {
   processedOn: number | undefined;
   expireAt?: number;
   usage?: JobUsage;
+  /** @internal */ private _record: TestJobRecord<D, R>;
 
   constructor(record: TestJobRecord<D, R>) {
+    this._record = record;
     this.id = record.id;
     this.name = record.name;
     this.data = record.data;
@@ -144,6 +150,24 @@ export class TestJob<D = any, R = any> {
       resolved.totalTokens = (resolved.inputTokens ?? 0) + (resolved.outputTokens ?? 0);
     }
     this.usage = resolved;
+  }
+
+  async stream(chunk: Record<string, string>): Promise<string> {
+    if (Object.keys(chunk).length === 0) {
+      throw new Error('Stream chunk must not be empty');
+    }
+    let totalBytes = 0;
+    for (const key of Object.keys(chunk)) {
+      totalBytes += Buffer.byteLength(key, 'utf8') + Buffer.byteLength(chunk[key], 'utf8');
+    }
+    if (totalBytes > MAX_JOB_DATA_SIZE) {
+      throw new Error(`Stream chunk exceeds maximum size (${totalBytes} bytes > ${MAX_JOB_DATA_SIZE})`);
+    }
+    if (!this._record.streamChunks) this._record.streamChunks = [];
+    if (this._record.streamCounter === undefined) this._record.streamCounter = 0;
+    const id = `test-${++this._record.streamCounter}`;
+    this._record.streamChunks.push({ id, fields: { ...chunk } });
+    return id;
   }
 }
 
@@ -632,6 +656,23 @@ export class TestQueue<D = any, R = any> extends EventEmitter {
     }
 
     return agg;
+  }
+
+  async readStream(
+    jobId: string,
+    opts?: { lastId?: string; count?: number },
+  ): Promise<{ id: string; fields: Record<string, string> }[]> {
+    const record = this.jobs.get(jobId);
+    if (!record) return [];
+    const chunks = record.streamChunks ?? [];
+    const lastId = opts?.lastId;
+    const count = opts?.count ?? 100;
+    let filtered = chunks;
+    if (lastId) {
+      const idx = chunks.findIndex((c) => c.id === lastId);
+      filtered = idx >= 0 ? chunks.slice(idx + 1) : chunks;
+    }
+    return filtered.slice(0, count);
   }
 
   async close(): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -426,6 +426,11 @@ export interface DAGFlow {
   nodes: DAGNode[];
 }
 
+export interface ReadStreamOptions {
+  lastId?: string;
+  count?: number;
+}
+
 /** AI-specific usage metadata reported by a job processor. */
 export interface JobUsage {
   /** Model identifier (e.g. 'gpt-4o', 'claude-sonnet-4-20250514'). */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,6 +116,7 @@ export function buildKeys(queueName: string, prefix = DEFAULT_PREFIX) {
     group: (key: string) => `${p}:group:${key}`,
     groupq: (key: string) => `${p}:groupq:${key}`,
     parents: (id: string) => `${p}:parents:${id}`,
+    jstream: (id: string) => `${p}:jstream:${id}`,
     worker: (id: string) => `${p}:w:${id}`,
   };
 }

--- a/tests/job-stream.test.ts
+++ b/tests/job-stream.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Tests for per-job streaming channel (Job.stream / Queue.readStream).
+ *
+ * Run: npx vitest run tests/job-stream.test.ts
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { Batch, ClusterBatch } from '@glidemq/speedkey';
+import { Job } from '../src/job';
+import { buildKeys, MAX_JOB_DATA_SIZE } from '../src/utils';
+import { TestQueue, TestWorker } from '../src/testing';
+
+vi.mock('@glidemq/speedkey');
+
+// ---- Unit tests (mocked client) ----
+
+function makeMockClient(overrides: Record<string, unknown> = {}) {
+  return {
+    fcall: vi.fn(),
+    hset: vi.fn().mockResolvedValue(1),
+    hget: vi.fn().mockResolvedValue(null),
+    hgetall: vi.fn().mockResolvedValue([]),
+    hmget: vi.fn().mockResolvedValue([]),
+    xadd: vi.fn().mockResolvedValue('1-0'),
+    xrange: vi.fn().mockResolvedValue(null),
+    smembers: vi.fn().mockResolvedValue(new Set()),
+    rpush: vi.fn().mockResolvedValue(1),
+    close: vi.fn(),
+    exec: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+const keys = buildKeys('test-queue');
+
+describe('Job.stream (unit)', () => {
+  let mockClient: ReturnType<typeof makeMockClient>;
+  let callCount: number;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    callCount = 0;
+    mockClient = makeMockClient({
+      xadd: vi.fn().mockImplementation(() => {
+        callCount++;
+        return Promise.resolve(`${callCount}-0`);
+      }),
+    });
+  });
+
+  it('calls XADD on jstream key', async () => {
+    const job = new Job(mockClient as any, keys, '42', 'llm-stream', {}, {});
+    const entryId = await job.stream({ token: 'Hello' });
+
+    expect(mockClient.xadd).toHaveBeenCalledWith(
+      keys.jstream('42'),
+      [['token', 'Hello']],
+    );
+    expect(entryId).toBe('1-0');
+  });
+
+  it('multiple chunks get different entry IDs', async () => {
+    const job = new Job(mockClient as any, keys, '42', 'llm-stream', {}, {});
+    const id1 = await job.stream({ token: 'Hello' });
+    const id2 = await job.stream({ token: ' world' });
+
+    expect(id1).toBe('1-0');
+    expect(id2).toBe('2-0');
+    expect(mockClient.xadd).toHaveBeenCalledTimes(2);
+  });
+
+  it('empty chunk object throws', async () => {
+    const job = new Job(mockClient as any, keys, '42', 'llm-stream', {}, {});
+    await expect(job.stream({})).rejects.toThrow('Stream chunk must not be empty');
+  });
+
+  it('large chunk near MAX_JOB_DATA_SIZE accepted', async () => {
+    const job = new Job(mockClient as any, keys, '42', 'llm-stream', {}, {});
+    const largeValue = 'x'.repeat(MAX_JOB_DATA_SIZE - 10);
+    const entryId = await job.stream({ data: largeValue });
+    expect(entryId).toBe('1-0');
+  });
+
+  it('chunk exceeding MAX_JOB_DATA_SIZE rejected', async () => {
+    const job = new Job(mockClient as any, keys, '42', 'llm-stream', {}, {});
+    const hugeValue = 'x'.repeat(MAX_JOB_DATA_SIZE + 1);
+    await expect(job.stream({ data: hugeValue })).rejects.toThrow('exceeds maximum size');
+  });
+
+  it('works without entryId (external context)', async () => {
+    const job = new Job(mockClient as any, keys, '42', 'llm-stream', {}, {});
+    // entryId is undefined (not set by a Worker) - stream() should still work
+    expect(job.entryId).toBeUndefined();
+    const id = await job.stream({ token: 'test' });
+    expect(id).toBe('1-0');
+  });
+});
+
+// ---- Testing mode tests ----
+
+describe('TestJob.stream + TestQueue.readStream', () => {
+  let queue: InstanceType<typeof TestQueue>;
+
+  afterAll(async () => {
+    if (queue) await queue.close();
+  });
+
+  it('round-trip: stream chunks read back via readStream', async () => {
+    queue = new TestQueue('test-stream-rt');
+    const job = await queue.add('llm-call', { prompt: 'hello' });
+    expect(job).not.toBeNull();
+
+    await job!.stream({ token: 'Hello' });
+    await job!.stream({ token: ' world' });
+
+    const entries = await queue.readStream(job!.id);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].fields.token).toBe('Hello');
+    expect(entries[1].fields.token).toBe(' world');
+    expect(entries[0].id).toBe('test-1');
+    expect(entries[1].id).toBe('test-2');
+  });
+
+  it('readStream with lastId filters correctly', async () => {
+    queue = new TestQueue('test-stream-lastid');
+    const job = await queue.add('llm-call', {});
+    expect(job).not.toBeNull();
+
+    const id1 = await job!.stream({ token: 'a' });
+    await job!.stream({ token: 'b' });
+    await job!.stream({ token: 'c' });
+
+    const entries = await queue.readStream(job!.id, { lastId: id1 });
+    expect(entries).toHaveLength(2);
+    expect(entries[0].fields.token).toBe('b');
+    expect(entries[1].fields.token).toBe('c');
+  });
+
+  it('readStream with count limits results', async () => {
+    queue = new TestQueue('test-stream-count');
+    const job = await queue.add('llm-call', {});
+    expect(job).not.toBeNull();
+
+    await job!.stream({ token: 'a' });
+    await job!.stream({ token: 'b' });
+    await job!.stream({ token: 'c' });
+
+    const entries = await queue.readStream(job!.id, { count: 2 });
+    expect(entries).toHaveLength(2);
+    expect(entries[0].fields.token).toBe('a');
+    expect(entries[1].fields.token).toBe('b');
+  });
+
+  it('readStream returns empty for nonexistent job', async () => {
+    queue = new TestQueue('test-stream-none');
+    const entries = await queue.readStream('nonexistent');
+    expect(entries).toEqual([]);
+  });
+
+  it('empty chunk throws', async () => {
+    queue = new TestQueue('test-stream-empty');
+    const job = await queue.add('llm-call', {});
+    await expect(job!.stream({})).rejects.toThrow('Stream chunk must not be empty');
+  });
+
+  it('oversized chunk throws', async () => {
+    queue = new TestQueue('test-stream-oversize');
+    const job = await queue.add('llm-call', {});
+    const huge = 'x'.repeat(MAX_JOB_DATA_SIZE + 1);
+    await expect(job!.stream({ data: huge })).rejects.toThrow('exceeds maximum size');
+  });
+});
+
+// ---- Integration tests (require Valkey) ----
+
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
+
+const QueueImpl = require('../dist/queue').Queue;
+const WorkerImpl = require('../dist/worker').Worker;
+
+import type { Server } from 'http';
+import { STANDALONE } from './helpers/fixture';
+
+const createProxyServer = require('../dist/proxy/index').createProxyServer;
+
+describe('SSE proxy endpoint', () => {
+  let server: Server;
+  let baseUrl: string;
+  let proxyClose: () => Promise<void>;
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(STANDALONE);
+    const proxy = createProxyServer({ connection: STANDALONE });
+    proxyClose = proxy.close;
+    await new Promise<void>((resolve) => {
+      server = proxy.app.listen(0, () => {
+        const addr = server.address();
+        if (typeof addr === 'object' && addr) {
+          baseUrl = `http://127.0.0.1:${addr.port}`;
+        }
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await proxyClose();
+    await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    await cleanupClient.close();
+  });
+
+  it('SSE proxy returns stream chunks for a job', async () => {
+    const Q = 'test-jstream-sse-' + Date.now();
+    const queue = new QueueImpl(Q, { connection: STANDALONE });
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.stream({ token: 'Hello' });
+      await job.stream({ token: ' world' });
+      return 'done';
+    }, { connection: STANDALONE });
+
+    try {
+      const job = await queue.add('sse-test', {});
+      await waitFor(async () => {
+        const fetched = await queue.getJob(job.id);
+        return fetched?.finishedOn !== undefined;
+      });
+
+      const res = await fetch(`${baseUrl}/queues/${Q}/jobs/${job.id}/stream`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toBe('text/event-stream');
+
+      const text = await res.text();
+      expect(text).toContain('data:');
+      expect(text).toContain('Hello');
+      expect(text).toContain(' world');
+    } finally {
+      await worker.close();
+      await queue.close();
+      await flushQueue(cleanupClient, Q);
+    }
+  });
+});
+
+describeEachMode('Job streaming integration', (CONNECTION) => {
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    cleanupClient.close();
+  });
+
+  it('stream() + readStream() round-trip on real Valkey', async () => {
+    const Q = 'test-jstream-rt-' + Date.now();
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.stream({ token: 'Hello' });
+      await job.stream({ token: ' world' });
+      return 'done';
+    }, { connection: CONNECTION });
+
+    try {
+      const job = await queue.add('stream-test', { prompt: 'hi' });
+      await waitFor(async () => {
+        const fetched = await queue.getJob(job.id);
+        return fetched?.finishedOn !== undefined;
+      });
+
+      const entries = await queue.readStream(job.id);
+      expect(entries.length).toBe(2);
+      expect(entries[0].fields.token).toBe('Hello');
+      expect(entries[1].fields.token).toBe(' world');
+    } finally {
+      await worker.close();
+      await queue.close();
+      await flushQueue(cleanupClient, Q);
+    }
+  });
+
+  it('readStream with lastId resume', async () => {
+    const Q = 'test-jstream-lid-' + Date.now();
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.stream({ token: 'a' });
+      await job.stream({ token: 'b' });
+      await job.stream({ token: 'c' });
+      return 'done';
+    }, { connection: CONNECTION });
+
+    try {
+      const job = await queue.add('stream-resume', {});
+      await waitFor(async () => {
+        const fetched = await queue.getJob(job.id);
+        return fetched?.finishedOn !== undefined;
+      });
+
+      const all = await queue.readStream(job.id);
+      expect(all.length).toBe(3);
+
+      const rest = await queue.readStream(job.id, { lastId: all[0].id });
+      expect(rest.length).toBe(2);
+      expect(rest[0].fields.token).toBe('b');
+      expect(rest[1].fields.token).toBe('c');
+    } finally {
+      await worker.close();
+      await queue.close();
+      await flushQueue(cleanupClient, Q);
+    }
+  });
+
+  it('multiple chunks arrive in order', async () => {
+    const Q = 'test-jstream-ord-' + Date.now();
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const CHUNK_COUNT = 10;
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      for (let i = 0; i < CHUNK_COUNT; i++) {
+        await job.stream({ index: String(i) });
+      }
+      return 'done';
+    }, { connection: CONNECTION });
+
+    try {
+      const job = await queue.add('stream-order', {});
+      await waitFor(async () => {
+        const fetched = await queue.getJob(job.id);
+        return fetched?.finishedOn !== undefined;
+      });
+
+      const entries = await queue.readStream(job.id, { count: 100 });
+      expect(entries.length).toBe(CHUNK_COUNT);
+      for (let i = 0; i < CHUNK_COUNT; i++) {
+        expect(entries[i].fields.index).toBe(String(i));
+      }
+    } finally {
+      await worker.close();
+      await queue.close();
+      await flushQueue(cleanupClient, Q);
+    }
+  });
+
+  it('stream survives job completion', async () => {
+    const Q = 'test-jstream-sv-' + Date.now();
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.stream({ token: 'persisted' });
+      return 'done';
+    }, { connection: CONNECTION });
+
+    try {
+      const job = await queue.add('stream-survive', {});
+      await waitFor(async () => {
+        const fetched = await queue.getJob(job.id);
+        return fetched?.finishedOn !== undefined;
+      });
+
+      const entries = await queue.readStream(job.id);
+      expect(entries.length).toBe(1);
+      expect(entries[0].fields.token).toBe('persisted');
+    } finally {
+      await worker.close();
+      await queue.close();
+      await flushQueue(cleanupClient, Q);
+    }
+  });
+
+  it('stream cleaned up on job.remove()', async () => {
+    const Q = 'test-jstream-rm-' + Date.now();
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.stream({ token: 'to-be-removed' });
+      return 'done';
+    }, { connection: CONNECTION });
+
+    try {
+      const job = await queue.add('stream-cleanup', {});
+      await waitFor(async () => {
+        const fetched = await queue.getJob(job.id);
+        return fetched?.finishedOn !== undefined;
+      });
+
+      const before = await queue.readStream(job.id);
+      expect(before.length).toBe(1);
+
+      const fetched = await queue.getJob(job.id);
+      await fetched.remove();
+
+      const after = await queue.readStream(job.id);
+      expect(after).toEqual([]);
+    } finally {
+      await worker.close();
+      await queue.close();
+      await flushQueue(cleanupClient, Q);
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary

- Per-job Valkey Stream for token-by-token LLM output delivery
- `Job.stream(chunk)` appends to `{queueName}:jstream:{jobId}` via XADD
- `Queue.readStream(jobId, opts)` reads with lastId resume semantics
- SSE proxy endpoint: `GET /queues/:name/jobs/:id/stream` with `Last-Event-ID`
- Stream keys auto-cleaned on job remove, drain, and age-based clean
- TestJob/TestQueue parity for in-memory testing mode
- Docs updated: README.md AI-native section, docs/USAGE.md streaming examples

## API

```ts
// Inside processor - stream tokens as they arrive
for await (const token of llm.stream(prompt)) {
  await job.stream({ type: 'token', content: token });
}

// Consumer - read with resume
const chunks = await queue.readStream(jobId, { lastId, count: 50 });

// SSE endpoint
// GET /queues/my-queue/jobs/123/stream
// Last-Event-ID: 1234567890-0
```

## Test plan

- [x] 23 tests passing (unit + testing-mode + standalone + cluster)
- [x] Full suite: 2120/2120 tests pass, zero regressions
- [x] `npm run build` clean
- [x] Prepare-delivery: all gates passed (deslop, review, validation, docs sync)