### PR TITLE
feat: dual-axis rate limiting (RPM + TPM) for LLM API compliance

### DIFF
--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -109,6 +109,10 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
   protected globalRateLimitEnabled = false;
   protected cachedRateLimitMax = 0;
   protected cachedRateLimitDuration = 0;
+
+  // TPM (token-per-minute) rate limiting state
+  protected tpmLocalCounter = 0;
+  protected tpmWindowStart = 0;
   protected sandboxClose?: (force?: boolean) => Promise<void>;
   protected workerHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
   protected pollLoopPromise: Promise<void> | null = null;
@@ -573,6 +577,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
 
     // Rate limit check (once per batch)
     if (this.opts.limiter || this.globalRateLimitEnabled) await this.waitForRateLimit();
+    if (this.opts.tokenLimiter) await this.waitForTokenLimit();
 
     // Set up abort controllers for all jobs
     const batchAc = new AbortController();
@@ -685,6 +690,14 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         entry.job.returnvalue = result;
         entry.job.finishedOn = Date.now();
         if (this.hasCompletedListeners) this.emit('completed', entry.job, result);
+
+        // TPM tracking for batch jobs
+        if (this.opts.tokenLimiter) {
+          const tpmTokens = Math.max(entry.job.usage?.totalTokens ?? 0, entry.job.tpmTokens ?? 0);
+          if (tpmTokens > 0) {
+            await this.incrementTpmCounter(tpmTokens);
+          }
+        }
       }
     } else if (batchError) {
       // Partial failure: process each result individually
@@ -738,6 +751,14 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           entry.job.returnvalue = result as R;
           entry.job.finishedOn = Date.now();
           if (this.hasCompletedListeners) this.emit('completed', entry.job, result);
+
+          // TPM tracking for batch jobs (partial success)
+          if (this.opts.tokenLimiter) {
+            const tpmTokens = Math.max(entry.job.usage?.totalTokens ?? 0, entry.job.tpmTokens ?? 0);
+            if (tpmTokens > 0) {
+              await this.incrementTpmCounter(tpmTokens);
+            }
+          }
         }
       }
     } else if (thrownError) {
@@ -835,6 +856,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     jobId: string,
   ): Promise<{ result?: R; error?: Error; aborted: boolean }> {
     if (this.opts.limiter || this.globalRateLimitEnabled) await this.waitForRateLimit();
+    if (this.opts.tokenLimiter) await this.waitForTokenLimit();
 
     const ac = new AbortController();
     this.activeAbortControllers.set(jobId, ac);
@@ -1397,6 +1419,15 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         }
       }
 
+      // Post-completion TPM tracking: increment counter for token rate limiting.
+      // Use whichever is larger: usage.totalTokens or explicit tpmTokens.
+      if (this.opts.tokenLimiter) {
+        const tpmTokens = Math.max(job.usage?.totalTokens ?? 0, job.tpmTokens ?? 0);
+        if (tpmTokens > 0) {
+          await this.incrementTpmCounter(tpmTokens);
+        }
+      }
+
       if (job.schedulerName) {
         await this.updateSchedulerAfterComplete(job.schedulerName, now);
       }
