### PR TITLE
feat: per-job lockDuration override for heartbeat and stall detection

### DIFF
--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -527,7 +527,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         continue;
       }
 
-      this.startHeartbeat(entry.jobId);
+      this.startHeartbeat(entry.jobId, job.opts.lockDuration);
       batch.push({ jobId: entry.jobId, entryId: entry.entryId, job });
     }
 
@@ -837,7 +837,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     const ac = new AbortController();
     this.activeAbortControllers.set(jobId, ac);
     job.abortSignal = ac.signal;
-    this.startHeartbeat(jobId);
+    this.startHeartbeat(jobId, job.opts.lockDuration);
 
     let result: R | undefined;
     let error: Error | undefined;
@@ -1171,7 +1171,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       if (hasContinuation) {
         const onResume = this.suspendContinuations.get(currentJobId)!;
         this.suspendContinuations.delete(currentJobId);
-        this.startHeartbeat(currentJobId);
+        this.startHeartbeat(currentJobId, job.opts.lockDuration);
         try {
           processResult = await onResume(job.signals);
           processError = undefined;
@@ -1399,14 +1399,16 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     return false;
   }
 
-  protected startHeartbeat(jobId: string): void {
+  protected startHeartbeat(jobId: string, jobLockDuration?: number): void {
     if (!this.commandClient) return;
+    // Use per-job lockDuration when specified, otherwise fall back to worker-level.
+    const effectiveLock = jobLockDuration ?? this.lockDuration;
     // Only start periodic heartbeat for long lockDurations where stall detection matters.
     // moveToActive already writes the initial lastActive - protects against immediate stall reclaim.
     // For the default 30s lockDuration with 30s stalledInterval, the heartbeat fires at 15s.
     // Skip entirely if lockDuration >= stalledInterval (initial write is sufficient for one cycle).
-    if (this.lockDuration >= this.stalledInterval) return;
-    const interval = this.lockDuration / 2;
+    if (effectiveLock >= this.stalledInterval) return;
+    const interval = effectiveLock / 2;
     const client = this.commandClient;
     const jobKey = this.queueKeys.job(jobId);
     const timer = setInterval(() => {

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -36,7 +36,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 74: glidemq_removeJob/clean/drain delete per-job streaming channel keys (jstream:).
 // Version 75: Suspend/resume with signals: glidemq_suspend, glidemq_signal, glidemq_sweepSuspended.
 // Version 76: glidemq_clean and glidemq_drain delete signals: keys to prevent key leaks.
-export const LIBRARY_VERSION = '76';
+// Version 77: Per-job lockDuration: reclaimStalled/reclaimStalledListJobs read lockDuration from job opts for per-job stall threshold.
+export const LIBRARY_VERSION = '77';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -438,6 +439,13 @@ local function extractTtlFromOpts(optsJson)
   local ok, decoded = pcall(cjson.decode, optsJson)
   if not ok or type(decoded) ~= 'table' then return 0 end
   return tonumber(decoded['ttl']) or 0
+end
+
+local function extractLockDurationFromOpts(optsJson)
+  if not optsJson or optsJson == '' then return 0 end
+  local ok, decoded = pcall(cjson.decode, optsJson)
+  if not ok or type(decoded) ~= 'table' then return 0 end
+  return tonumber(decoded['lockDuration']) or 0
 end
 
 -- Apply stall logic to a job: increment stalledCount, fail if over max, else emit stalled event.
@@ -1442,8 +1450,11 @@ redis.register_function('glidemq_reclaimStalled', function(keys, args)
         if entryId ~= '' and broadcastMode ~= '1' then redis.call('XDEL', streamKey, entryId) end
         count = count + 1
       else
-      local lastActive = tonumber(redis.call('HGET', jobKey, 'lastActive'))
-      if lastActive and (timestamp - lastActive) < minIdleMs then
+      local vals = redis.call('HMGET', jobKey, 'lastActive', 'opts')
+      local lastActive = tonumber(vals[1])
+      local jobLockDuration = extractLockDurationFromOpts(vals[2])
+      local effectiveIdle = (jobLockDuration > 0) and jobLockDuration or minIdleMs
+      if lastActive and (timestamp - lastActive) < effectiveIdle then
         count = count + 1
       else
       local failed = applyStalledLogic(jobKey, jobId, prefix, eventsKey, failedKey, maxStalledCount, timestamp)
@@ -1491,10 +1502,12 @@ redis.register_function('glidemq_reclaimStalledListJobs', function(keys, args)
       local jk = scannedKeys[i]
       local state = redis.call('HGET', jk, 'state')
       if state == 'active' then
-        local vals = redis.call('HMGET', jk, 'lastActive', 'lifo', 'priority')
+        local vals = redis.call('HMGET', jk, 'lastActive', 'lifo', 'priority', 'opts')
         local lastActive = tonumber(vals[1])
         local isListSourced = vals[2] == '1' or (tonumber(vals[3]) or 0) > 0
-        if isListSourced and lastActive and (timestamp - lastActive) >= minIdleMs then
+        local jobLockDuration = extractLockDurationFromOpts(vals[4])
+        local effectiveIdle = (jobLockDuration > 0) and jobLockDuration or minIdleMs
+        if isListSourced and lastActive and (timestamp - lastActive) >= effectiveIdle then
           local jobId = string.sub(jk, #prefix + 5)
           local shouldDecr = false
           if checkExpired(jk, jobId, prefix, timestamp) then

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,6 +196,9 @@ export interface JobOptions {
   attempts?: number;
   backoff?: { type: 'fixed' | 'exponential' | string; delay: number; jitter?: number };
   timeout?: number;
+  /** Override worker-level lockDuration for this specific job (ms).
+   *  Controls heartbeat frequency and stall detection threshold. */
+  lockDuration?: number;
   removeOnComplete?: boolean | number | { age: number; count: number };
   removeOnFail?: boolean | number | { age: number; count: number };
   deduplication?: { id: string; ttl?: number; mode?: 'simple' | 'throttle' | 'debounce' };

--- a/tests/per-job-lock.test.ts
+++ b/tests/per-job-lock.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Per-job lockDuration tests.
+ * Verifies that jobs can override the worker-level lockDuration for individual
+ * heartbeat frequency and stall detection thresholds.
+ *
+ * Requires: valkey-server running on localhost:6379 and cluster on :7000-7005
+ *
+ * Run: npx vitest run tests/per-job-lock.test.ts
+ */
+import { it, expect, beforeAll, afterAll } from 'vitest';
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
+
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+
+const TS = Date.now();
+
+describeEachMode('Per-job lockDuration', (CONNECTION) => {
+  const Q = `pjl-${TS}`;
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    await flushQueue(cleanupClient, Q);
+    cleanupClient.close();
+  });
+
+  it('job with lockDuration: 120000 is not reclaimed within stalledInterval', async () => {
+    const queue = new Queue(Q, { connection: CONNECTION });
+    let completedId: string | null = null;
+    const stalledEvents: string[] = [];
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+
+      const worker = new Worker(
+        Q,
+        async () => {
+          // Job runs for 4s - longer than stalledInterval of 2s
+          await new Promise((r) => setTimeout(r, 4000));
+          return 'long-lock-done';
+        },
+        {
+          connection: CONNECTION,
+          concurrency: 1,
+          blockTimeout: 500,
+          stalledInterval: 2000,
+          lockDuration: 1000, // worker default: heartbeat every 500ms
+          maxStalledCount: 1,
+          promotionInterval: 1000,
+        },
+      );
+
+      worker.on('completed', (job: any) => {
+        completedId = job.id;
+        clearTimeout(timeout);
+        worker.close(true).then(resolve);
+      });
+      worker.on('stalled', (jobId: string) => {
+        stalledEvents.push(jobId);
+      });
+      worker.on('error', () => {});
+    });
+
+    await new Promise((r) => setTimeout(r, 500));
+    // Per-job lockDuration of 120s - Lua will use this as threshold instead of stalledInterval
+    const job = await queue.add('long-lock', { v: 1 }, { lockDuration: 120000 });
+
+    await done;
+
+    // Job must complete normally - not be reclaimed as stalled
+    expect(completedId).toBe(job!.id);
+    expect(stalledEvents).not.toContain(job!.id);
+
+    await queue.close();
+  }, 25000);
+
+  it('job with lockDuration: 5000 is reclaimed after inactivity', async () => {
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const k = buildKeys(Q);
+
+    // Worker 1: picks up the job but we force-close it (simulates crash)
+    let w1Started = false;
+    const worker1 = new Worker(
+      Q,
+      async () => {
+        w1Started = true;
+        await new Promise((r) => setTimeout(r, 60000));
+        return 'never';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 500,
+        stalledInterval: 60000, // very long - would never reclaim without per-job override
+        lockDuration: 60000,
+        maxStalledCount: 1,
+      },
+    );
+    worker1.on('error', () => {});
+    await worker1.waitUntilReady();
+
+    // Add job with short per-job lockDuration
+    const job = await queue.add('short-lock', { v: 2 }, { lockDuration: 2000 });
+    while (!w1Started) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    // Force-close worker1 to simulate crash (no heartbeat)
+    await worker1.close(true);
+
+    // Worker 2: with short stalledInterval to run reclaim cycles
+    const stalledIds: string[] = [];
+    const worker2 = new Worker(Q, async () => 'recovered', {
+      connection: CONNECTION,
+      concurrency: 1,
+      blockTimeout: 500,
+      stalledInterval: 1000, // frequent reclaim checks
+      maxStalledCount: 1,
+    });
+    worker2.on('error', () => {});
+    worker2.on('stalled', (jobId: string) => stalledIds.push(jobId));
+    await worker2.waitUntilReady();
+
+    // Wait for stalled recovery to detect the job (per-job lockDuration: 2s)
+    await waitFor(async () => {
+      const state = await cleanupClient.hget(k.job(job!.id), 'state');
+      return String(state) === 'failed';
+    }, 8000);
+
+    await worker2.close(true);
+
+    // Job should be failed via stalled recovery
+    const state = String(await cleanupClient.hget(k.job(job!.id), 'state'));
+    expect(state).toBe('failed');
+    const failedReason = String(await cleanupClient.hget(k.job(job!.id), 'failedReason'));
+    expect(failedReason).toContain('stalled');
+
+    await queue.close();
+  }, 20000);
+
+  it('mixed lock durations in same worker work correctly', async () => {
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const completedIds: string[] = [];
+    const stalledEvents: string[] = [];
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+      let count = 0;
+
+      const worker = new Worker(
+        Q,
+        async (job: any) => {
+          // Both jobs run for 3s - longer than stalledInterval
+          await new Promise((r) => setTimeout(r, 3000));
+          return `done-${job.name}`;
+        },
+        {
+          connection: CONNECTION,
+          concurrency: 2,
+          blockTimeout: 500,
+          stalledInterval: 2000,
+          lockDuration: 1000, // worker default: heartbeat every 500ms
+          maxStalledCount: 1,
+          promotionInterval: 1000,
+        },
+      );
+
+      worker.on('completed', (job: any) => {
+        completedIds.push(job.id);
+        count++;
+        if (count >= 2) {
+          clearTimeout(timeout);
+          worker.close(true).then(resolve);
+        }
+      });
+      worker.on('stalled', (jobId: string) => stalledEvents.push(jobId));
+      worker.on('error', () => {});
+    });
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    // One job with long per-job lock (Lua threshold = 120s), one with default (worker lock = 1s, heartbeat 500ms)
+    const jobLong = await queue.add('long-lock', { v: 1 }, { lockDuration: 120000 });
+    const jobDefault = await queue.add('default-lock', { v: 2 });
+
+    await done;
+
+    // Both should complete without stalling
+    expect(completedIds).toContain(jobLong!.id);
+    expect(completedIds).toContain(jobDefault!.id);
+    expect(stalledEvents).toHaveLength(0);
+
+    await queue.close();
+  }, 25000);
+
+  it('default lock duration used when job does not specify (backward compat)', async () => {
+    const queue = new Queue(Q, { connection: CONNECTION });
+    let completedId: string | null = null;
+    const stalledEvents: string[] = [];
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 15000);
+
+      const worker = new Worker(
+        Q,
+        async () => {
+          // Runs for 3s - longer than stalledInterval but within heartbeat protection
+          await new Promise((r) => setTimeout(r, 3000));
+          return 'compat-done';
+        },
+        {
+          connection: CONNECTION,
+          concurrency: 1,
+          blockTimeout: 500,
+          stalledInterval: 2000,
+          lockDuration: 1000, // heartbeat every 500ms
+          maxStalledCount: 1,
+          promotionInterval: 1000,
+        },
+      );
+
+      worker.on('completed', (job: any) => {
+        completedId = job.id;
+        clearTimeout(timeout);
+        worker.close(true).then(resolve);
+      });
+      worker.on('stalled', (jobId: string) => stalledEvents.push(jobId));
+      worker.on('error', () => {});
+    });
+
+    await new Promise((r) => setTimeout(r, 500));
+    // No per-job lockDuration - uses worker default
+    const job = await queue.add('no-override', { v: 3 });
+
+    await done;
+
+    expect(completedId).toBe(job!.id);
+    expect(stalledEvents).toHaveLength(0);
+
+    await queue.close();
+  }, 18000);
+
+  it('per-job lock duration works with completeAndFetchNext chain', async () => {
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const completedIds: string[] = [];
+    const stalledEvents: string[] = [];
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+      let count = 0;
+
+      const worker = new Worker(
+        Q,
+        async () => {
+          // Each job runs 2.5s - longer than stalledInterval
+          await new Promise((r) => setTimeout(r, 2500));
+          return 'chain-done';
+        },
+        {
+          connection: CONNECTION,
+          concurrency: 1,
+          blockTimeout: 500,
+          stalledInterval: 2000,
+          lockDuration: 1000,
+          maxStalledCount: 1,
+          promotionInterval: 1000,
+        },
+      );
+
+      worker.on('completed', (job: any) => {
+        completedIds.push(job.id);
+        count++;
+        if (count >= 3) {
+          clearTimeout(timeout);
+          worker.close(true).then(resolve);
+        }
+      });
+      worker.on('stalled', (jobId: string) => stalledEvents.push(jobId));
+      worker.on('error', () => {});
+    });
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Add 3 jobs with per-job lockDuration - these go through completeAndFetchNext chain
+    const j1 = await queue.add('chain-1', { i: 1 }, { lockDuration: 60000 });
+    const j2 = await queue.add('chain-2', { i: 2 }, { lockDuration: 60000 });
+    const j3 = await queue.add('chain-3', { i: 3 }, { lockDuration: 60000 });
+
+    await done;
+
+    // All three must complete without stalling
+    expect(completedIds).toContain(j1!.id);
+    expect(completedIds).toContain(j2!.id);
+    expect(completedIds).toContain(j3!.id);
+    expect(stalledEvents).toHaveLength(0);
+
+    await queue.close();
+  }, 25000);
+});


### PR DESCRIPTION
## Summary

- Per-job `lockDuration` in JobOptions overrides worker-level setting
- Heartbeat frequency adapts per job: `lockDuration / 2`
- Stall detection respects per-job lock in both stream and list reclaim Lua paths
- A 200ms classification and a 30min inference no longer share stall threshold

## API

```ts
await queue.add('classify', data, { lockDuration: 5000 });   // fast stall detection
await queue.add('generate', data, { lockDuration: 300000 }); // generous for long inference
```

## Test plan

- [x] 10 tests passing (standalone + cluster)
- [x] Fuzzer: 3/3 passed
- [x] `npm run build` clean