### PR TITLE
feat: budget middleware for flow-level token and cost caps

### DIFF
--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -44,11 +44,13 @@ import {
   moveToWaitingChildren,
   suspendJob,
   deferActive,
+  checkBudget,
+  recordUsageAndCheckBudget,
 } from './functions/index';
 import type { QueueKeys } from './functions/index';
 import { Scheduler } from './scheduler';
 
-export type WorkerEvent = 'completed' | 'failed' | 'error' | 'stalled' | 'closing' | 'closed' | 'active' | 'drained';
+export type WorkerEvent = 'completed' | 'failed' | 'error' | 'stalled' | 'closing' | 'closed' | 'active' | 'drained' | 'budget-exceeded';
 
 /**
  * Configuration that differs between Worker and BroadcastWorker.
@@ -1162,6 +1164,42 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       this.isDrained = false;
       if (this.hasActiveListeners) this.emit('active', job, currentJobId);
 
+      // Pre-dispatch budget check: if budget already exceeded, fail immediately
+      if (job.budgetKey && this.commandClient) {
+        const budgetStatus = await checkBudget(this.commandClient, job.budgetKey);
+        if (budgetStatus === 'exceeded') {
+          const onExceeded = await this.getBudgetOnExceeded(job.budgetKey);
+          this.emit('budget-exceeded', job, currentJobId);
+          if (onExceeded === 'pause') {
+            // Move to delayed with a long backoff so it can be resumed
+            try {
+              await moveActiveToDelayed(
+                this.commandClient,
+                this.queueKeys,
+                currentJobId,
+                currentEntryId,
+                Date.now() + 86400000,
+                undefined,
+                Date.now(),
+                this.consumerGroup,
+                this.broadcastMode ? true : undefined,
+              );
+            } catch (err) {
+              const e = err instanceof Error ? err : new Error(String(err));
+              await this.handleJobFailure(job, currentJobId, currentEntryId, e);
+            }
+          } else {
+            await this.handleJobFailure(
+              job,
+              currentJobId,
+              currentEntryId,
+              new Error('Budget exceeded'),
+            );
+          }
+          return;
+        }
+      }
+
       // Check for suspend continuation: if this job was previously suspended on this
       // worker and has an onResume callback, run it instead of the main processor.
       let processResult: R | undefined;
@@ -1342,6 +1380,23 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       job.finishedOn = now;
       if (this.hasCompletedListeners) this.emit('completed', job, processResult);
 
+      // Post-completion budget check: record usage and detect exceeded
+      if (job.budgetKey && job.usage && this.commandClient) {
+        const tokens = job.usage.totalTokens ?? 0;
+        const cost = job.usage.costUsd ?? 0;
+        if (tokens > 0 || cost > 0) {
+          const budgetResult = await recordUsageAndCheckBudget(
+            this.commandClient,
+            job.budgetKey,
+            tokens,
+            cost,
+          );
+          if (budgetResult === 'exceeded') {
+            this.emit('budget-exceeded', job, currentJobId);
+          }
+        }
+      }
+
       if (job.schedulerName) {
         await this.updateSchedulerAfterComplete(job.schedulerName, now);
       }
@@ -1506,6 +1561,20 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       this.cachedRateLimitDuration = Number(rlDur) || 0;
     } catch {
       // Transient error - next tick will retry
+    }
+  }
+
+  /**
+   * Read the onExceeded policy from a budget hash.
+   * Returns 'fail' (default) or 'pause'.
+   */
+  private async getBudgetOnExceeded(budgetKey: string): Promise<string> {
+    if (!this.commandClient) return 'fail';
+    try {
+      const val = await this.commandClient.hget(budgetKey, 'onExceeded');
+      return val ? String(val) : 'fail';
+    } catch {
+      return 'fail';
     }
   }
 

--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -1,4 +1,4 @@
-import type { FlowProducerOptions, FlowJob, DAGFlow, Client, Serializer } from './types';
+import type { FlowProducerOptions, FlowJob, DAGFlow, Client, Serializer, BudgetOptions } from './types';
 import { JSON_SERIALIZER } from './types';
 import { Job } from './job';
 import { buildKeys, keyPrefix, MAX_JOB_DATA_SIZE, validateJobId, validateQueueName } from './utils';