@@ -1539,6 +1570,90 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
 
       // Wait for the delay, then re-check
       await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  /**
+   * Check the TPM (token-per-minute) rate limit and wait if either the local or
+   * per-queue counter exceeds the configured maxTokens for the current window.
+   */
+  protected async waitForTokenLimit(): Promise<void> {
+    const tl = this.opts.tokenLimiter;
+    if (!tl) return;
+
+    const scope = tl.scope ?? 'both';
+
+    while (true) {
+      const now = Date.now();
+
+      // Reset local counter if the window has expired
+      if (now >= this.tpmWindowStart + tl.duration) {
+        this.tpmLocalCounter = 0;
+        this.tpmWindowStart = now - (now % tl.duration);
+      }
+
+      // Local check
+      if (scope === 'worker' || scope === 'both') {
+        if (this.tpmLocalCounter >= tl.maxTokens) {
+          const sleepMs = this.tpmWindowStart + tl.duration - now;
+          if (sleepMs > 0) {
+            await new Promise<void>((resolve) => setTimeout(resolve, sleepMs));
+            continue;
+          }
+        }
+      }
+
+      // Queue-wide (Valkey) check
+      if ((scope === 'queue' || scope === 'both') && this.commandClient) {
+        const windowId = Math.floor(now / tl.duration);
+        const tpmKey = `${this.queueKeys.tpm}:${windowId}`;
+        // INCRBY 0 reads the current value without modifying it
+        const current = await this.commandClient.incrBy(tpmKey, 0);
+        if (current >= tl.maxTokens) {
+          const windowEndMs = (windowId + 1) * tl.duration;
+          const sleepMs = windowEndMs - now;
+          if (sleepMs > 0) {
+            await new Promise<void>((resolve) => setTimeout(resolve, sleepMs));
+            continue;
+          }
+        }
+      }
+
+      break;
+    }
+  }
+
+  /**
+   * Increment the TPM counter after a job completes (or reports tokens).
+   * Called from the completion path when tokenLimiter is configured.
+   */
+  protected async incrementTpmCounter(tokens: number): Promise<void> {
+    if (tokens <= 0) return;
+    const tl = this.opts.tokenLimiter;
+    if (!tl) return;
+
+    const scope = tl.scope ?? 'both';
+    const now = Date.now();
+
+    // Local counter
+    if (scope === 'worker' || scope === 'both') {
+      if (now >= this.tpmWindowStart + tl.duration) {
+        this.tpmLocalCounter = 0;
+        this.tpmWindowStart = now - (now % tl.duration);
+      }
+      this.tpmLocalCounter += tokens;
+    }
+
+    // Valkey counter
+    if ((scope === 'queue' || scope === 'both') && this.commandClient) {
+      const windowId = Math.floor(now / tl.duration);
+      const tpmKey = `${this.queueKeys.tpm}:${windowId}`;
+      const newVal = await this.commandClient.incrBy(tpmKey, tokens);
+      // Set expiry on first increment so the key auto-cleans.
+      // If newVal === tokens, this is likely the first write in this window.
+      if (newVal === tokens) {
+        await this.commandClient.pexpire(tpmKey, tl.duration);
+      }
     }
   }
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -43,6 +43,9 @@ export class Job<D = any, R = any> {
   /** AI-specific usage metadata reported via reportUsage(). */
   usage?: JobUsage;
 
+  /** Tokens reported via reportTokens() for TPM rate limiting. */
+  tpmTokens?: number;
+
   /**
    * AbortSignal that fires when this job is revoked during processing.
    * The processor should check signal.aborted cooperatively.
@@ -222,6 +225,20 @@ export class Job<D = any, R = any> {
     }
 
     this.usage = resolved;
+  }
+
+  /**
+   * Report tokens consumed by this job for TPM (tokens-per-minute) tracking.
+   * The count is stored in the job hash field `tpmTokens`.
+   * After job completion, the Worker reads this value and increments the TPM counter
+   * if a tokenLimiter is configured.
+   *
+   * Calling multiple times overwrites the previous value.
+   */
+  async reportTokens(count: number): Promise<void> {
+    if (count < 0) throw new Error('Token count must not be negative');
+    await this.client.hset(this.queueKeys.job(this.id), { tpmTokens: count.toString() });
+    this.tpmTokens = count;
   }
 
   /**
@@ -723,6 +740,7 @@ export class Job<D = any, R = any> {
     job.schedulerName = hash.schedulerName || undefined;
     job.budgetKey = hash.budgetKey || undefined;
     job.fallbackIndex = hash.fallbackIndex ? parseInt(hash.fallbackIndex, 10) : 0;
+    job.tpmTokens = hash.tpmTokens ? parseInt(hash.tpmTokens, 10) : undefined;
     if (hash.parentIds) {
       try {
         job.parentIds = JSON.parse(hash.parentIds);

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -98,6 +98,7 @@ export class TestJob<D = any, R = any> {
   expireAt?: number;
   fallbackIndex: number = 0;
   usage?: JobUsage;
+  tpmTokens?: number;
   signals: SignalEntry[] = [];
   budgetKey?: string;
   /** @internal */ private _record: TestJobRecord<D, R>;
@@ -175,6 +176,11 @@ export class TestJob<D = any, R = any> {
       resolved.totalTokens = (resolved.inputTokens ?? 0) + (resolved.outputTokens ?? 0);
     }
     this.usage = resolved;
+  }
+
+  async reportTokens(count: number): Promise<void> {
+    if (count < 0) throw new Error('Token count must not be negative');
+    this.tpmTokens = count;
   }
 
   async stream(chunk: Record<string, string>): Promise<string> {
@@ -976,6 +982,11 @@ export class TestQueue<D = any, R = any> extends EventEmitter {
 export interface TestWorkerOptions {
   concurrency?: number;
   batch?: { size: number; timeout?: number };
+  /** Token-per-minute rate limiting (in-memory only for testing mode). */
+  tokenLimiter?: {
+    maxTokens: number;
+    duration: number;
+  };
 }
 
 export class TestWorker<D = any, R = any> extends EventEmitter {
@@ -994,6 +1005,9 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
   private readonly batchTimeout: number;
   private readonly batchProcessor: ((jobs: TestJob<D, R>[]) => Promise<R[]>) | null;
   private batchTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly tokenLimiter: TestWorkerOptions['tokenLimiter'];
+  private tpmLocalCounter = 0;
+  private tpmWindowStart = 0;
 
   constructor(
     queue: TestQueue<D, R>,
@@ -1045,6 +1059,7 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
       }
     }
     this.concurrency = opts?.concurrency ?? 1;
+    this.tokenLimiter = opts?.tokenLimiter;
     this.id = `test-worker-${++TestWorker.idCounter}`;
     this.startedAt = Date.now();
 
@@ -1160,7 +1175,8 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
         return;
       }
     }
