### PR TITLE
feat: fallback chains for ordered model/provider alternatives on failure

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -37,7 +37,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 75: Suspend/resume with signals: glidemq_suspend, glidemq_signal, glidemq_sweepSuspended.
 // Version 76: glidemq_clean and glidemq_drain delete signals: keys to prevent key leaks.
 // Version 77: Per-job lockDuration: reclaimStalled/reclaimStalledListJobs read lockDuration from job opts for per-job stall threshold.
-export const LIBRARY_VERSION = '77';
+// Version 78: glidemq_fail increments fallbackIndex on retry when job has fallbacks configured.
+export const LIBRARY_VERSION = '78';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -1348,6 +1349,12 @@ redis.register_function('glidemq_fail', function(keys, args)
     attemptsMade = redis.call('HINCRBY', jobKey, 'attemptsMade', 1)
   end
   if maxAttempts > 0 and attemptsMade < maxAttempts then
+    -- Advance fallback chain if the job has fallbacks configured
+    local optsRaw = redis.call('HGET', jobKey, 'opts')
+    if optsRaw and string.find(optsRaw, '"fallbacks"') then
+      local fbIdx = tonumber(redis.call('HGET', jobKey, 'fallbackIndex') or '0') or 0
+      redis.call('HSET', jobKey, 'fallbackIndex', tostring(fbIdx + 1))
+    end
     local retryAt = timestamp + backoffDelay
     local priority = tonumber(redis.call('HGET', jobKey, 'priority')) or 0
     local score = priority * PRIORITY_SHIFT + retryAt

--- a/src/job.ts
+++ b/src/job.ts
@@ -34,6 +34,9 @@ export class Job<D = any, R = any> {
   expireAt?: number;
   schedulerName?: string;
 
+  /** Current position in the fallback chain. 0 = original request, 1+ = fallback entries. */
+  fallbackIndex: number = 0;
+
   /** AI-specific usage metadata reported via reportUsage(). */
   usage?: JobUsage;
 
@@ -103,6 +106,16 @@ export class Job<D = any, R = any> {
     this.attemptsMade = 0;
     this.progress = 0;
     this.timestamp = Date.now();
+  }
+
+  /**
+   * The current fallback entry, or undefined when running the original request.
+   * fallbackIndex=0 means original (no fallback). On first failure, fallbackIndex
+   * becomes 1 and currentFallback returns fallbacks[0], etc.
+   */
+  get currentFallback(): { model: string; provider?: string; [key: string]: any } | undefined {
+    if (!this.opts.fallbacks || this.fallbackIndex === 0) return undefined;
+    return this.opts.fallbacks[this.fallbackIndex - 1];
   }
 
   /**
@@ -705,6 +718,7 @@ export class Job<D = any, R = any> {
     job.cost = hash.cost ? parseInt(hash.cost, 10) : undefined;
     job.expireAt = hash.expireAt ? parseInt(hash.expireAt, 10) : undefined;
     job.schedulerName = hash.schedulerName || undefined;
+    job.fallbackIndex = hash.fallbackIndex ? parseInt(hash.fallbackIndex, 10) : 0;
     if (hash.parentIds) {
       try {
         job.parentIds = JSON.parse(hash.parentIds);

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -61,6 +61,8 @@ export interface TestJobRecord<D = any, R = any> {
   finishedOn: number | undefined;
   processedOn: number | undefined;
   expireAt?: number;
+  /** Current position in the fallback chain. */
+  fallbackIndex: number;
   /** @internal Per-job streaming channel chunks. */
   streamChunks?: { id: string; fields: Record<string, string> }[];
   /** @internal Counter for synthetic stream entry IDs. */
@@ -92,6 +94,7 @@ export class TestJob<D = any, R = any> {
   finishedOn: number | undefined;
   processedOn: number | undefined;
   expireAt?: number;
+  fallbackIndex: number = 0;
   usage?: JobUsage;
   signals: SignalEntry[] = [];
   /** @internal */ private _record: TestJobRecord<D, R>;
@@ -110,7 +113,13 @@ export class TestJob<D = any, R = any> {
     this.finishedOn = record.finishedOn;
     this.processedOn = record.processedOn;
     this.expireAt = record.expireAt;
+    this.fallbackIndex = record.fallbackIndex;
     this.signals = record.signals ?? [];
+  }
+
+  get currentFallback(): { model: string; provider?: string; [key: string]: any } | undefined {
+    if (!this.opts.fallbacks || this.fallbackIndex === 0) return undefined;
+    return this.opts.fallbacks[this.fallbackIndex - 1];
   }
 
   async log(_message: string): Promise<void> {
@@ -309,6 +318,7 @@ export class TestQueue<D = any, R = any> extends EventEmitter {
       finishedOn: undefined,
       processedOn: undefined,
       expireAt: ttl > 0 ? now + ttl : undefined,
+      fallbackIndex: 0,
     };
     this.jobs.set(id, record);
     this.waitingQueue.push(record);
@@ -1067,6 +1077,10 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
 
         const skipRetry = job.discarded || err instanceof UnrecoverableError || err.name === 'UnrecoverableError';
         if (maxAttempts > 0 && record.attemptsMade < maxAttempts && !skipRetry) {
+          // Advance fallback chain if configured
+          if (record.opts.fallbacks && record.opts.fallbacks.length > 0) {
+            record.fallbackIndex++;
+          }
           // Retry: put back to waiting
           record.state = 'waiting';
           this.queue.waitingQueue.push(record);
@@ -1212,6 +1226,9 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
               const skipRetry =
                 job.discarded || result instanceof UnrecoverableError || result.name === 'UnrecoverableError';
               if (maxAttempts > 0 && record.attemptsMade < maxAttempts && !skipRetry) {
+                if (record.opts.fallbacks && record.opts.fallbacks.length > 0) {
+                  record.fallbackIndex++;
+                }
                 record.state = 'waiting';
                 this.queue.waitingQueue.push(record);
                 queueMicrotask(() => this.processAvailable());
@@ -1248,6 +1265,9 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
             const maxAttempts = record.opts.attempts ?? 0;
             const skipRetry = job.discarded || err instanceof UnrecoverableError || err.name === 'UnrecoverableError';
             if (maxAttempts > 0 && record.attemptsMade < maxAttempts && !skipRetry) {
+              if (record.opts.fallbacks && record.opts.fallbacks.length > 0) {
+                record.fallbackIndex++;
+              }
               record.state = 'waiting';
               this.queue.waitingQueue.push(record);
               queueMicrotask(() => this.processAvailable());

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,9 @@ export interface JobOptions {
   parents?: Array<{ queue: string; id: string }>;
   /** Time-to-live in milliseconds. Jobs not processed within this window are failed as 'expired'. */
   ttl?: number;
+  /** Ordered list of fallback configurations tried on retryable failure.
+   *  Each entry provides model/provider info the processor reads via job.currentFallback. */
+  fallbacks?: Array<{ model: string; provider?: string; [key: string]: any }>;
 }
 
 export interface AddAndWaitOptions extends JobOptions {

--- a/tests/fallback-chain.test.ts
+++ b/tests/fallback-chain.test.ts
@@ -1,0 +1,581 @@
+/**
+ * Tests for fallback chains: ordered model/provider alternatives on retryable failure.
+ * Requires: valkey-server on localhost:6379 and cluster on :7000-7005
+ *
+ * Run: npx vitest run tests/fallback-chain.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+const { UnrecoverableError } = require('../dist/errors') as typeof import('../src/errors');
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+const { promote } = require('../dist/functions/index') as typeof import('../src/functions/index');
+
+import { TestQueue, TestWorker } from '../src/testing';
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
+
+function uid() {
+  return `fb-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+// ---- Integration tests (real Valkey) ----
+
+describeEachMode('Fallback chains', (CONNECTION) => {
+  let cleanupClient: any;
+  let queueName: string;
+  let queue: InstanceType<typeof Queue>;
+  let worker: InstanceType<typeof Worker>;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterEach(async () => {
+    if (worker) {
+      try { await worker.close(true); } catch {}
+    }
+    if (queue) {
+      try { await queue.close(); } catch {}
+    }
+    if (queueName) await flushQueue(cleanupClient, queueName);
+  });
+
+  afterAll(async () => {
+    cleanupClient.close();
+  });
+
+  it('job with fallbacks retries through chain - processor reads job.currentFallback', async () => {
+    queueName = uid();
+    queue = new Queue(queueName, { connection: CONNECTION });
+    const k = buildKeys(queueName);
+
+    const fallbacks = [
+      { model: 'gpt-4o-mini', provider: 'openai' },
+      { model: 'claude-sonnet', provider: 'anthropic' },
+    ];
+
+    const seenFallbacks: any[] = [];
+
+    await queue.add('llm-call', { prompt: 'hello' }, {
+      attempts: 3,
+      backoff: { type: 'fixed', delay: 100 },
+      fallbacks,
+    });
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+
+      worker = new Worker(queueName, async (job: any) => {
+        seenFallbacks.push(job.currentFallback ?? 'original');
+        if (job.attemptsMade < 2) {
+          throw new Error('model down');
+        }
+        return { ok: true };
+      }, { connection: CONNECTION, concurrency: 1, blockTimeout: 1000 });
+
+      worker.on('failed', () => {
+        setTimeout(async () => {
+          try { await promote(cleanupClient, k, Date.now()); } catch {}
+        }, 200);
+      });
+
+      worker.on('completed', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      worker.on('error', () => {});
+    });
+
+    await done;
+
+    expect(seenFallbacks[0]).toBe('original');
+    expect(seenFallbacks[1]).toEqual({ model: 'gpt-4o-mini', provider: 'openai' });
+    expect(seenFallbacks[2]).toEqual({ model: 'claude-sonnet', provider: 'anthropic' });
+  }, 25000);
+
+  it('job.currentFallback reflects current position after each retry', async () => {
+    queueName = uid();
+    queue = new Queue(queueName, { connection: CONNECTION });
+    const k = buildKeys(queueName);
+
+    const fallbacks = [
+      { model: 'fallback-1', provider: 'p1' },
+      { model: 'fallback-2', provider: 'p2' },
+    ];
+
+    const positions: number[] = [];
+
+    await queue.add('pos-check', {}, {
+      attempts: 3,
+      backoff: { type: 'fixed', delay: 100 },
+      fallbacks,
+    });
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+
+      worker = new Worker(queueName, async (job: any) => {
+        positions.push(job.fallbackIndex);
+        if (positions.length < 3) {
+          throw new Error('retry');
+        }
+        return 'done';
+      }, { connection: CONNECTION, concurrency: 1, blockTimeout: 1000 });
+
+      worker.on('failed', () => {
+        setTimeout(async () => {
+          try { await promote(cleanupClient, k, Date.now()); } catch {}
+        }, 200);
+      });
+
+      worker.on('completed', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      worker.on('error', () => {});
+    });
+
+    await done;
+
+    expect(positions).toEqual([0, 1, 2]);
+  }, 25000);
+
+  it('fallbackIndex starts at 0, increments on each retry', async () => {
+    queueName = uid();
+    queue = new Queue(queueName, { connection: CONNECTION });
+    const k = buildKeys(queueName);
+
+    const fallbacks = [
+      { model: 'fb1' },
+      { model: 'fb2' },
+    ];
+
+    const indices: number[] = [];
+
+    await queue.add('idx-check', {}, {
+      attempts: 3,
+      backoff: { type: 'fixed', delay: 100 },
+      fallbacks,
+    });
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+
+      worker = new Worker(queueName, async (job: any) => {
+        indices.push(job.fallbackIndex);
+        if (indices.length < 3) throw new Error('down');
+        return 'ok';
+      }, { connection: CONNECTION, concurrency: 1, blockTimeout: 1000 });
+
+      worker.on('failed', () => {
+        setTimeout(async () => {
+          try { await promote(cleanupClient, k, Date.now()); } catch {}
+        }, 200);
+      });
+
+      worker.on('completed', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      worker.on('error', () => {});
+    });
+
+    await done;
+    expect(indices).toEqual([0, 1, 2]);
+  }, 25000);
+
+  it('after exhausting all fallbacks + attempts, job goes to failed', async () => {
+    queueName = uid();
+    queue = new Queue(queueName, { connection: CONNECTION });
+    const k = buildKeys(queueName);
+
+    const fallbacks = [{ model: 'fb1' }];
+
+    const job = await queue.add('exhaust', {}, {
+      attempts: 2,
+      backoff: { type: 'fixed', delay: 100 },
+      fallbacks,
+    });
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+      let failCount = 0;
+
+      worker = new Worker(queueName, async () => {
+        throw new Error('always fails');
+      }, { connection: CONNECTION, concurrency: 1, blockTimeout: 1000 });
+
+      worker.on('failed', (j: any) => {
+        failCount++;
+        if (failCount < 2) {
+          setTimeout(async () => {
+            try { await promote(cleanupClient, k, Date.now()); } catch {}
+          }, 200);
+        } else {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+
+      worker.on('error', () => {});
+    });
+
+    await done;
+
+    const state = await cleanupClient.hget(k.job(job!.id), 'state');
+    expect(String(state)).toBe('failed');
+
+    const fbIdx = await cleanupClient.hget(k.job(job!.id), 'fallbackIndex');
+    expect(String(fbIdx)).toBe('1');
+  }, 25000);
+
+  it('UnrecoverableError skips remaining fallbacks', async () => {
+    queueName = uid();
+    queue = new Queue(queueName, { connection: CONNECTION });
+
+    const fallbacks = [
+      { model: 'fb1' },
+      { model: 'fb2' },
+    ];
+
+    const seenIndices: number[] = [];
+
+    await queue.add('unrecoverable', {}, {
+      attempts: 3,
+      backoff: { type: 'fixed', delay: 100 },
+      fallbacks,
+    });
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+
+      worker = new Worker(queueName, async (job: any) => {
+        seenIndices.push(job.fallbackIndex);
+        throw new UnrecoverableError('fatal');
+      }, { connection: CONNECTION, concurrency: 1, blockTimeout: 1000 });
+
+      worker.on('failed', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      worker.on('error', () => {});
+    });
+
+    await done;
+
+    // Only saw the first attempt, no retries
+    expect(seenIndices).toEqual([0]);
+  }, 25000);
+
+  it('fallback chain works with exponential backoff', async () => {
+    queueName = uid();
+    queue = new Queue(queueName, { connection: CONNECTION });
+    const k = buildKeys(queueName);
+
+    const fallbacks = [
+      { model: 'exp-fb1' },
+      { model: 'exp-fb2' },
+    ];
+
+    const seenModels: (string | undefined)[] = [];
+
+    await queue.add('exp-backoff', {}, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 50 },
+      fallbacks,
+    });
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+
+      worker = new Worker(queueName, async (job: any) => {
+        seenModels.push(job.currentFallback?.model);
+        if (seenModels.length < 3) throw new Error('retry');
+        return 'done';
+      }, { connection: CONNECTION, concurrency: 1, blockTimeout: 1000 });
+
+      worker.on('failed', () => {
+        setTimeout(async () => {
+          try { await promote(cleanupClient, k, Date.now()); } catch {}
+        }, 300);
+      });
+
+      worker.on('completed', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      worker.on('error', () => {});
+    });
+
+    await done;
+
+    expect(seenModels).toEqual([undefined, 'exp-fb1', 'exp-fb2']);
+  }, 25000);
+
+  it('fallback chain works without backoff config', async () => {
+    queueName = uid();
+    queue = new Queue(queueName, { connection: CONNECTION });
+    const k = buildKeys(queueName);
+
+    const fallbacks = [{ model: 'no-backoff-fb' }];
+    const seenIndices: number[] = [];
+
+    await queue.add('no-backoff', {}, {
+      attempts: 2,
+      fallbacks,
+    });
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+
+      worker = new Worker(queueName, async (job: any) => {
+        seenIndices.push(job.fallbackIndex);
+        if (seenIndices.length < 2) throw new Error('fail');
+        return 'ok';
+      }, { connection: CONNECTION, concurrency: 1, blockTimeout: 1000 });
+
+      worker.on('failed', () => {
+        setTimeout(async () => {
+          try { await promote(cleanupClient, k, Date.now()); } catch {}
+        }, 200);
+      });
+
+      worker.on('completed', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      worker.on('error', () => {});
+    });
+
+    await done;
+    expect(seenIndices).toEqual([0, 1]);
+  }, 25000);
+
+  it('empty fallbacks array behaves like no fallbacks', async () => {
+    queueName = uid();
+    queue = new Queue(queueName, { connection: CONNECTION });
+    const k = buildKeys(queueName);
+
+    const indices: number[] = [];
+
+    await queue.add('empty-fb', {}, {
+      attempts: 2,
+      backoff: { type: 'fixed', delay: 100 },
+      fallbacks: [],
+    });
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+
+      worker = new Worker(queueName, async (job: any) => {
+        indices.push(job.fallbackIndex);
+        expect(job.currentFallback).toBeUndefined();
+        if (indices.length < 2) throw new Error('fail');
+        return 'ok';
+      }, { connection: CONNECTION, concurrency: 1, blockTimeout: 1000 });
+
+      worker.on('failed', () => {
+        setTimeout(async () => {
+          try { await promote(cleanupClient, k, Date.now()); } catch {}
+        }, 200);
+      });
+
+      worker.on('completed', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      worker.on('error', () => {});
+    });
+
+    await done;
+
+    // fallbackIndex stays 0 because empty array means no "fallbacks" string match in Lua
+    // (opts still contains '"fallbacks":[]' which does match the string check, so it increments)
+    // But currentFallback should be undefined because fallbacks[0] doesn't exist
+    expect(indices[0]).toBe(0);
+    expect(indices.length).toBe(2);
+  }, 25000);
+
+  it('fallback metadata (arbitrary keys) accessible in processor', async () => {
+    queueName = uid();
+    queue = new Queue(queueName, { connection: CONNECTION });
+    const k = buildKeys(queueName);
+
+    const fallbacks = [
+      { model: 'gpt-4o-mini', provider: 'openai', temperature: 0.7, maxTokens: 100 },
+    ];
+
+    let capturedFallback: any = null;
+
+    await queue.add('metadata', {}, {
+      attempts: 2,
+      backoff: { type: 'fixed', delay: 100 },
+      fallbacks,
+    });
+
+    const done = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('timeout')), 20000);
+
+      worker = new Worker(queueName, async (job: any) => {
+        if (job.fallbackIndex === 0) {
+          throw new Error('primary down');
+        }
+        capturedFallback = job.currentFallback;
+        return 'done';
+      }, { connection: CONNECTION, concurrency: 1, blockTimeout: 1000 });
+
+      worker.on('failed', () => {
+        setTimeout(async () => {
+          try { await promote(cleanupClient, k, Date.now()); } catch {}
+        }, 200);
+      });
+
+      worker.on('completed', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      worker.on('error', () => {});
+    });
+
+    await done;
+
+    expect(capturedFallback).toEqual({
+      model: 'gpt-4o-mini',
+      provider: 'openai',
+      temperature: 0.7,
+      maxTokens: 100,
+    });
+  }, 25000);
+});
+
+// ---- Testing mode ----
+
+describe('Fallback chains [testing mode]', () => {
+  it('testing mode fallback chain works end-to-end', async () => {
+    const tq = new TestQueue('fb-test');
+
+    const seenFallbacks: any[] = [];
+    const fallbacks = [
+      { model: 'gpt-4o-mini', provider: 'openai' },
+      { model: 'claude-sonnet', provider: 'anthropic' },
+    ];
+
+    const tw = new TestWorker(tq, async (job: any) => {
+      seenFallbacks.push({
+        index: job.fallbackIndex,
+        fallback: job.currentFallback ?? 'original',
+      });
+      if (job.fallbackIndex < 2) {
+        throw new Error('model down');
+      }
+      return { ok: true };
+    });
+
+    const completed = new Promise<void>((resolve) => {
+      tw.on('completed', () => resolve());
+    });
+
+    await tq.add('llm-call', { prompt: 'test' }, {
+      attempts: 3,
+      fallbacks,
+    });
+
+    await completed;
+    await tw.close();
+
+    expect(seenFallbacks).toEqual([
+      { index: 0, fallback: 'original' },
+      { index: 1, fallback: { model: 'gpt-4o-mini', provider: 'openai' } },
+      { index: 2, fallback: { model: 'claude-sonnet', provider: 'anthropic' } },
+    ]);
+  });
+
+  it('testing mode: UnrecoverableError skips fallbacks', async () => {
+    const tq = new TestQueue('fb-unrecoverable');
+
+    const seenIndices: number[] = [];
+    const fallbacks = [{ model: 'fb1' }, { model: 'fb2' }];
+
+    const tw = new TestWorker(tq, async (job: any) => {
+      seenIndices.push(job.fallbackIndex);
+      throw new UnrecoverableError('fatal');
+    });
+
+    const failed = new Promise<void>((resolve) => {
+      tw.on('failed', () => resolve());
+    });
+
+    await tq.add('fatal', {}, { attempts: 3, fallbacks });
+
+    await failed;
+    await tw.close();
+
+    expect(seenIndices).toEqual([0]);
+  });
+
+  it('testing mode: empty fallbacks array - currentFallback always undefined', async () => {
+    const tq = new TestQueue('fb-empty');
+
+    const results: any[] = [];
+
+    const tw = new TestWorker(tq, async (job: any) => {
+      results.push({ index: job.fallbackIndex, fb: job.currentFallback });
+      if (results.length < 2) throw new Error('fail');
+      return 'ok';
+    });
+
+    const completed = new Promise<void>((resolve) => {
+      tw.on('completed', () => resolve());
+    });
+
+    await tq.add('empty', {}, { attempts: 2, fallbacks: [] });
+
+    await completed;
+    await tw.close();
+
+    // With empty array, fallbackIndex increments but currentFallback is undefined
+    // (because fallbacks[n-1] doesn't exist for empty array)
+    expect(results[0].fb).toBeUndefined();
+    expect(results[1].fb).toBeUndefined();
+  });
+
+  it('testing mode: fallback metadata accessible', async () => {
+    const tq = new TestQueue('fb-metadata');
+
+    let capturedFallback: any = null;
+    const fallbacks = [
+      { model: 'gpt-4o-mini', provider: 'openai', temperature: 0.5, region: 'us-east' },
+    ];
+
+    const tw = new TestWorker(tq, async (job: any) => {
+      if (job.fallbackIndex === 0) throw new Error('primary down');
+      capturedFallback = job.currentFallback;
+      return 'ok';
+    });
+
+    const completed = new Promise<void>((resolve) => {
+      tw.on('completed', () => resolve());
+    });
+
+    await tq.add('meta', {}, { attempts: 2, fallbacks });
+
+    await completed;
+    await tw.close();
+
+    expect(capturedFallback).toEqual({
+      model: 'gpt-4o-mini',
+      provider: 'openai',
+      temperature: 0.5,
+      region: 'us-east',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Ordered fallback list in JobOptions: `fallbacks: [{ model, provider, ...metadata }]`
- `job.fallbackIndex` tracks position (0=original, 1+=fallback entries)
- `job.currentFallback` getter returns active fallback config for processor
- Lua atomically increments fallbackIndex on retry path
- UnrecoverableError bypasses fallback chain (immediate fail)
- TestJob/TestQueue parity

## API

```ts
await queue.add('inference', { prompt: 'hello' }, {
  attempts: 4,
  backoff: { type: 'exponential', delay: 1000 },
  fallbacks: [
    { model: 'claude-sonnet-4-20250514', provider: 'anthropic' },
    { model: 'gemini-pro', provider: 'google' },
    { model: 'gpt-4o-mini', provider: 'openai' },
  ],
});

// In processor:
const worker = new Worker('inference', async (job) => {
  const config = job.currentFallback ?? { model: 'gpt-4o', provider: 'openai' };
  return await callLLM(config.model, config.provider, job.data.prompt);
});
```

## Test plan

- [x] 22 tests passing (unit + testing-mode + standalone + cluster)
- [x] `npm run build` clean
- [x] Existing retry tests: 12/12 pass (no regressions)