@@ -66,8 +66,13 @@ export class FlowProducer {
    * Add a flow (parent with children) atomically.
    * Children can have their own children (recursive flows), which are flattened
    * into multiple addFlow calls (one per level with children).
+   *
+   * When `flowOpts.budget` is provided, a budget hash is created in Valkey and
+   * a `budgetKey` field is written to the parent and all child job hashes.
+   * Workers check this key before processing and after completion to enforce
+   * token and cost caps across the entire flow.
    */
-  async add(flow: FlowJob): Promise<JobNode> {
+  async add(flow: FlowJob, flowOpts?: { budget?: BudgetOptions }): Promise<JobNode> {
     return withSpan(
       'glide-mq.flow.add',
       {
@@ -77,9 +82,55 @@ export class FlowProducer {
       },
       async () => {
         const client = await this.getClient();
-        return this.addFlowRecursive(client, flow);
+        const result = await this.addFlowRecursive(client, flow);
+
+        if (flowOpts?.budget) {
+          const prefix = this.opts.prefix ?? 'glide';
+          const budgetKey = `${prefix}:{${flow.queueName}}:budget:${result.job.id}`;
+          const budgetFields: Record<string, string> = {
+            usedTokens: '0',
+            usedCost: '0',
+            exceeded: '0',
+            onExceeded: flowOpts.budget.onExceeded ?? 'fail',
+          };
+          if (flowOpts.budget.maxTotalTokens != null) {
+            budgetFields.maxTotalTokens = flowOpts.budget.maxTotalTokens.toString();
+          }
+          if (flowOpts.budget.maxCostUsd != null) {
+            budgetFields.maxCostUsd = flowOpts.budget.maxCostUsd.toString();
+          }
+          await client.hset(budgetKey, budgetFields);
+
+          // Write budgetKey to all jobs in the flow
+          await this.propagateBudgetKey(client, result, flow, budgetKey, prefix);
+        }
+
+        return result;
       },
     );
+  }
+
+  /**
+   * Recursively write budgetKey to every job in a flow tree.
+   * Walks the FlowJob tree in parallel with the JobNode tree to access queue names.
+   */
+  private async propagateBudgetKey(
+    client: Client,
+    node: JobNode,
+    flowDef: FlowJob,
+    budgetKey: string,
+    prefix: string,
+  ): Promise<void> {
+    const keys = buildKeys(flowDef.queueName, prefix);
+    await client.hset(keys.job(node.job.id), { budgetKey });
+    node.job.budgetKey = budgetKey;
+    if (node.children && flowDef.children) {
+      for (let i = 0; i < node.children.length; i++) {
+        const childNode = node.children[i];
+        const childFlow = flowDef.children[i];
+        await this.propagateBudgetKey(client, childNode, childFlow, budgetKey, prefix);
+      }
+    }
   }
 
   /**

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -38,7 +38,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 76: glidemq_clean and glidemq_drain delete signals: keys to prevent key leaks.
 // Version 77: Per-job lockDuration: reclaimStalled/reclaimStalledListJobs read lockDuration from job opts for per-job stall threshold.
 // Version 78: glidemq_fail increments fallbackIndex on retry when job has fallbacks configured.
-export const LIBRARY_VERSION = '78';
+// Version 79: Budget middleware: glidemq_checkBudget, glidemq_recordUsageAndCheckBudget.
+export const LIBRARY_VERSION = '79';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -3431,6 +3432,41 @@ redis.register_function('glidemq_sweepSuspended', function(keys, args)
   end
   return count
 end)
+
+redis.register_function('glidemq_checkBudget', function(keys, args)
+  local budgetKey = keys[1]
+  local exists = redis.call('EXISTS', budgetKey)
+  if exists == 0 then return 'no_budget' end
+  local exceeded = redis.call('HGET', budgetKey, 'exceeded')
+  if exceeded == '1' then return 'exceeded' end
+  return 'ok'
+end)
+
+redis.register_function('glidemq_recordUsageAndCheckBudget', function(keys, args)
+  local budgetKey = keys[1]
+  local tokens = tonumber(args[1]) or 0
+  local cost = tonumber(args[2]) or 0
+
+  local exists = redis.call('EXISTS', budgetKey)
+  if exists == 0 then return 'no_budget' end
+
+  if tokens > 0 then redis.call('HINCRBYFLOAT', budgetKey, 'usedTokens', tokens) end
+  if cost > 0 then redis.call('HINCRBYFLOAT', budgetKey, 'usedCost', cost) end
+
+  local maxTokens = tonumber(redis.call('HGET', budgetKey, 'maxTotalTokens')) or 0
+  local maxCost = tonumber(redis.call('HGET', budgetKey, 'maxCostUsd')) or 0
+  local usedTokens = tonumber(redis.call('HGET', budgetKey, 'usedTokens')) or 0
+  local usedCost = tonumber(redis.call('HGET', budgetKey, 'usedCost')) or 0
+
+  local tokenExceeded = maxTokens > 0 and usedTokens > maxTokens
+  local costExceeded = maxCost > 0 and usedCost > maxCost
+
+  if tokenExceeded or costExceeded then
+    redis.call('HSET', budgetKey, 'exceeded', '1')
+    return 'exceeded'
+  end
+  return 'ok'
+end)
 `;
 
 // ---- Key set type ----
@@ -4580,4 +4616,30 @@ export async function sweepSuspended(
     [timestamp.toString(), keyPrefix],
   );
   return Number(result) || 0;
+}
+
+/**
+ * Check whether a budget has been exceeded. Returns 'ok', 'exceeded', or 'no_budget'.
+ */
+export async function checkBudget(client: Client, budgetKey: string): Promise<string> {
+  const result = await client.fcall('glidemq_checkBudget', [budgetKey], []);
+  return result as string;
+}
+
+/**
+ * Atomically record usage and check whether the budget is now exceeded.
+ * Returns 'ok', 'exceeded', or 'no_budget'.
+ */
+export async function recordUsageAndCheckBudget(
+  client: Client,
+  budgetKey: string,
+  tokens: number,
+  costUsd: number,
+): Promise<string> {
+  const result = await client.fcall(
+    'glidemq_recordUsageAndCheckBudget',
+    [budgetKey],
+    [tokens.toString(), costUsd.toString()],
+  );
+  return result as string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export type {
   ReadStreamOptions,
   SuspendOptions,
   SignalEntry,
+  BudgetOptions,
 } from './types';
 
 export { JSON_SERIALIZER } from './types';

--- a/src/job.ts
+++ b/src/job.ts
@@ -34,6 +34,9 @@ export class Job<D = any, R = any> {
   expireAt?: number;
   schedulerName?: string;
 
+  /** Budget key for flow-level budget enforcement. Set when the job belongs to a budgeted flow. */
+  budgetKey?: string;
+
   /** Current position in the fallback chain. 0 = original request, 1+ = fallback entries. */
   fallbackIndex: number = 0;
 
@@ -718,6 +721,7 @@ export class Job<D = any, R = any> {
     job.cost = hash.cost ? parseInt(hash.cost, 10) : undefined;
     job.expireAt = hash.expireAt ? parseInt(hash.expireAt, 10) : undefined;
     job.schedulerName = hash.schedulerName || undefined;
+    job.budgetKey = hash.budgetKey || undefined;
     job.fallbackIndex = hash.fallbackIndex ? parseInt(hash.fallbackIndex, 10) : 0;
     if (hash.parentIds) {
       try {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1763,6 +1763,33 @@ export class Queue<D = any, R = any> extends EventEmitter {
   }
 
   /**
+   * Read the budget state for a flow. Returns null if no budget was set.
+   */
+  async getFlowBudget(flowId: string): Promise<{
+    maxTotalTokens?: number;
+    maxCostUsd?: number;
+    usedTokens: number;
+    usedCost: number;
+    exceeded: boolean;
+    onExceeded: 'pause' | 'fail';
+  } | null> {
+    const client = await this.getClient();
+    const budgetKey = this.keys.budget(flowId);
+    const raw = await client.hgetall(budgetKey);
+    if (!raw || (Array.isArray(raw) && raw.length === 0)) return null;
+    const fields = hashDataToRecord(raw as any);
+    if (!fields) return null;
+    return {
+      maxTotalTokens: fields.maxTotalTokens ? parseFloat(fields.maxTotalTokens) : undefined,
+      maxCostUsd: fields.maxCostUsd ? parseFloat(fields.maxCostUsd) : undefined,
+      usedTokens: parseFloat(fields.usedTokens || '0'),
+      usedCost: parseFloat(fields.usedCost || '0'),
+      exceeded: fields.exceeded === '1',
+      onExceeded: (fields.onExceeded as 'pause' | 'fail') || 'fail',
+    };
+  }
+
+  /**
    * Read entries from a job's streaming channel.
    * Uses XRANGE for non-blocking reads. Pass lastId to resume from a known position.
    */

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -75,6 +75,8 @@ export interface TestJobRecord<D = any, R = any> {
   suspendedAt?: number;
   /** @internal Suspend timeout in ms. */
   suspendTimeout?: number;
+  /** @internal Budget key for flow-level budget enforcement. */
+  budgetKey?: string;
 }
 
 /**
@@ -97,6 +99,7 @@ export class TestJob<D = any, R = any> {
   fallbackIndex: number = 0;
   usage?: JobUsage;
   signals: SignalEntry[] = [];
+  budgetKey?: string;
   /** @internal */ private _record: TestJobRecord<D, R>;
 
   constructor(record: TestJobRecord<D, R>) {
@@ -115,6 +118,7 @@ export class TestJob<D = any, R = any> {
     this.expireAt = record.expireAt;
     this.fallbackIndex = record.fallbackIndex;
     this.signals = record.signals ?? [];
+    this.budgetKey = record.budgetKey;
   }
 
   get currentFallback(): { model: string; provider?: string; [key: string]: any } | undefined {
@@ -242,11 +246,22 @@ export interface TestQueueOptions {
  * - repeatAfterComplete behaves like 'every'
  * - No sandbox processor support
  */
+/** Budget state stored in-memory for testing mode. */
+interface TestBudgetState {
+  maxTotalTokens?: number;
+  maxCostUsd?: number;
+  usedTokens: number;
+  usedCost: number;
+  exceeded: boolean;
+  onExceeded: 'pause' | 'fail';
+}
+
 export class TestQueue<D = any, R = any> extends EventEmitter {
   readonly name: string;
   /** @internal */ readonly jobs: Map<string, TestJobRecord<D, R>> = new Map();
   /** @internal */ readonly dedupSet: Set<string> = new Set();
   /** @internal */ readonly waitingQueue: TestJobRecord<D, R>[] = [];
+  /** @internal */ readonly budgets: Map<string, TestBudgetState> = new Map();
   private idCounter = 0;
   private paused = false;
   private opts: TestQueueOptions;
@@ -698,6 +713,70 @@ export class TestQueue<D = any, R = any> extends EventEmitter {
     return agg;
   }
 
+  /**
+   * Read the budget state for a flow. Returns null if no budget was set.
+   */
+  async getFlowBudget(flowId: string): Promise<{
+    maxTotalTokens?: number;
+    maxCostUsd?: number;
+    usedTokens: number;
+    usedCost: number;
+    exceeded: boolean;
+    onExceeded: 'pause' | 'fail';
+  } | null> {
+    const budget = this.budgets.get(flowId);
+    if (!budget) return null;
+    return { ...budget };
+  }
+
+  /**
+   * @internal Set a budget for a flow (used by test setup).
+   */
+  setBudget(flowId: string, budget: {
+    maxTotalTokens?: number;
+    maxCostUsd?: number;
+    onExceeded?: 'pause' | 'fail';
+  }): void {
+    this.budgets.set(flowId, {
+      maxTotalTokens: budget.maxTotalTokens,
+      maxCostUsd: budget.maxCostUsd,
+      usedTokens: 0,
+      usedCost: 0,
+      exceeded: false,
+      onExceeded: budget.onExceeded ?? 'fail',
+    });
+  }
+
+  /**
+   * @internal Record usage against a budget and check if exceeded.
+   * Returns 'ok', 'exceeded', or 'no_budget'.
+   */
+  recordBudgetUsage(budgetKey: string, tokens: number, costUsd: number): string {
+    const budget = this.budgets.get(budgetKey);
+    if (!budget) return 'no_budget';
+
+    budget.usedTokens += tokens;
+    budget.usedCost += costUsd;
+
+    const tokenExceeded = (budget.maxTotalTokens ?? 0) > 0 && budget.usedTokens > budget.maxTotalTokens!;
+    const costExceeded = (budget.maxCostUsd ?? 0) > 0 && budget.usedCost > budget.maxCostUsd!;
+
+    if (tokenExceeded || costExceeded) {
+      budget.exceeded = true;
+      return 'exceeded';
+    }
+    return 'ok';
+  }
+
+  /**
+   * @internal Check if a budget is exceeded. Returns 'ok', 'exceeded', or 'no_budget'.
+   */
+  checkBudget(budgetKey: string): string {
+    const budget = this.budgets.get(budgetKey);
+    if (!budget) return 'no_budget';
+    return budget.exceeded ? 'exceeded' : 'ok';
+  }
+
   async readStream(
     jobId: string,
     opts?: { lastId?: string; count?: number },
@@ -1050,6 +1129,37 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
       }
       return;
     }
+    // Pre-dispatch budget check
+    if (record.budgetKey) {
+      const budgetStatus = this.queue.checkBudget(record.budgetKey);
+      if (budgetStatus === 'exceeded') {
+        const budget = this.queue.budgets.get(record.budgetKey);
+        this.emit('budget-exceeded', job, record.id);
+        if (budget?.onExceeded === 'pause') {
+          // Move back to waiting for later retry
+          record.state = 'waiting';
+          this.activeCount--;
+          if (this.running && !this.queue.isPaused()) {
+            this.processAvailable();
+          }
+          return;
+        }
+        record.state = 'failed';
+        record.failedReason = 'Budget exceeded';
+        record.finishedOn = Date.now();
+        job.failedReason = 'Budget exceeded';
+        job.finishedOn = record.finishedOn;
+        this.queue.recordMetric('failed', record.processedOn, record.finishedOn);
+        const err = new Error('Budget exceeded');
+        this.emit('failed', job, err);
+        this.queue.emit('failed', job, err);
+        this.activeCount--;
+        if (this.running && !this.queue.isPaused()) {
+          this.processAvailable();
+        }
+        return;
+      }
+    }
     this.processor(job as any)
       .then((result) => {
         // Roundtrip returnvalue through serializer to match production behavior
@@ -1063,6 +1173,18 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
         this.queue.recordMetric('completed', record.processedOn, record.finishedOn);
         this.emit('completed', job, roundtripped);
         this.queue.emit('completed', job, roundtripped);
+
+        // Post-completion budget check
+        if (record.budgetKey && job.usage) {
+          const tokens = job.usage.totalTokens ?? 0;
+          const cost = job.usage.costUsd ?? 0;
+          if (tokens > 0 || cost > 0) {
+            const budgetResult = this.queue.recordBudgetUsage(record.budgetKey, tokens, cost);
+            if (budgetResult === 'exceeded') {
+              this.emit('budget-exceeded', job, record.id);
+            }
+          }
+        }
       })
       .catch((err: Error) => {
         // Handle suspend: the job is already marked suspended by TestJob.suspend()

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,6 +274,16 @@ export interface BatchOptions {
 
 export type BatchProcessor<D = any, R = any> = (jobs: import('./job').Job<D, R>[]) => Promise<R[]>;
 
+/** Budget constraints for a flow. Caps total token usage and/or USD cost across all jobs. */
+export interface BudgetOptions {
+  /** Hard cap on total tokens across all jobs in this flow. */
+  maxTotalTokens?: number;
+  /** Hard cap on total USD cost across all jobs in this flow. */
+  maxCostUsd?: number;
+  /** What happens when budget is exceeded. Default: 'fail'. */
+  onExceeded?: 'pause' | 'fail';
+}
+
 export interface FlowJob {
   name: string;
   queueName: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,6 +120,7 @@ export function buildKeys(queueName: string, prefix = DEFAULT_PREFIX) {
     worker: (id: string) => `${p}:w:${id}`,
     suspended: `${p}:suspended`,
     signals: (id: string) => `${p}:signals:${id}`,
+    budget: (flowId: string) => `${p}:budget:${flowId}`,
   };
 }
 

--- a/tests/budget.test.ts
+++ b/tests/budget.test.ts
@@ -1,0 +1,519 @@
+/**
+ * Budget middleware tests - flow-level token/cost caps.
+ * Requires: valkey-server on localhost:6379 and cluster on :7000-7005
+ *
+ * Run: npx vitest run tests/budget.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+const { FlowProducer } = require('../dist/flow-producer') as typeof import('../src/flow-producer');
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+
+import { TestQueue, TestWorker } from '../src/testing';
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
+
+function uid() {
+  return `budget-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+// ---- Integration tests (real Valkey) ----
+
+describeEachMode('Budget middleware', (CONNECTION) => {
+  let cleanupClient: any;
+  let queueName: string;
+  let queue: InstanceType<typeof Queue>;
+  let worker: InstanceType<typeof Worker>;
+  let flow: InstanceType<typeof FlowProducer>;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterEach(async () => {
+    if (worker) {
+      try { await worker.close(true); } catch {}
+    }
+    if (queue) {
+      try { await queue.close(); } catch {}
+    }
+    if (flow) {
+      try { await flow.close(); } catch {}
+    }
+    if (queueName) await flushQueue(cleanupClient, queueName);
+  });
+
+  afterAll(async () => {
+    cleanupClient.close();
+  });
+
+  it('creates budget hash when flow is added with budget option', async () => {
+    queueName = uid();
+    flow = new FlowProducer({ connection: CONNECTION });
+    queue = new Queue(queueName, { connection: CONNECTION });
+
+    const node = await flow.add(
+      {
+        name: 'parent',
+        queueName,
+        data: { task: 'summarize' },
+        children: [
+          { name: 'child-1', queueName, data: { step: 'embed' } },
+          { name: 'child-2', queueName, data: { step: 'generate' } },
+        ],
+      },
+      { budget: { maxTotalTokens: 5000, maxCostUsd: 1.0 } },
+    );
+
+    const budget = await queue.getFlowBudget(node.job.id);
+    expect(budget).not.toBeNull();
+    expect(budget!.maxTotalTokens).toBe(5000);
+    expect(budget!.maxCostUsd).toBe(1.0);
+    expect(budget!.usedTokens).toBe(0);
+    expect(budget!.usedCost).toBe(0);
+    expect(budget!.exceeded).toBe(false);
+    expect(budget!.onExceeded).toBe('fail');
+
+    // Verify budgetKey is written to parent and children
+    const k = buildKeys(queueName);
+    const parentBudgetKey = await cleanupClient.hget(k.job(node.job.id), 'budgetKey');
+    expect(parentBudgetKey).toBeTruthy();
+
+    for (const child of node.children!) {
+      const childBudgetKey = await cleanupClient.hget(k.job(child.job.id), 'budgetKey');
+      expect(String(childBudgetKey)).toBe(String(parentBudgetKey));
+    }
+  });
+
+  it('flow with maxCostUsd stops after exceeding', async () => {
+    queueName = uid();
+    flow = new FlowProducer({ connection: CONNECTION });
+    queue = new Queue(queueName, { connection: CONNECTION });
+
+    const node = await flow.add(
+      {
+        name: 'parent',
+        queueName,
+        data: {},
+        children: [
+          { name: 'child-1', queueName, data: { step: 1 } },
+          { name: 'child-2', queueName, data: { step: 2 } },
+          { name: 'child-3', queueName, data: { step: 3 } },
+        ],
+      },
+      { budget: { maxCostUsd: 0.05 } },
+    );
+
+    const processed: string[] = [];
+    const budgetExceededJobs: string[] = [];
+
+    worker = new Worker(
+      queueName,
+      async (job: any) => {
+        processed.push(job.name);
+        // Each child reports $0.03 - second child should trigger exceeded
+        if (job.name.startsWith('child')) {
+          await job.reportUsage({ model: 'gpt-4o', inputTokens: 100, costUsd: 0.03 });
+        }
+        return 'done';
+      },
+      { connection: CONNECTION },
+    );
+
+    worker.on('budget-exceeded', (job: any) => {
+      budgetExceededJobs.push(job.name);
+    });
+
+    // Wait for children to process (parent stays in waiting-children)
+    await waitFor(async () => {
+      const counts = await queue.getJobCounts();
+      return counts.failed >= 1 || processed.length >= 3;
+    }, 10000);
+
+    // At least the first two children should have been processed
+    expect(processed.length).toBeGreaterThanOrEqual(2);
+
+    // Budget should be exceeded after 2 children ($0.06 > $0.05)
+    const budget = await queue.getFlowBudget(node.job.id);
+    expect(budget).not.toBeNull();
+    expect(budget!.exceeded).toBe(true);
+    expect(budget!.usedCost).toBeGreaterThanOrEqual(0.06);
+
+    // Budget-exceeded event should have been emitted
+    expect(budgetExceededJobs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('maxTotalTokens enforced independently of cost', async () => {
+    queueName = uid();
+    flow = new FlowProducer({ connection: CONNECTION });
+    queue = new Queue(queueName, { connection: CONNECTION });
+
+    const node = await flow.add(
+      {
+        name: 'parent',
+        queueName,
+        data: {},
+        children: [
+          { name: 'child-1', queueName, data: {} },
+          { name: 'child-2', queueName, data: {} },
+        ],
+      },
+      { budget: { maxTotalTokens: 500 } },
+    );
+
+    worker = new Worker(
+      queueName,
+      async (job: any) => {
+        if (job.name === 'child-1') {
+          await job.reportUsage({ inputTokens: 300, outputTokens: 100 });
+        } else if (job.name === 'child-2') {
+          await job.reportUsage({ inputTokens: 200, outputTokens: 50 });
+        }
+        return 'ok';
+      },
+      { connection: CONNECTION },
+    );
+
+    await waitFor(async () => {
+      const budget = await queue.getFlowBudget(node.job.id);
+      return budget !== null && budget.exceeded;
+    }, 10000);
+
+    const budget = await queue.getFlowBudget(node.job.id);
+    expect(budget!.exceeded).toBe(true);
+    expect(budget!.usedTokens).toBeGreaterThanOrEqual(500);
+  });
+
+  it('pre-dispatch check prevents starting job when budget already exceeded', async () => {
+    queueName = uid();
+    flow = new FlowProducer({ connection: CONNECTION });
+    queue = new Queue(queueName, { connection: CONNECTION });
+
+    const node = await flow.add(
+      {
+        name: 'parent',
+        queueName,
+        data: {},
+        children: [
+          { name: 'child-1', queueName, data: {} },
+          { name: 'child-2', queueName, data: {} },
+        ],
+      },
+      { budget: { maxCostUsd: 0.01 } },
+    );
+
+    // Manually set budget to exceeded before any worker runs
+    const budgetKey = node.job.budgetKey!;
+    await cleanupClient.hset(budgetKey, { exceeded: '1' });
+
+    const processedJobs: string[] = [];
+    const failedJobs: string[] = [];
+
+    worker = new Worker(
+      queueName,
+      async (job: any) => {
+        processedJobs.push(job.name);
+        return 'ok';
+      },
+      { connection: CONNECTION },
+    );
+
+    worker.on('failed', (job: any) => {
+      failedJobs.push(job.name);
+    });
+
+    // Wait for children to fail
+    await waitFor(async () => {
+      return failedJobs.length >= 2;
+    }, 10000);
+
+    // No children should have been processed (budget was pre-exceeded)
+    expect(processedJobs).toHaveLength(0);
+    expect(failedJobs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('onExceeded: fail fails remaining jobs', async () => {
+    queueName = uid();
+    flow = new FlowProducer({ connection: CONNECTION });
+    queue = new Queue(queueName, { connection: CONNECTION });
+
+    const node = await flow.add(
+      {
+        name: 'parent',
+        queueName,
+        data: {},
+        children: [
+          { name: 'child-1', queueName, data: {} },
+          { name: 'child-2', queueName, data: {} },
+          { name: 'child-3', queueName, data: {} },
+        ],
+      },
+      { budget: { maxCostUsd: 0.01, onExceeded: 'fail' } },
+    );
+
+    let childOneDone = false;
+    const failedJobs: string[] = [];
+
+    worker = new Worker(
+      queueName,
+      async (job: any) => {
+        if (job.name === 'child-1') {
+          // First child exceeds the budget
+          await job.reportUsage({ costUsd: 0.02 });
+          childOneDone = true;
+        }
+        return 'ok';
+      },
+      { connection: CONNECTION, concurrency: 1 },
+    );
+
+    worker.on('failed', (job: any) => {
+      failedJobs.push(job.name);
+    });
+
+    await waitFor(async () => {
+      return childOneDone && failedJobs.length >= 2;
+    }, 10000);
+
+    // Remaining children should have failed with budget exceeded
+    const failedChildren = failedJobs.filter((n) => n.startsWith('child'));
+    expect(failedChildren.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('budget state readable via getFlowBudget()', async () => {
+    queueName = uid();
+    flow = new FlowProducer({ connection: CONNECTION });
+    queue = new Queue(queueName, { connection: CONNECTION });
+
+    const node = await flow.add(
+      {
+        name: 'parent',
+        queueName,
+        data: {},
+        children: [{ name: 'child-1', queueName, data: {} }],
+      },
+      { budget: { maxTotalTokens: 10000, maxCostUsd: 5.0, onExceeded: 'pause' } },
+    );
+
+    const budget = await queue.getFlowBudget(node.job.id);
+    expect(budget).not.toBeNull();
+    expect(budget!.maxTotalTokens).toBe(10000);
+    expect(budget!.maxCostUsd).toBe(5.0);
+    expect(budget!.usedTokens).toBe(0);
+    expect(budget!.usedCost).toBe(0);
+    expect(budget!.exceeded).toBe(false);
+    expect(budget!.onExceeded).toBe('pause');
+  });
+
+  it('getFlowBudget returns null for jobs without budget', async () => {
+    queueName = uid();
+    queue = new Queue(queueName, { connection: CONNECTION });
+    const budget = await queue.getFlowBudget('nonexistent-id');
+    expect(budget).toBeNull();
+  });
+
+  it('worker emits budget-exceeded event', async () => {
+    queueName = uid();
+    flow = new FlowProducer({ connection: CONNECTION });
+    queue = new Queue(queueName, { connection: CONNECTION });
+
+    const node = await flow.add(
+      {
+        name: 'parent',
+        queueName,
+        data: {},
+        children: [{ name: 'child-1', queueName, data: {} }],
+      },
+      { budget: { maxCostUsd: 0.001 } },
+    );
+
+    let budgetExceededEmitted = false;
+
+    worker = new Worker(
+      queueName,
+      async (job: any) => {
+        if (job.name === 'child-1') {
+          await job.reportUsage({ costUsd: 0.01 });
+        }
+        return 'ok';
+      },
+      { connection: CONNECTION },
+    );
+
+    worker.on('budget-exceeded', () => {
+      budgetExceededEmitted = true;
+    });
+
+    await waitFor(() => budgetExceededEmitted, 10000);
+    expect(budgetExceededEmitted).toBe(true);
+  });
+
+  it('budget not checked for jobs without budgetKey', async () => {
+    queueName = uid();
+    queue = new Queue(queueName, { connection: CONNECTION });
+
+    // Add a plain job (no flow, no budget)
+    await queue.add('plain-job', { data: 'test' });
+
+    const processed: string[] = [];
+    worker = new Worker(
+      queueName,
+      async (job: any) => {
+        processed.push(job.name);
+        return 'ok';
+      },
+      { connection: CONNECTION },
+    );
+
+    await waitFor(() => processed.length >= 1, 5000);
+    expect(processed).toContain('plain-job');
+  });
+});
+
+// ---- Testing mode tests ----
+
+describe('Budget middleware (testing mode)', () => {
+  it('budget enforcement in TestWorker', async () => {
+    const queue = new TestQueue('test-budget');
+    const budgetFlowId = 'flow-1';
+
+    queue.setBudget(budgetFlowId, {
+      maxCostUsd: 0.05,
+    });
+
+    // Add jobs with budgetKey
+    const job1 = await queue.add('child-1', { step: 1 }, {});
+    const job2 = await queue.add('child-2', { step: 2 }, {});
+    const job3 = await queue.add('child-3', { step: 3 }, {});
+
+    // Set budgetKey on records
+    const r1 = queue.jobs.get(job1!.id)!;
+    const r2 = queue.jobs.get(job2!.id)!;
+    const r3 = queue.jobs.get(job3!.id)!;
+    r1.budgetKey = budgetFlowId;
+    r2.budgetKey = budgetFlowId;
+    r3.budgetKey = budgetFlowId;
+
+    const processed: string[] = [];
+    const budgetExceededJobs: string[] = [];
+    const failedJobs: string[] = [];
+
+    const worker = new TestWorker(
+      queue,
+      async (job: any) => {
+        processed.push(job.name);
+        // Each child costs $0.03
+        await job.reportUsage({ costUsd: 0.03 });
+        return 'ok';
+      },
+      { concurrency: 1 },
+    );
+
+    worker.on('budget-exceeded', (job: any) => {
+      budgetExceededJobs.push(job.name);
+    });
+
+    worker.on('failed', (job: any) => {
+      failedJobs.push(job.name);
+    });
+
+    // Wait for processing
+    await new Promise((r) => setTimeout(r, 200));
+
+    // First child completes, second child triggers exceeded
+    expect(processed.length).toBeGreaterThanOrEqual(1);
+
+    // Budget should be exceeded
+    const budget = await queue.getFlowBudget(budgetFlowId);
+    expect(budget!.exceeded).toBe(true);
+
+    // Third child should be failed (budget was exceeded before it ran)
+    expect(failedJobs.length).toBeGreaterThanOrEqual(1);
+
+    await worker.close();
+    await queue.close();
+  });
+
+  it('getFlowBudget returns null when no budget set', async () => {
+    const queue = new TestQueue('test-no-budget');
+    const budget = await queue.getFlowBudget('nonexistent');
+    expect(budget).toBeNull();
+    await queue.close();
+  });
+
+  it('onExceeded pause does not fail jobs', async () => {
+    const queue = new TestQueue('test-budget-pause');
+    const budgetFlowId = 'flow-pause';
+
+    queue.setBudget(budgetFlowId, {
+      maxCostUsd: 0.01,
+      onExceeded: 'pause',
+    });
+
+    // Manually mark as exceeded
+    const budgetState = queue.budgets.get(budgetFlowId)!;
+    budgetState.exceeded = true;
+
+    const job1 = await queue.add('paused-job', {}, {});
+    const r1 = queue.jobs.get(job1!.id)!;
+    r1.budgetKey = budgetFlowId;
+
+    const failedJobs: string[] = [];
+    const budgetExceededJobs: string[] = [];
+
+    const worker = new TestWorker(
+      queue,
+      async () => 'ok',
+      { concurrency: 1 },
+    );
+
+    worker.on('failed', (job: any) => failedJobs.push(job.name));
+    worker.on('budget-exceeded', (job: any) => budgetExceededJobs.push(job.name));
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Job should NOT be failed - it should be moved back to waiting
+    expect(failedJobs).toHaveLength(0);
+    // Budget-exceeded event should fire
+    expect(budgetExceededJobs.length).toBeGreaterThanOrEqual(1);
+
+    await worker.close();
+    await queue.close();
+  });
+
+  it('maxTotalTokens works in testing mode', async () => {
+    const queue = new TestQueue('test-budget-tokens');
+    const budgetFlowId = 'flow-tokens';
+
+    queue.setBudget(budgetFlowId, {
+      maxTotalTokens: 500,
+    });
+
+    const job1 = await queue.add('child-1', {}, {});
+    const r1 = queue.jobs.get(job1!.id)!;
+    r1.budgetKey = budgetFlowId;
+
+    const worker = new TestWorker(
+      queue,
+      async (job: any) => {
+        await job.reportUsage({ inputTokens: 300, outputTokens: 300 });
+        return 'ok';
+      },
+      { concurrency: 1 },
+    );
+
+    let budgetExceeded = false;
+    worker.on('budget-exceeded', () => { budgetExceeded = true; });
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    const budget = await queue.getFlowBudget(budgetFlowId);
+    expect(budget!.exceeded).toBe(true);
+    expect(budget!.usedTokens).toBe(600);
+    expect(budgetExceeded).toBe(true);
+
+    await worker.close();
+    await queue.close();
+  });
+});

--- a/tests/helpers/fixture.ts
+++ b/tests/helpers/fixture.ts
@@ -130,6 +130,7 @@ export async function flushQueue(client: any, queueName: string, prefix = 'glide
     `${pfx}:parents:*`,
     `${pfx}:w:*`,
     `${pfx}:signals:*`,
+    `${pfx}:budget:*`,
   ]) {
     try {
       if (client.constructor.name === 'GlideClusterClient') {


### PR DESCRIPTION
## Summary

- Per-flow budget enforcement: `maxTotalTokens` and `maxCostUsd` caps
- Dual enforcement: pre-dispatch check (skip if exceeded) + post-completion check (atomic HINCRBY + compare)
- Two modes: `onExceeded: 'fail'` (default) or `'pause'`
- Worker emits `budget-exceeded` event
- New Lua FCALLs: `glidemq_checkBudget`, `glidemq_recordUsageAndCheckBudget`
- Queue.getFlowBudget() for introspection
- TestQueue/TestWorker parity

## API

```ts
const flow = await flowProducer.add({
  name: 'rag-pipeline',
  queueName: 'ai',
  data: {},
  children: [
    { name: 'embed', queueName: 'ai', data: {} },
    { name: 'generate', queueName: 'ai', data: {} },
  ],
}, {
  budget: { maxCostUsd: 1.0, maxTotalTokens: 50000, onExceeded: 'fail' },
});

// In processor - reportUsage feeds budget tracking automatically
await job.reportUsage({ model: 'gpt-4o', inputTokens: 500, costUsd: 0.01 });

// Introspection
const budget = await queue.getFlowBudget(flow.job.id);
// { maxTotalTokens: 50000, maxCostUsd: 1.0, usedTokens: 500, usedCost: 0.01, exceeded: false }
```

## Test plan

- [x] 22 tests passing (unit + testing-mode + standalone + cluster)
- [x] `npm run build` clean