-    this.processor(job as any)
+    this.waitForTokenLimitIfNeeded()
+      .then(() => this.processor(job as any))
       .then((result) => {
         // Roundtrip returnvalue through serializer to match production behavior
         const s = this.queue.serializer;
@@ -1173,6 +1189,12 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
         this.queue.recordMetric('completed', record.processedOn, record.finishedOn);
         this.emit('completed', job, roundtripped);
         this.queue.emit('completed', job, roundtripped);
+
+        // Post-completion TPM tracking
+        if (this.tokenLimiter) {
+          const tpmTokens = Math.max(job.usage?.totalTokens ?? 0, job.tpmTokens ?? 0);
+          this.incrementLocalTpm(tpmTokens);
+        }
 
         // Post-completion budget check
         if (record.budgetKey && job.usage) {
@@ -1412,6 +1434,36 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
           this.processAvailable();
         }
       });
+  }
+
+  /** Wait if the TPM counter exceeds the limit for the current window. */
+  private async waitForTokenLimitIfNeeded(): Promise<void> {
+    if (!this.tokenLimiter) return;
+    const tl = this.tokenLimiter;
+
+    while (true) {
+      const now = Date.now();
+      // Reset window if expired
+      if (now >= this.tpmWindowStart + tl.duration) {
+        this.tpmLocalCounter = 0;
+        this.tpmWindowStart = now - (now % tl.duration);
+      }
+      if (this.tpmLocalCounter < tl.maxTokens) break;
+      const sleepMs = this.tpmWindowStart + tl.duration - now;
+      if (sleepMs <= 0) continue;
+      await new Promise<void>((resolve) => setTimeout(resolve, sleepMs));
+    }
+  }
+
+  /** Increment the local TPM counter after a job completes. */
+  private incrementLocalTpm(tokens: number): void {
+    if (tokens <= 0 || !this.tokenLimiter) return;
+    const now = Date.now();
+    if (now >= this.tpmWindowStart + this.tokenLimiter.duration) {
+      this.tpmLocalCounter = 0;
+      this.tpmWindowStart = now - (now % this.tokenLimiter.duration);
+    }
+    this.tpmLocalCounter += tokens;
   }
 
   /** Return the number of jobs currently being processed. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,20 @@ export interface WorkerOptions extends QueueOptions {
   maxStalledCount?: number;
   promotionInterval?: number;
   limiter?: { max: number; duration: number };
+  /** Token-per-minute rate limiting. Tracks total tokens consumed per time window.
+   *  Worker pauses fetching when either RPM limiter or TPM tokenLimiter is exceeded.
+   *  Tokens reported via job.reportTokens() or auto-extracted from job.reportUsage(). */
+  tokenLimiter?: {
+    /** Max tokens per window. */
+    maxTokens: number;
+    /** Window duration in milliseconds. */
+    duration: number;
+    /** Enforcement scope. Default: 'both'.
+     *  - 'queue': Valkey counter shared across all workers.
+     *  - 'worker': In-memory counter per worker.
+     *  - 'both': Local check first, then Valkey (optimal). */
+    scope?: 'queue' | 'worker' | 'both';
+  };
   backoffStrategies?: Record<string, (attemptsMade: number, err: Error) => number>;
   /** Lock duration in ms. The worker sends a heartbeat every lockDuration/2.
    *  Jobs with a recent heartbeat are not reclaimed as stalled.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,6 +121,7 @@ export function buildKeys(queueName: string, prefix = DEFAULT_PREFIX) {
     suspended: `${p}:suspended`,
     signals: (id: string) => `${p}:signals:${id}`,
     budget: (flowId: string) => `${p}:budget:${flowId}`,
+    tpm: `${p}:tpm`,
   };
 }
 
@@ -230,6 +231,7 @@ export const JOB_METADATA_FIELDS: readonly string[] = Object.freeze([
   'suspendedAt',
   'suspendTimeout',
   'signals',
+  'tpmTokens',
 ]);
 
 /**

--- a/tests/dual-rate-limit.test.ts
+++ b/tests/dual-rate-limit.test.ts
@@ -1,0 +1,624 @@
+/**
+ * Tests for dual-axis rate limiting (RPM + TPM).
+ *
+ * Run: npx vitest run tests/dual-rate-limit.test.ts
+ */
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+import { Batch, ClusterBatch } from '@glidemq/speedkey';
+import { Job } from '../src/job';
+import { buildKeys } from '../src/utils';
+import { TestQueue, TestWorker } from '../src/testing';
+
+vi.mock('@glidemq/speedkey');
+
+// ---- Unit tests (mocked client) ----
+
+function makeMockClient(overrides: Record<string, unknown> = {}) {
+  return {
+    fcall: vi.fn(),
+    hset: vi.fn().mockResolvedValue(1),
+    hget: vi.fn().mockResolvedValue(null),
+    hgetall: vi.fn().mockResolvedValue([]),
+    hmget: vi.fn().mockResolvedValue([]),
+    xadd: vi.fn().mockResolvedValue('1-0'),
+    smembers: vi.fn().mockResolvedValue(new Set()),
+    rpush: vi.fn().mockResolvedValue(1),
+    close: vi.fn(),
+    exec: vi.fn().mockResolvedValue([]),
+    incrBy: vi.fn().mockResolvedValue(0),
+    pexpire: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+const keys = buildKeys('test-queue');
+
+describe('Job.reportTokens (unit)', () => {
+  let mockClient: ReturnType<typeof makeMockClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = makeMockClient();
+  });
+
+  it('stores tpmTokens in the job hash', async () => {
+    const job = new Job(mockClient as any, keys, '1', 'llm-call', {}, {});
+    await job.reportTokens(500);
+
+    expect(mockClient.hset).toHaveBeenCalledWith(
+      keys.job('1'),
+      { tpmTokens: '500' },
+    );
+    expect(job.tpmTokens).toBe(500);
+  });
+
+  it('rejects negative token count', async () => {
+    const job = new Job(mockClient as any, keys, '1', 'llm-call', {}, {});
+    await expect(job.reportTokens(-1)).rejects.toThrow('Token count must not be negative');
+  });
+
+  it('overwrites previous value on second call', async () => {
+    const job = new Job(mockClient as any, keys, '1', 'llm-call', {}, {});
+    await job.reportTokens(100);
+    await job.reportTokens(200);
+
+    expect(job.tpmTokens).toBe(200);
+    expect(mockClient.hset).toHaveBeenCalledTimes(2);
+    expect(mockClient.hset).toHaveBeenLastCalledWith(
+      keys.job('1'),
+      { tpmTokens: '200' },
+    );
+  });
+
+  it('allows zero tokens', async () => {
+    const job = new Job(mockClient as any, keys, '1', 'llm-call', {}, {});
+    await job.reportTokens(0);
+
+    expect(mockClient.hset).toHaveBeenCalledWith(
+      keys.job('1'),
+      { tpmTokens: '0' },
+    );
+    expect(job.tpmTokens).toBe(0);
+  });
+});
+
+describe('Job.fromHash parses tpmTokens', () => {
+  let mockClient: ReturnType<typeof makeMockClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = makeMockClient();
+  });
+
+  it('parses tpmTokens from hash', () => {
+    const hash: Record<string, string> = {
+      name: 'test',
+      data: '{}',
+      opts: '{}',
+      timestamp: '1000',
+      attemptsMade: '0',
+      tpmTokens: '750',
+    };
+    const job = Job.fromHash(mockClient as any, keys, '1', hash);
+    expect(job.tpmTokens).toBe(750);
+  });
+
+  it('tpmTokens is undefined when not present', () => {
+    const hash: Record<string, string> = {
+      name: 'test',
+      data: '{}',
+      opts: '{}',
+      timestamp: '1000',
+      attemptsMade: '0',
+    };
+    const job = Job.fromHash(mockClient as any, keys, '1', hash);
+    expect(job.tpmTokens).toBeUndefined();
+  });
+});
+
+// ---- Testing mode tests ----
+
+describe('TestJob.reportTokens', () => {
+  let queue: TestQueue;
+
+  beforeEach(() => {
+    queue = new TestQueue('test-tpm');
+  });
+
+  it('stores tpmTokens on the TestJob', async () => {
+    const job = await queue.add('test', { prompt: 'hello' });
+    expect(job).not.toBeNull();
+    await job!.reportTokens(300);
+    expect(job!.tpmTokens).toBe(300);
+  });
+
+  it('rejects negative token count', async () => {
+    const job = await queue.add('test', { prompt: 'hello' });
+    await expect(job!.reportTokens(-1)).rejects.toThrow('Token count must not be negative');
+  });
+});
+
+describe('TestWorker TPM enforcement', () => {
+  it('delays processing when TPM limit is exceeded', async () => {
+    const queue = new TestQueue('test-tpm-delay');
+    const completionTimes: number[] = [];
+    const WINDOW_MS = 2000;
+
+    const worker = new TestWorker(queue, async (job: any) => {
+      await job.reportTokens(600);
+      completionTimes.push(Date.now());
+      return 'done';
+    }, {
+      tokenLimiter: { maxTokens: 1000, duration: WINDOW_MS },
+    });
+
+    // Add 3 jobs - first two consume 1200 tokens total (exceeds 1000 limit).
+    // Third job should be delayed until the window resets.
+    await queue.add('job1', {});
+    await queue.add('job2', {});
+    await queue.add('job3', {});
+
+    let completedCount = 0;
+    worker.on('completed', () => { completedCount++; });
+
+    const start = Date.now();
+    while (completedCount < 3 && Date.now() - start < 8000) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    expect(completedCount).toBe(3);
+    expect(completionTimes.length).toBe(3);
+    // Jobs 1 and 2 complete fast. After job 2, counter = 1200 > 1000.
+    // Job 3 must wait for window reset. The wait depends on window alignment,
+    // so we just verify there IS a meaningful delay (> 200ms).
+    const gap = completionTimes[2] - completionTimes[1];
+    expect(gap).toBeGreaterThanOrEqual(200);
+
+    await worker.close();
+    await queue.close();
+  });
+
+  it('reportUsage auto-feeds TPM when tokenLimiter is active', async () => {
+    const queue = new TestQueue('test-tpm-usage');
+    const completionTimes: number[] = [];
+    const WINDOW_MS = 2000;
+
+    const worker = new TestWorker(queue, async (job: any) => {
+      await job.reportUsage({ inputTokens: 400, outputTokens: 200 });
+      completionTimes.push(Date.now());
+      return 'done';
+    }, {
+      tokenLimiter: { maxTokens: 1000, duration: WINDOW_MS },
+    });
+
+    await queue.add('job1', {});
+    await queue.add('job2', {});
+    await queue.add('job3', {});
+
+    let completedCount = 0;
+    worker.on('completed', () => { completedCount++; });
+
+    const start = Date.now();
+    while (completedCount < 3 && Date.now() - start < 8000) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    expect(completedCount).toBe(3);
+    // Jobs 1 + 2 = 1200 tokens, exceeds 1000. Job 3 must wait for window reset.
+    const gap = completionTimes[2] - completionTimes[1];
+    expect(gap).toBeGreaterThanOrEqual(200);
+
+    await worker.close();
+    await queue.close();
+  });
+
+  it('allows processing when under the TPM limit', async () => {
+    const queue = new TestQueue('test-tpm-under');
+    const completionTimes: number[] = [];
+
+    const worker = new TestWorker(queue, async (job: any) => {
+      await job.reportTokens(100);
+      completionTimes.push(Date.now());
+      return 'done';
+    }, {
+      tokenLimiter: { maxTokens: 10000, duration: 5000 },
+    });
+
+    // 5 jobs x 100 tokens = 500 tokens - well under 10000 limit
+    for (let i = 0; i < 5; i++) {
+      await queue.add(`job${i}`, {});
+    }
+
+    let completedCount = 0;
+    worker.on('completed', () => { completedCount++; });
+
+    const start = Date.now();
+    while (completedCount < 5 && Date.now() - start < 3000) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    expect(completedCount).toBe(5);
+    // All should complete quickly - no significant delay
+    const totalTime = completionTimes[4] - completionTimes[0];
+    expect(totalTime).toBeLessThan(500);
+
+    await worker.close();
+    await queue.close();
+  });
+
+  it('uses max of reportTokens and reportUsage totalTokens', async () => {
+    const queue = new TestQueue('test-tpm-max');
+    const completionTimes: number[] = [];
+    const WINDOW_MS = 2000;
+
+    const worker = new TestWorker(queue, async (job: any) => {
+      // reportUsage gives 200 totalTokens, reportTokens gives 600
+      // Worker should use max(200, 600) = 600 for TPM tracking
+      await job.reportUsage({ inputTokens: 100, outputTokens: 100 });
+      await job.reportTokens(600);
+      completionTimes.push(Date.now());
+      return 'done';
+    }, {
+      tokenLimiter: { maxTokens: 1000, duration: WINDOW_MS },
+    });
+
+    await queue.add('job1', {});
+    await queue.add('job2', {});
+    await queue.add('job3', {});
+
+    let completedCount = 0;
+    worker.on('completed', () => { completedCount++; });
+
+    const start = Date.now();
+    while (completedCount < 3 && Date.now() - start < 8000) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    expect(completedCount).toBe(3);
+    // 600 tokens per job (from tpmTokens, since it's larger than 200).
+    // 2 jobs = 1200 > 1000. Third must wait.
+    const gap = completionTimes[2] - completionTimes[1];
+    expect(gap).toBeGreaterThanOrEqual(200);
+
+    await worker.close();
+    await queue.close();
+  });
+});
+
+describe('buildKeys includes tpm key', () => {
+  it('generates correct tpm key', () => {
+    const k = buildKeys('my-queue');
+    expect(k.tpm).toBe('glide:{my-queue}:tpm');
+  });
+
+  it('respects custom prefix', () => {
+    const k = buildKeys('my-queue', 'custom');
+    expect(k.tpm).toBe('custom:{my-queue}:tpm');
+  });
+});
+
+// ---- Integration tests (require Valkey) ----
+
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
+
+const QueueImpl = require('../dist/queue').Queue;
+const WorkerImpl = require('../dist/worker').Worker;
+
+describeEachMode('Dual-axis rate limiting (TPM)', (CONNECTION) => {
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    cleanupClient.close();
+  });
+
+  async function cleanupTpmKeys(queueName: string) {
+    const tpmPattern = `glide:{${queueName}}:tpm:*`;
+    try {
+      if (cleanupClient.constructor.name === 'GlideClusterClient') {
+        const { ClusterScanCursor } = require('@glidemq/speedkey');
+        let cursor = new ClusterScanCursor();
+        while (!cursor.isFinished()) {
+          const [nextCursor, found] = await cleanupClient.scan(cursor, { match: tpmPattern, count: 100 });
+          cursor = nextCursor;
+          if (found.length > 0) await cleanupClient.del(found.map((k: any) => String(k)));
+        }
+      } else {
+        let cursor = '0';
+        do {
+          const result = await cleanupClient.scan(cursor, { match: tpmPattern, count: 100 });
+          cursor = result[0] as string;
+          const found = result[1] as string[];
+          if (found.length > 0) await cleanupClient.del(found);
+        } while (cursor !== '0');
+      }
+    } catch { /* ignore */ }
+  }
+
+  it('reportTokens persists tpmTokens in the job hash', async () => {
+    const Q = `tpm-persist-${Date.now()}`;
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.reportTokens(1500);
+      return 'done';
+    }, { connection: CONNECTION });
+
+    const added = await queue.add('test-report-tokens', { prompt: 'test' });
+    await waitFor(async () => {
+      const fetched = await queue.getJob(added.id);
+      return fetched?.finishedOn !== undefined;
+    });
+
+    const fetched = await queue.getJob(added.id);
+    expect(fetched.tpmTokens).toBe(1500);
+
+    await worker.close(true);
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+  });
+
+  it('worker pauses when TPM limit is exceeded (scope: worker)', async () => {
+    const Q = `tpm-wscope-${Date.now()}`;
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const completionTimes: number[] = [];
+    // Use a 2s window for reliability
+    const WINDOW_MS = 2000;
+
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.reportTokens(600);
+      completionTimes.push(Date.now());
+      return 'done';
+    }, {
+      connection: CONNECTION,
+      tokenLimiter: { maxTokens: 1000, duration: WINDOW_MS, scope: 'worker' },
+    });
+
+    await queue.add('tpm-w1', {});
+    await queue.add('tpm-w2', {});
+    await queue.add('tpm-w3', {});
+
+    await waitFor(async () => completionTimes.length >= 3, 10000);
+
+    expect(completionTimes.length).toBe(3);
+    // First two: 1200 tokens > 1000 limit. Third must wait for window reset.
+    // Window alignment means the gap can be anywhere from ~0ms to ~2000ms.
+    // We just verify the gap exceeds some minimum (> 200ms).
+    const gap = completionTimes[2] - completionTimes[1];
+    expect(gap).toBeGreaterThanOrEqual(200);
+
+    await worker.close(true);
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    await cleanupTpmKeys(Q);
+  });
+
+  it('worker pauses when TPM limit is exceeded (scope: queue)', async () => {
+    const Q = `tpm-qscope-${Date.now()}`;
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const completionTimes: number[] = [];
+    const WINDOW_MS = 2000;
+
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.reportTokens(600);
+      completionTimes.push(Date.now());
+      return 'done';
+    }, {
+      connection: CONNECTION,
+      tokenLimiter: { maxTokens: 1000, duration: WINDOW_MS, scope: 'queue' },
+    });
+
+    await queue.add('tpm-q1', {});
+    await queue.add('tpm-q2', {});
+    await queue.add('tpm-q3', {});
+
+    await waitFor(async () => completionTimes.length >= 3, 10000);
+
+    expect(completionTimes.length).toBe(3);
+    const gap = completionTimes[2] - completionTimes[1];
+    expect(gap).toBeGreaterThanOrEqual(200);
+
+    await worker.close(true);
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    await cleanupTpmKeys(Q);
+  });
+
+  it('worker pauses when TPM limit is exceeded (scope: both)', async () => {
+    const Q = `tpm-bscope-${Date.now()}`;
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const completionTimes: number[] = [];
+    const WINDOW_MS = 2000;
+
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.reportTokens(600);
+      completionTimes.push(Date.now());
+      return 'done';
+    }, {
+      connection: CONNECTION,
+      tokenLimiter: { maxTokens: 1000, duration: WINDOW_MS, scope: 'both' },
+    });
+
+    await queue.add('tpm-b1', {});
+    await queue.add('tpm-b2', {});
+    await queue.add('tpm-b3', {});
+
+    await waitFor(async () => completionTimes.length >= 3, 10000);
+
+    expect(completionTimes.length).toBe(3);
+    const gap = completionTimes[2] - completionTimes[1];
+    expect(gap).toBeGreaterThanOrEqual(200);
+
+    await worker.close(true);
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    await cleanupTpmKeys(Q);
+  });
+
+  it('worker resumes after TPM window expires', async () => {
+    const Q = `tpm-resume-${Date.now()}`;
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const completionTimes: number[] = [];
+    const WINDOW_MS = 2000;
+
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.reportTokens(1100);
+      completionTimes.push(Date.now());
+      return 'done';
+    }, {
+      connection: CONNECTION,
+      tokenLimiter: { maxTokens: 1000, duration: WINDOW_MS, scope: 'worker' },
+    });
+
+    await queue.add('tpm-resume-1', {});
+    await queue.add('tpm-resume-2', {});
+
+    await waitFor(async () => completionTimes.length >= 2, 10000);
+
+    expect(completionTimes.length).toBe(2);
+    // Single job of 1100 tokens exceeds 1000. Second job waits for new window.
+    const gap = completionTimes[1] - completionTimes[0];
+    expect(gap).toBeGreaterThanOrEqual(200);
+
+    await worker.close(true);
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    await cleanupTpmKeys(Q);
+  });
+
+  it('RPM and TPM enforced independently', async () => {
+    const Q = `tpm-indep-${Date.now()}`;
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const completedNames: string[] = [];
+
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      // Report minimal tokens - TPM should not block
+      await job.reportTokens(10);
+      completedNames.push(job.name);
+      return 'done';
+    }, {
+      connection: CONNECTION,
+      limiter: { max: 100, duration: 5000 },
+      tokenLimiter: { maxTokens: 100000, duration: 5000, scope: 'worker' },
+    });
+
+    await queue.add('rpm-tpm-1', {});
+    await queue.add('rpm-tpm-2', {});
+    await queue.add('rpm-tpm-3', {});
+
+    await waitFor(async () => completedNames.length >= 3, 8000);
+
+    expect(completedNames.length).toBe(3);
+
+    await worker.close(true);
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    await cleanupTpmKeys(Q);
+  });
+
+  it('one large-token job blocks until window resets', async () => {
+    const Q = `tpm-large-${Date.now()}`;
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const completionTimes: number[] = [];
+    const WINDOW_MS = 2000;
+
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.reportTokens(5000);
+      completionTimes.push(Date.now());
+      return 'done';
+    }, {
+      connection: CONNECTION,
+      tokenLimiter: { maxTokens: 5000, duration: WINDOW_MS, scope: 'worker' },
+    });
+
+    await queue.add('big-token-1', {});
+    await queue.add('big-token-2', {});
+
+    await waitFor(async () => completionTimes.length >= 2, 10000);
+
+    expect(completionTimes.length).toBe(2);
+    const gap = completionTimes[1] - completionTimes[0];
+    // The delay depends on window alignment, but must be non-trivial.
+    expect(gap).toBeGreaterThanOrEqual(200);
+
+    await worker.close(true);
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    await cleanupTpmKeys(Q);
+  });
+
+  it('reportUsage auto-feeds TPM counter', async () => {
+    const Q = `tpm-auto-${Date.now()}`;
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const completionTimes: number[] = [];
+    const WINDOW_MS = 2000;
+
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.reportUsage({ inputTokens: 400, outputTokens: 200 });
+      completionTimes.push(Date.now());
+      return 'done';
+    }, {
+      connection: CONNECTION,
+      tokenLimiter: { maxTokens: 1000, duration: WINDOW_MS, scope: 'worker' },
+    });
+
+    await queue.add('auto-tpm-1', {});
+    await queue.add('auto-tpm-2', {});
+    await queue.add('auto-tpm-3', {});
+
+    await waitFor(async () => completionTimes.length >= 3, 10000);
+
+    expect(completionTimes.length).toBe(3);
+    // 600 tokens per job via usage. 2 jobs = 1200 > 1000. Third must wait.
+    const gap = completionTimes[2] - completionTimes[1];
+    expect(gap).toBeGreaterThanOrEqual(200);
+
+    await worker.close(true);
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    await cleanupTpmKeys(Q);
+  });
+
+  it('queue-scope TPM uses shared Valkey counter', async () => {
+    // Verify the Valkey counter is actually incremented and readable.
+    // We don't test multi-worker blocking (too flaky with timing) but verify the
+    // shared counter mechanics directly.
+    const Q = `tpm-shared-${Date.now()}`;
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    const { buildKeys: buildK } = require('../dist/utils') as typeof import('../src/utils');
+    const k = buildK(Q);
+    const WINDOW_MS = 5000;
+
+    const worker = new WorkerImpl(Q, async (job: any) => {
+      await job.reportTokens(500);
+      return 'done';
+    }, {
+      connection: CONNECTION,
+      tokenLimiter: { maxTokens: 10000, duration: WINDOW_MS, scope: 'queue' },
+    });
+
+    // Add 3 jobs - each reports 500 tokens
+    await queue.add('shared-1', {});
+    await queue.add('shared-2', {});
+    await queue.add('shared-3', {});
+
+    await waitFor(async () => {
+      const counts = await queue.getJobCounts();
+      return counts.completed >= 3;
+    }, 8000);
+
+    // Check the Valkey TPM counter - should have 1500 tokens
+    const windowId = Math.floor(Date.now() / WINDOW_MS);
+    const tpmKey = `${k.tpm}:${windowId}`;
+    const counterVal = await cleanupClient.incrBy(tpmKey, 0);
+    expect(Number(counterVal)).toBe(1500);
+
+    await worker.close(true);
+    await queue.close();
+    await flushQueue(cleanupClient, Q);
+    await cleanupTpmKeys(Q);
+  });
+});

--- a/tests/helpers/fixture.ts
+++ b/tests/helpers/fixture.ts
@@ -131,6 +131,7 @@ export async function flushQueue(client: any, queueName: string, prefix = 'glide
     `${pfx}:w:*`,
     `${pfx}:signals:*`,
     `${pfx}:budget:*`,
+    `${pfx}:tpm:*`,
   ]) {
     try {
       if (client.constructor.name === 'GlideClusterClient') {


### PR DESCRIPTION
## Summary

- `tokenLimiter` on WorkerOptions: tracks tokens-per-minute alongside existing RPM `limiter`
- `Job.reportTokens(count)` for explicit token tracking
- `reportUsage()` auto-feeds TPM via `totalTokens`
- Three scopes: `queue` (Valkey shared), `worker` (local), `both` (default)
- Window-aligned counters with PEXPIRE auto-cleanup
- Worker pauses fetching when either RPM or TPM is exceeded

## API

```ts
const worker = new Worker('ai', processor, {
  connection: CONNECTION,
  limiter: { max: 60, duration: 60000 },       // 60 RPM
  tokenLimiter: { maxTokens: 100000, duration: 60000 }, // 100K TPM
});

// In processor
await job.reportUsage({ totalTokens: 1500 });  // auto-feeds TPM
// or explicitly
await job.reportTokens(1500);
```

## Test plan

- [x] 32 tests passing (unit + testing-mode + standalone + cluster)
- [x] `npm run build` clean