### PR TITLE
feat: 18 real-world AI examples with framework integrations

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   valkey:
-    image: valkey/valkey:8.0
+    image: valkey/valkey-bundle:latest
     ports:
       - "6379:6379"
     command: valkey-server --save "" --appendonly no --maxmemory-policy noeviction

--- a/examples/adaptive-timeout.ts
+++ b/examples/adaptive-timeout.ts
@@ -1,0 +1,116 @@
+/**
+ * Adaptive Timeout - per-job lockDuration
+ *
+ * Real scenario: Mixed AI workload with fast classification and slow generation.
+ * Each job type gets a different lockDuration so heartbeats and stall detection
+ * match the expected processing time.
+ *
+ * Run: npx tsx examples/adaptive-timeout.ts
+ */
+import { Queue, Worker } from '../dist/index';
+import { chat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `adaptive-timeout-${Date.now()}`;
+
+interface TaskResult {
+  name: string;
+  lockDuration: number;
+  processingTime: number;
+  result: string;
+}
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  const results: TaskResult[] = [];
+
+  const worker = new Worker(QUEUE, async (job) => {
+    const { task, prompt, model } = job.data;
+    const lock = job.opts.lockDuration ?? 30_000;
+    const start = Date.now();
+
+    console.log(`[${task}] Started (lockDuration=${lock}ms, heartbeat every ${lock / 2}ms)`);
+
+    const messages: Message[] = [
+      { role: 'system', content: 'Be concise.' },
+      { role: 'user', content: prompt },
+    ];
+
+    // maxTokens varies by task type
+    const maxTokens = task === 'classify' ? 20 : task === 'summarize' ? 80 : 150;
+    const result = await chat(model, messages, maxTokens);
+    const elapsed = Date.now() - start;
+
+    console.log(`[${task}] Done in ${elapsed}ms - "${result.content.slice(0, 60)}..."`);
+
+    return { name: task, lockDuration: lock, processingTime: elapsed, result: result.content };
+  }, {
+    connection: CONNECTION,
+    concurrency: 1,
+    lockDuration: 30_000,
+  });
+
+  worker.on('completed', (_job, result) => { results.push(result); });
+
+  // Enqueue 3 jobs with different lockDurations
+  const jobs = [
+    {
+      name: 'classify',
+      data: {
+        task: 'classify',
+        prompt: 'Classify this as positive/negative/neutral: "The product works great!"',
+        model: MODELS.fast,
+      },
+      opts: { lockDuration: 5_000 },
+    },
+    {
+      name: 'summarize',
+      data: {
+        task: 'summarize',
+        prompt: 'Summarize in one sentence: Message queues decouple producers from consumers, enabling async processing.',
+        model: MODELS.nano,
+      },
+      opts: { lockDuration: 30_000 },
+    },
+    {
+      name: 'generate',
+      data: {
+        task: 'generate',
+        prompt: 'Write a product description for a wireless noise-canceling headphone.',
+        model: MODELS.fast,
+      },
+      opts: { lockDuration: 120_000 },
+    },
+  ];
+
+  for (const j of jobs) {
+    await queue.add(j.name, j.data, j.opts);
+  }
+  console.log(`Enqueued ${jobs.length} jobs with varying lockDurations\n`);
+
+  // Wait for all to complete
+  const deadline = Date.now() + 60_000;
+  while (results.length < 3 && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  console.log('\n--- Results ---');
+  for (const r of results) {
+    console.log(`  ${r.name}: lock=${r.lockDuration}ms, processed in ${r.processingTime}ms`);
+  }
+
+  if (results.length < 3) {
+    console.log('[WARN] Not all jobs completed within timeout');
+  }
+
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+
+  console.log('\n[OK] Adaptive timeout example complete');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/agent-memory.ts
+++ b/examples/agent-memory.ts
@@ -1,0 +1,143 @@
+/**
+ * Agent Memory - Chatbot with persistent memory
+ *
+ * Real scenario: Multi-turn chatbot where each turn is a queued job. Long-term
+ * memory is stored in a Valkey hash. The worker loads prior context from memory,
+ * calls the LLM with conversation history, and stores new entries. Finally,
+ * searchJobs finds past interactions by user.
+ *
+ * Run: npx tsx examples/agent-memory.ts
+ */
+import { GlideClient } from '@glidemq/speedkey';
+import { Queue, Worker } from '../dist/index';
+import { chat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `agent-memory-${Date.now()}`;
+const MEMORY_KEY = `memory:${Date.now()}`;
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  const valkey = await GlideClient.createClient({ addresses: CONNECTION.addresses });
+
+  const completedResults: { turn: number; reply: string }[] = [];
+
+  const worker = new Worker(QUEUE, async (job) => {
+    const { userId, userMessage, turn } = job.data;
+
+    // Load memory (prior conversation turns)
+    const rawMemory = await valkey.hgetall(MEMORY_KEY);
+    const history: Message[] = [];
+
+    if (rawMemory && rawMemory.length > 0) {
+      // rawMemory is HashDataType: { field, value }[]
+      const sorted = [...rawMemory].sort((a, b) =>
+        String(a.field).localeCompare(String(b.field))
+      );
+      for (const entry of sorted) {
+        const parsed = JSON.parse(String(entry.value));
+        history.push({ role: 'user', content: parsed.user });
+        history.push({ role: 'assistant', content: parsed.assistant });
+      }
+    }
+
+    // Build messages with memory
+    const messages: Message[] = [
+      { role: 'system', content: `You are a helpful assistant. User: ${userId}. Answer concisely.` },
+      ...history,
+      { role: 'user', content: userMessage },
+    ];
+
+    const result = await chat(MODELS.fast, messages, 100);
+    console.log(`[Turn ${turn}] User: ${userMessage}`);
+    console.log(`[Turn ${turn}] Bot: ${result.content}\n`);
+
+    // Store this turn in memory
+    await valkey.hset(MEMORY_KEY, [
+      { field: `turn-${turn}`, value: JSON.stringify({ user: userMessage, assistant: result.content }) },
+    ]);
+
+    await job.reportUsage({
+      model: result.model,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+    });
+
+    return { reply: result.content, tokens: result.totalTokens };
+  }, { connection: CONNECTION, concurrency: 1 });
+
+  worker.on('completed', (job, result) => {
+    completedResults.push({ turn: job.data.turn, reply: result.reply });
+  });
+
+  // Turn 1: initial question
+  const job1 = await queue.add('chat-turn', {
+    userId: 'user-42',
+    userMessage: 'My name is Alice and I am building an AI chatbot. What framework should I use?',
+    turn: 1,
+  });
+
+  // Wait for turn 1
+  await waitForJobs(completedResults, 1);
+
+  // Turn 2: follow-up that tests memory
+  const job2 = await queue.add('chat-turn', {
+    userId: 'user-42',
+    userMessage: 'Can you remind me what I said my name was and what I am building?',
+    turn: 2,
+  });
+
+  await waitForJobs(completedResults, 2);
+
+  // Turn 3: different user
+  const job3 = await queue.add('chat-turn', {
+    userId: 'user-99',
+    userMessage: 'What is a message queue?',
+    turn: 3,
+  });
+
+  await waitForJobs(completedResults, 3);
+
+  // Search jobs by user
+  console.log('--- Search: jobs from user-42 ---');
+  const user42Jobs = await queue.searchJobs({ data: { userId: 'user-42' } });
+  console.log(`  Found ${user42Jobs.length} job(s) for user-42`);
+  for (const j of user42Jobs) {
+    console.log(`  id=${j.id} turn=${j.data.turn} message="${j.data.userMessage.slice(0, 50)}..."`);
+  }
+
+  console.log('\n--- Search: jobs from user-99 ---');
+  const user99Jobs = await queue.searchJobs({ data: { userId: 'user-99' } });
+  console.log(`  Found ${user99Jobs.length} job(s) for user-99`);
+
+  // Verify memory was stored
+  console.log('\n--- Memory contents ---');
+  const mem = await valkey.hgetall(MEMORY_KEY);
+  if (mem) {
+    for (const entry of mem) {
+      const parsed = JSON.parse(String(entry.value));
+      console.log(`  ${entry.field}: user="${parsed.user.slice(0, 40)}..." assistant="${parsed.assistant.slice(0, 40)}..."`);
+    }
+  }
+
+  // Cleanup
+  await valkey.del([MEMORY_KEY]);
+  valkey.close();
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+
+  console.log('\n[OK] Agent memory example complete');
+  process.exit(0);
+}
+
+async function waitForJobs(results: any[], target: number) {
+  const deadline = Date.now() + 45_000;
+  while (results.length < target && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 300));
+  }
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/ai-agent-loop.ts
+++ b/examples/ai-agent-loop.ts
@@ -1,0 +1,141 @@
+/**
+ * AI Agent Loop - ReAct-style agent
+ *
+ * Combines: suspend/resume + fallbacks + usage tracking + TPM limiter
+ *
+ * The agent receives a task and iterates through a plan/execute/observe loop.
+ * Each step makes an LLM call, tracks usage, and decides whether to continue
+ * or ask for human input. TPM limiter prevents overwhelming the API.
+ *
+ * Run: npx tsx examples/ai-agent-loop.ts
+ */
+import { Queue, Worker } from '../dist/index';
+import { chat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `ai-agent-${Date.now()}`;
+
+const TOOLS: Record<string, (input: string) => string> = {
+  search: (q) => `Search results for "${q}": Found 3 articles about ${q}.`,
+  calculate: (expr) => `Calculation: ${expr} = 42`,
+  lookup: (key) => `Database lookup for "${key}": Record found with status=active.`,
+};
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  let finalResult: any = null;
+
+  const worker = new Worker(QUEUE, async (job) => {
+    const { task, history = [], iteration = 0 } = job.data;
+
+    // Check for human signal on resume
+    if (job.signals.length > 0) {
+      const sig = job.signals[0];
+      const data = typeof sig.data === 'string' ? JSON.parse(sig.data) : sig.data;
+      console.log(`[Agent] Received human input: "${data.input}"`);
+      // Continue with human's answer as context
+      history.push({ role: 'user' as const, content: `Human provided: ${data.input}` });
+    }
+
+    if (iteration >= 4) {
+      console.log('[Agent] Max iterations reached. Summarizing...');
+      const result = await chat(MODELS.fast, [
+        ...history,
+        { role: 'user', content: 'Summarize what you accomplished in one sentence.' },
+      ], 60);
+      await job.reportUsage({ model: result.model, inputTokens: result.inputTokens, outputTokens: result.outputTokens });
+      return { status: 'done', summary: result.content, iterations: iteration };
+    }
+
+    // Step 1: Plan
+    console.log(`\n[Agent] Iteration ${iteration + 1} - Planning...`);
+    const planMessages: Message[] = [
+      { role: 'system', content: `You are an AI agent. Available tools: search, calculate, lookup. Task: ${task}\nRespond with EXACTLY one line in format: ACTION: tool_name(input) OR DONE: summary OR ASK: question for human` },
+      ...history,
+      { role: 'user', content: iteration === 0 ? 'What is your first action?' : 'What is your next action?' },
+    ];
+
+    const plan = await chat(MODELS.fast, planMessages, 50);
+    await job.reportUsage({ model: plan.model, inputTokens: plan.inputTokens, outputTokens: plan.outputTokens });
+    console.log(`[Agent] Plan: ${plan.content.trim()}`);
+
+    const action = plan.content.trim();
+    history.push({ role: 'assistant' as const, content: action });
+
+    // Step 2: Check if done
+    if (action.startsWith('DONE:')) {
+      return { status: 'done', summary: action.slice(5).trim(), iterations: iteration + 1 };
+    }
+
+    // Step 3: Check if needs human input
+    if (action.startsWith('ASK:')) {
+      console.log(`[Agent] Needs human input: ${action.slice(4).trim()}`);
+      await job.suspend({ reason: 'needs-human-input' });
+      return; // unreachable
+    }
+
+    // Step 4: Execute tool
+    const toolMatch = action.match(/ACTION:\s*(\w+)\((.+?)\)/);
+    let observation: string;
+    if (toolMatch) {
+      const [, toolName, toolInput] = toolMatch;
+      const tool = TOOLS[toolName];
+      observation = tool ? tool(toolInput) : `Unknown tool: ${toolName}`;
+      console.log(`[Agent] Tool result: ${observation}`);
+    } else {
+      observation = 'Could not parse action. Try again with format: ACTION: tool_name(input)';
+    }
+
+    history.push({ role: 'user' as const, content: `Observation: ${observation}` });
+
+    // Step 5: Update data then re-enqueue (moveToDelayed throws, so updateData must come first)
+    await job.updateData({ task, history, iteration: iteration + 1 });
+    await job.moveToDelayed(Date.now() + 100);
+  }, {
+    connection: CONNECTION,
+    concurrency: 1,
+    tokenLimiter: { maxTokens: 500, duration: 10_000 },
+    stalledInterval: 30_000,
+  });
+
+  worker.on('completed', (_job, result) => { finalResult = result; });
+
+  await queue.add('agent-task', {
+    task: 'Find information about message queues and calculate the total number of articles found.',
+    history: [],
+    iteration: 0,
+  }, {
+    fallbacks: [
+      { model: MODELS.nano },
+      { model: MODELS.fast },
+    ],
+  });
+
+  console.log('Agent started. Processing task...');
+
+  // Wait for completion or suspension
+  const deadline = Date.now() + 60_000;
+  while (!finalResult && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  if (finalResult) {
+    console.log('\n--- Agent Result ---');
+    console.log(`  Status: ${finalResult.status}`);
+    console.log(`  Iterations: ${finalResult.iterations}`);
+    console.log(`  Summary: ${finalResult.summary}`);
+  } else {
+    console.log('\n[WARN] Agent did not complete in time (may be waiting for human input)');
+  }
+
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+
+  console.log('\n[OK] AI agent loop example complete');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/broadcast-events.ts
+++ b/examples/broadcast-events.ts
@@ -1,0 +1,106 @@
+/**
+ * Broadcast Events - Event-driven AI notifications
+ *
+ * Real scenario: AI system publishes events (inference completed, failed,
+ * billing usage) to a broadcast channel. Three BroadcastWorkers with
+ * subject filters receive relevant events: a logger (all), a billing
+ * service (billing only), and an alerts service (failures only).
+ *
+ * Run: npx tsx examples/broadcast-events.ts
+ */
+import { Broadcast, BroadcastWorker } from '../dist/index';
+import { CONNECTION } from './llm';
+
+const CHANNEL = `ai-events-${Date.now()}`;
+
+async function main() {
+  const broadcast = new Broadcast(CHANNEL, { connection: CONNECTION });
+
+  const received: Record<string, string[]> = {
+    logger: [],
+    billing: [],
+    alerts: [],
+  };
+
+  // Worker 1: Logger - receives ALL ai events
+  const logger = new BroadcastWorker(CHANNEL, async (job) => {
+    received.logger.push(job.data.subject);
+    console.log(`  [logger]  ${job.data.subject}: ${JSON.stringify(job.data.payload)}`);
+  }, {
+    connection: CONNECTION,
+    subscription: 'logger',
+    subjects: ['ai.>'],
+  });
+
+  // Worker 2: Billing - only ai.billing.* events
+  const billing = new BroadcastWorker(CHANNEL, async (job) => {
+    received.billing.push(job.data.subject);
+    console.log(`  [billing] ${job.data.subject}: cost=$${job.data.payload.cost}`);
+  }, {
+    connection: CONNECTION,
+    subscription: 'billing',
+    subjects: ['ai.billing.*'],
+  });
+
+  // Worker 3: Alerts - only ai.inference.failed events
+  const alerts = new BroadcastWorker(CHANNEL, async (job) => {
+    received.alerts.push(job.data.subject);
+    console.log(`  [alerts]  ${job.data.subject}: ${job.data.payload.error}`);
+  }, {
+    connection: CONNECTION,
+    subscription: 'alerts',
+    subjects: ['ai.inference.failed'],
+  });
+
+  // Give workers time to initialize
+  await new Promise(r => setTimeout(r, 1000));
+
+  // Publish 5 events
+  const events = [
+    { subject: 'ai.inference.completed', payload: { model: 'gpt-4', tokens: 150, latencyMs: 800 } },
+    { subject: 'ai.inference.completed', payload: { model: 'gpt-3.5', tokens: 80, latencyMs: 300 } },
+    { subject: 'ai.inference.failed', payload: { model: 'gpt-4', error: 'Rate limit exceeded' } },
+    { subject: 'ai.billing.usage', payload: { userId: 'user-42', cost: 0.015, tokens: 230 } },
+    { subject: 'ai.inference.completed', payload: { model: 'gpt-4', tokens: 200, latencyMs: 1200 } },
+  ];
+
+  console.log(`Publishing ${events.length} events...\n`);
+  for (const evt of events) {
+    await broadcast.publish(evt.subject, { subject: evt.subject, payload: evt.payload });
+  }
+
+  // Wait for events to be processed
+  const deadline = Date.now() + 15_000;
+  const expectedLogger = 5;
+  const expectedBilling = 1;
+  const expectedAlerts = 1;
+
+  while (Date.now() < deadline) {
+    if (
+      received.logger.length >= expectedLogger &&
+      received.billing.length >= expectedBilling &&
+      received.alerts.length >= expectedAlerts
+    ) break;
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  // Summary
+  console.log('\n--- Event Distribution ---');
+  console.log(`  logger (ai.>):              ${received.logger.length} event(s) - ${received.logger.join(', ')}`);
+  console.log(`  billing (ai.billing.*):     ${received.billing.length} event(s) - ${received.billing.join(', ')}`);
+  console.log(`  alerts (ai.inference.failed): ${received.alerts.length} event(s) - ${received.alerts.join(', ')}`);
+
+  // Cleanup
+  await logger.close(true);
+  await billing.close(true);
+  await alerts.close(true);
+  await broadcast.close();
+
+  console.log('\n[OK] Broadcast events example complete');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/budget-cap.ts
+++ b/examples/budget-cap.ts
@@ -1,0 +1,117 @@
+/**
+ * Budget Cap - budget middleware
+ *
+ * Real scenario: Prevent a runaway AI agent from burning through token budget.
+ * A flow with 5 child jobs has a budget of 200 total tokens. After 3-4 jobs,
+ * the budget is exceeded and remaining jobs fail with "Budget exceeded".
+ *
+ * Run: npx tsx examples/budget-cap.ts
+ */
+import { Queue, Worker, FlowProducer } from '../dist/index';
+import { chat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `budget-cap-${Date.now()}`;
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  const flow = new FlowProducer({ connection: CONNECTION });
+  const completedJobs: { name: string; tokens: number }[] = [];
+  const failedJobs: { name: string; reason: string }[] = [];
+
+  const worker = new Worker(QUEUE, async (job) => {
+    if (job.name === 'budget-parent') {
+      const children = await job.getChildrenValues();
+      return { childCount: Object.keys(children).length };
+    }
+
+    const messages: Message[] = [
+      { role: 'user', content: job.data.prompt },
+    ];
+
+    const result = await chat(MODELS.fast, messages, 40);
+
+    await job.reportUsage({
+      model: result.model,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+    });
+
+    // Use parentId to check flow-level budget state
+    const parentId = job.parentId;
+    if (parentId) {
+      const budget = await queue.getFlowBudget(parentId);
+      console.log(`  [${job.name}] ${result.totalTokens} tokens | Budget: ${budget?.usedTokens ?? '?'}/${budget?.maxTotalTokens ?? '?'} tokens, exceeded=${budget?.exceeded}`);
+    }
+
+    return { tokens: result.totalTokens, content: result.content.slice(0, 50) };
+  }, { connection: CONNECTION, concurrency: 1 });
+
+  worker.on('completed', (job, result) => {
+    if (job.name !== 'budget-parent') {
+      completedJobs.push({ name: job.name, tokens: result.tokens });
+    }
+  });
+  worker.on('failed', (job, err) => {
+    failedJobs.push({ name: job.name, reason: err.message });
+  });
+
+  const prompts = [
+    'What is 1+1?',
+    'Name a color.',
+    'What is the sun?',
+    'Name an ocean.',
+    'What is code?',
+  ];
+
+  const node = await flow.add(
+    {
+      name: 'budget-parent',
+      queueName: QUEUE,
+      data: { task: 'aggregate' },
+      children: prompts.map((prompt, i) => ({
+        name: `step-${i + 1}`,
+        queueName: QUEUE,
+        data: { prompt },
+      })),
+    },
+    { budget: { maxTotalTokens: 200, onExceeded: 'fail' } },
+  );
+
+  const flowId = node.job.id;
+  console.log(`Flow created: parent=${flowId}, budget=200 tokens, children=${node.children!.length}`);
+  console.log('');
+
+  // Wait for jobs to process
+  const deadline = Date.now() + 60_000;
+  while (completedJobs.length + failedJobs.length < 5 && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  console.log('\n--- Summary ---');
+  console.log(`  Completed: ${completedJobs.length}`);
+  for (const j of completedJobs) {
+    console.log(`    ${j.name}: ${j.tokens} tokens`);
+  }
+  console.log(`  Failed: ${failedJobs.length}`);
+  for (const j of failedJobs) {
+    console.log(`    ${j.name}: ${j.reason}`);
+  }
+
+  const finalBudget = await queue.getFlowBudget(flowId);
+  if (finalBudget) {
+    console.log(`  Final budget state: ${finalBudget.usedTokens}/${finalBudget.maxTotalTokens} tokens, exceeded=${finalBudget.exceeded}`);
+  }
+
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+  await flow.close();
+
+  console.log('\n[OK] Budget cap example complete');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/content-pipeline.ts
+++ b/examples/content-pipeline.ts
@@ -1,0 +1,188 @@
+/**
+ * Content Pipeline - content moderation with streaming + human approval + fallbacks + budget
+ *
+ * Flow:
+ * 1. AI classifies user-submitted content (fast model)
+ * 2. If borderline, suspends for human review
+ * 3. If approved, AI generates a polished version (streaming, with fallback models)
+ * Budget cap prevents excessive generation costs.
+ *
+ * Run: npx tsx examples/content-pipeline.ts
+ */
+import { Queue, Worker, FlowProducer } from '../dist/index';
+import { chat, streamChat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `content-pipeline-${Date.now()}`;
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  const flow = new FlowProducer({ connection: CONNECTION });
+  let pipelineDone = false;
+  let pipelineResult: any = null;
+
+  const worker = new Worker(QUEUE, async (job) => {
+    const { step } = job.data;
+
+    if (step === 'classify') {
+      console.log('[classify] Analyzing content...');
+      const result = await chat(MODELS.fast, [
+        { role: 'system', content: 'Classify the following content as: safe, borderline, or unsafe. Respond with exactly one word.' },
+        { role: 'user', content: job.data.content },
+      ], 10);
+
+      await job.reportUsage({ model: result.model, inputTokens: result.inputTokens, outputTokens: result.outputTokens });
+
+      const classification = result.content.trim().toLowerCase();
+      console.log(`[classify] Result: ${classification}`);
+      return { classification, tokens: result.totalTokens };
+    }
+
+    if (step === 'moderate') {
+      // Check classification from sibling job
+      const children = await job.getChildrenValues();
+      const classifyResult = Object.values(children).find((v: any) => v?.classification);
+      const classification = (classifyResult as any)?.classification ?? 'borderline';
+
+      if (classification === 'unsafe') {
+        return { action: 'rejected', reason: 'Content classified as unsafe' };
+      }
+
+      if (classification === 'borderline') {
+        // Check if we have a signal from human review
+        if (job.signals.length > 0) {
+          const sig = job.signals[0];
+          const data = typeof sig.data === 'string' ? JSON.parse(sig.data) : sig.data;
+          if (data.action === 'approve') {
+            console.log('[moderate] Human approved. Proceeding to polish.');
+            return { action: 'approved' };
+          }
+          return { action: 'rejected', reason: data.reason || 'Human rejected' };
+        }
+
+        console.log('[moderate] Content is borderline. Suspending for human review...');
+        console.log(`\n  Content: "${job.data.content}"\n`);
+        await job.suspend({ reason: 'borderline-content-review' });
+        return; // unreachable
+      }
+
+      return { action: 'approved' };
+    }
+
+    if (step === 'polish') {
+      console.log('[polish] Generating polished version (streaming)...');
+
+      // Use fallback model from chain if primary fails
+      const fallback = job.currentFallback;
+      const model = fallback ? fallback.model : MODELS.fast;
+
+      const messages: Message[] = [
+        { role: 'system', content: 'Rewrite the following content to be more professional and engaging. Keep it concise (2-3 sentences).' },
+        { role: 'user', content: job.data.content },
+      ];
+
+      let full = '';
+      let inTok = 0, outTok = 0;
+      process.stdout.write('\n  ');
+      for await (const chunk of streamChat(model, messages, 150)) {
+        if (chunk.type === 'token') {
+          process.stdout.write(chunk.content);
+          await job.stream({ t: chunk.content });
+          full += chunk.content;
+        } else {
+          inTok = chunk.inputTokens ?? 0;
+          outTok = chunk.outputTokens ?? 0;
+          await job.stream({ t: '', done: '1' });
+        }
+      }
+      console.log('\n');
+
+      await job.reportUsage({ model, inputTokens: inTok, outputTokens: outTok });
+      return { polished: full, tokens: inTok + outTok };
+    }
+
+    if (step === 'aggregate') {
+      const children = await job.getChildrenValues();
+      pipelineDone = true;
+      pipelineResult = children;
+      return children;
+    }
+
+    return null;
+  }, { connection: CONNECTION, concurrency: 2 });
+
+  const content = 'Our new product might help people lose weight rapidly with minimal effort, results may vary.';
+
+  const node = await flow.add(
+    {
+      name: 'pipeline',
+      queueName: QUEUE,
+      data: { step: 'aggregate' },
+      children: [
+        { name: 'classify', queueName: QUEUE, data: { step: 'classify', content } },
+        {
+          name: 'moderate', queueName: QUEUE,
+          data: { step: 'moderate', content },
+          children: [
+            { name: 'classify-for-moderate', queueName: QUEUE, data: { step: 'classify', content } },
+          ],
+        },
+        {
+          name: 'polish', queueName: QUEUE,
+          data: { step: 'polish', content },
+          opts: {
+            lockDuration: 60_000,
+            fallbacks: [
+              { model: MODELS.nano },
+              { model: MODELS.fast },
+            ],
+          },
+        },
+      ],
+    },
+    { budget: { maxTotalTokens: 800 } },
+  );
+
+  console.log(`Content pipeline started: "${content.slice(0, 50)}..."`);
+  console.log(`Flow: parent=${node.job.id}, budget=800 tokens\n`);
+
+  // Wait a bit, then check if moderation is suspended
+  await new Promise(r => setTimeout(r, 5_000));
+
+  const moderateJob = node.children!.find(c => c.job.name === 'moderate');
+  if (moderateJob) {
+    const info = await queue.getSuspendInfo(moderateJob.job.id);
+    if (info) {
+      console.log('[Human] Content flagged as borderline. Auto-approving for demo...');
+      await queue.signal(moderateJob.job.id, 'review', { action: 'approve' });
+    }
+  }
+
+  // Wait for pipeline completion
+  const deadline = Date.now() + 60_000;
+  while (!pipelineDone && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  // Print usage summary
+  const usage = await queue.getFlowUsage(node.job.id);
+  console.log('--- Pipeline Usage ---');
+  console.log(`  Jobs: ${usage.jobCount}, Tokens: ${usage.totalInputTokens + usage.totalOutputTokens}`);
+
+  const budget = await queue.getFlowBudget(node.job.id);
+  if (budget) {
+    console.log(`  Budget: ${budget.usedTokens}/${budget.maxTotalTokens} tokens`);
+  }
+
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+  await flow.close();
+
+  console.log('\n[OK] Content pipeline example complete');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/embedding-pipeline.ts
+++ b/examples/embedding-pipeline.ts
@@ -1,0 +1,131 @@
+/**
+ * Embedding Pipeline - Batch document ingestion with queue
+ *
+ * Real scenario: Process document chunks through a queue with rate limiting.
+ * Each chunk is "embedded" (summarized via LLM as a proxy), with token usage
+ * tracked per chunk. A flow budget caps total tokens at 2000.
+ *
+ * Run: npx tsx examples/embedding-pipeline.ts
+ */
+import { Queue, Worker, FlowProducer } from '../dist/index';
+import { chat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `embedding-pipeline-${Date.now()}`;
+
+const CHUNKS = [
+  'Machine learning enables computers to learn from data without explicit programming.',
+  'Neural networks are inspired by the structure of biological brains.',
+  'Transformers use self-attention mechanisms for sequence-to-sequence tasks.',
+  'Vector databases store embeddings for fast similarity search.',
+  'Retrieval-augmented generation grounds LLM responses in documents.',
+  'Fine-tuning adapts pre-trained models to specific domains.',
+  'Prompt engineering crafts inputs to guide model outputs effectively.',
+  'Token limits constrain the context window of language models.',
+];
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  const flow = new FlowProducer({ connection: CONNECTION });
+
+  const timings: { chunk: number; tokens: number; ms: number }[] = [];
+  const failedJobs: { name: string; reason: string }[] = [];
+
+  const worker = new Worker(QUEUE, async (job) => {
+    if (job.name === 'pipeline-root') {
+      const children = await job.getChildrenValues();
+      return { processed: Object.keys(children).length };
+    }
+
+    const { text, index } = job.data;
+    const messages: Message[] = [
+      { role: 'system', content: 'Summarize this text in one short sentence.' },
+      { role: 'user', content: text },
+    ];
+
+    const start = Date.now();
+    const result = await chat(MODELS.fast, messages, 50);
+    const elapsed = Date.now() - start;
+
+    await job.reportUsage({
+      model: result.model,
+      provider: 'openrouter',
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      latencyMs: elapsed,
+    });
+
+    timings.push({ chunk: index, tokens: result.totalTokens, ms: elapsed });
+    return { summary: result.content, tokens: result.totalTokens };
+  }, {
+    connection: CONNECTION,
+    concurrency: 2,
+    tokenLimiter: { maxTokens: 500, duration: 10_000 },
+  });
+
+  const completedCount = { n: 0 };
+  worker.on('completed', (job) => {
+    if (job.name !== 'pipeline-root') completedCount.n++;
+  });
+  worker.on('failed', (job, err) => {
+    failedJobs.push({ name: job.name, reason: err.message });
+  });
+
+  const node = await flow.add({
+    name: 'pipeline-root',
+    queueName: QUEUE,
+    data: { task: 'aggregate' },
+    children: CHUNKS.map((text, i) => ({
+      name: `chunk-${i}`,
+      queueName: QUEUE,
+      data: { text, index: i },
+    })),
+  }, { budget: { maxTotalTokens: 2000, onExceeded: 'fail' } });
+
+  console.log(`Pipeline created: ${CHUNKS.length} chunks, budget=2000 tokens\n`);
+
+  // Wait for processing
+  const deadline = Date.now() + 90_000;
+  while (completedCount.n + failedJobs.length < CHUNKS.length && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  // Per-chunk timings
+  console.log('--- Per-Chunk Results ---');
+  timings.sort((a, b) => a.chunk - b.chunk);
+  for (const t of timings) {
+    console.log(`  chunk-${t.chunk}: ${t.tokens} tokens, ${t.ms}ms`);
+  }
+
+  if (failedJobs.length > 0) {
+    console.log('\n--- Failed (budget exceeded) ---');
+    for (const f of failedJobs) {
+      console.log(`  ${f.name}: ${f.reason.slice(0, 80)}`);
+    }
+  }
+
+  // Flow usage
+  const flowUsage = await queue.getFlowUsage(node.job.id);
+  console.log('\n--- Flow Usage ---');
+  console.log(`  Jobs with usage: ${flowUsage.jobCount}`);
+  console.log(`  Total input tokens: ${flowUsage.totalInputTokens}`);
+  console.log(`  Total output tokens: ${flowUsage.totalOutputTokens}`);
+  console.log(`  Total: ${flowUsage.totalInputTokens + flowUsage.totalOutputTokens}`);
+
+  const budget = await queue.getFlowBudget(node.job.id);
+  if (budget) {
+    console.log(`  Budget: ${budget.usedTokens}/${budget.maxTotalTokens} tokens, exceeded=${budget.exceeded}`);
+  }
+
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+  await flow.close();
+
+  console.log('\n[OK] Embedding pipeline example complete');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/human-approval.ts
+++ b/examples/human-approval.ts
@@ -1,0 +1,141 @@
+/**
+ * Human Approval - suspend / signal
+ *
+ * Real scenario: AI generates a customer email reply, human approves before sending.
+ * The worker drafts an email, suspends for review, and resumes based on the
+ * human's decision (approve or reject). On rejection, it generates a new draft.
+ *
+ * Run: npx tsx examples/human-approval.ts
+ */
+import readline from 'readline';
+import { Queue, Worker } from '../dist/index';
+import { chat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `human-approval-${Date.now()}`;
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  let completedResult: any = null;
+  let failedReason: string | null = null;
+
+  const worker = new Worker(QUEUE, async (job) => {
+    const { complaint } = job.data;
+
+    if (job.signals.length > 0) {
+      const signal = job.signals[0];
+      const signalData = typeof signal.data === 'string' ? JSON.parse(signal.data) : signal.data;
+
+      if (signalData.action === 'approve') {
+        console.log('\n[Worker] Approval received. Finalizing email...');
+        return { status: 'sent', draft: signalData.draft };
+      }
+
+      if (signalData.action === 'reject') {
+        console.log(`\n[Worker] Rejection received: "${signalData.reason}". Generating new draft...`);
+        const messages: Message[] = [
+          { role: 'system', content: 'You are a customer service agent. Write a polite email reply.' },
+          { role: 'user', content: `Customer complaint: ${complaint}\nPrevious draft was rejected because: ${signalData.reason}\nWrite an improved reply (2-3 sentences).` },
+        ];
+        const result = await chat(MODELS.fast, messages, 150);
+        console.log('\n--- Revised Draft ---');
+        console.log(result.content);
+        console.log('---\n');
+
+        await job.suspend({ reason: 'awaiting-review-v2' });
+        return; // unreachable - suspend throws
+      }
+    }
+
+    // First invocation: generate initial draft
+    console.log('[Worker] Generating email draft...');
+    const messages: Message[] = [
+      { role: 'system', content: 'You are a customer service agent. Write a polite email reply.' },
+      { role: 'user', content: `Customer complaint: ${complaint}\nWrite a brief reply (2-3 sentences).` },
+    ];
+    const result = await chat(MODELS.fast, messages, 150);
+
+    console.log('\n--- Draft Email ---');
+    console.log(result.content);
+    console.log('---\n');
+
+    await job.suspend({
+      reason: 'awaiting-review',
+      onResume: async (signals) => {
+        const sig = signals[0];
+        const data = typeof sig.data === 'string' ? JSON.parse(sig.data) : sig.data;
+        if (data.action === 'approve') {
+          return { status: 'sent', draft: result.content };
+        }
+        // If rejected, the main processor handles re-generation above
+        return undefined;
+      },
+    });
+  }, { connection: CONNECTION, concurrency: 1 });
+
+  worker.on('completed', (_job, result) => { completedResult = result; });
+  worker.on('failed', (_job, err) => { failedReason = err.message; });
+
+  const job = await queue.add('email-reply', {
+    complaint: 'I ordered a laptop 2 weeks ago and it still has not arrived. Order #12345.',
+  });
+
+  if (!job) {
+    console.error('Failed to add job');
+    await cleanup(worker, queue);
+    process.exit(1);
+  }
+
+  // Wait for the job to be suspended
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const info = await queue.getSuspendInfo(job.id);
+    if (info) break;
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  // Ask the human
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+  const answer = await new Promise<string>(resolve => {
+    rl.question('Press Enter to approve, or type a reason to reject: ', resolve);
+  });
+  rl.close();
+
+  const fetchedJob = await queue.getJob(job.id);
+  const currentDraft = fetchedJob?.returnvalue ?? '(draft in worker memory)';
+
+  if (answer.trim() === '') {
+    console.log('Approving...');
+    await queue.signal(job.id, 'review', { action: 'approve', draft: currentDraft });
+  } else {
+    console.log(`Rejecting with reason: "${answer.trim()}"`);
+    await queue.signal(job.id, 'review', { action: 'reject', reason: answer.trim() });
+  }
+
+  // Wait for final completion
+  while (!completedResult && !failedReason && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  if (completedResult) {
+    console.log(`\n[OK] Email ${completedResult.status}!`);
+  } else if (failedReason) {
+    console.log(`\n[ERROR] Job failed: ${failedReason}`);
+  } else {
+    console.log('\n[WARN] Timed out waiting for completion');
+  }
+
+  await cleanup(worker, queue);
+  process.exit(0);
+}
+
+async function cleanup(worker: Worker, queue: Queue) {
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/llm.ts
+++ b/examples/llm.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared LLM helper for examples.
+ * Uses OpenRouter with free models. Set OPENROUTER_API_KEY env var.
+ */
+
+const API_KEY = process.env.OPENROUTER_API_KEY;
+if (!API_KEY) {
+  console.error('Set OPENROUTER_API_KEY env var (free key from openrouter.ai/keys)');
+  process.exit(1);
+}
+
+const BASE = 'https://openrouter.ai/api/v1/chat/completions';
+
+export const MODELS = {
+  fast: 'liquid/lfm-2.5-1.2b-instruct:free',
+  large: 'arcee-ai/trinity-large-preview:free',
+  reasoning: 'stepfun/step-3.5-flash:free',
+  nano: 'nvidia/nemotron-3-nano-30b-a3b:free',
+};
+
+export interface Message { role: 'system' | 'user' | 'assistant'; content: string }
+
+export interface LLMResult {
+  content: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export async function chat(
+  model: string,
+  messages: Message[],
+  maxTokens = 150,
+): Promise<LLMResult> {
+  const resp = await fetch(BASE, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model, messages, max_tokens: maxTokens }),
+  });
+  if (!resp.ok) throw new Error(`LLM ${resp.status}: ${await resp.text()}`);
+  const data = await resp.json() as any;
+  const msg = data.choices?.[0]?.message;
+  return {
+    content: msg?.content ?? msg?.reasoning ?? '[empty]',
+    model: data.model ?? model,
+    inputTokens: data.usage?.prompt_tokens ?? 0,
+    outputTokens: data.usage?.completion_tokens ?? 0,
+    totalTokens: data.usage?.total_tokens ?? 0,
+  };
+}
+
+export async function* streamChat(
+  model: string,
+  messages: Message[],
+  maxTokens = 200,
+): AsyncGenerator<{ type: 'token' | 'done'; content: string; inputTokens?: number; outputTokens?: number }> {
+  const resp = await fetch(BASE, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${API_KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model, messages, max_tokens: maxTokens, stream: true }),
+  });
+  if (!resp.ok) throw new Error(`LLM ${resp.status}`);
+
+  const reader = resp.body!.getReader();
+  const decoder = new TextDecoder();
+  let full = '';
+  let inTok = 0, outTok = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    for (const line of decoder.decode(value, { stream: true }).split('\n')) {
+      if (!line.startsWith('data: ')) continue;
+      const p = line.slice(6).trim();
+      if (p === '[DONE]') continue;
+      try {
+        const c = JSON.parse(p);
+        const delta = c.choices?.[0]?.delta?.content;
+        if (delta) { full += delta; yield { type: 'token', content: delta }; }
+        if (c.usage) { inTok = c.usage.prompt_tokens ?? inTok; outTok = c.usage.completion_tokens ?? outTok; }
+      } catch {}
+    }
+  }
+  yield { type: 'done', content: full, inputTokens: inTok, outputTokens: outTok };
+}
+
+export const CONNECTION = { addresses: [{ host: 'localhost', port: 6379 }] };

--- a/examples/model-failover.ts
+++ b/examples/model-failover.ts
@@ -1,0 +1,107 @@
+/**
+ * Model Failover - fallback chains
+ *
+ * Real scenario: Primary model is unavailable, falls back through a chain
+ * of alternatives. The processor reads job.currentFallback to know which
+ * model to use on each retry.
+ *
+ * Run: npx tsx examples/model-failover.ts
+ */
+import { Queue, Worker } from '../dist/index';
+import { chat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `model-failover-${Date.now()}`;
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  let completedResult: any = null;
+  let attempts: { model: string; fallbackIndex: number; error?: string }[] = [];
+
+  const worker = new Worker(QUEUE, async (job) => {
+    const { prompt } = job.data;
+    const fallback = job.currentFallback;
+
+    // On first attempt (no fallback), use the "primary" model from job data.
+    // On retries, use whatever the fallback chain provides.
+    const model = fallback ? fallback.model : job.data.primaryModel;
+
+    console.log(`[Attempt ${job.attemptsMade + 1}] model="${model}", fallbackIndex=${job.fallbackIndex}`);
+
+    const messages: Message[] = [
+      { role: 'system', content: 'Be concise.' },
+      { role: 'user', content: prompt },
+    ];
+
+    try {
+      const result = await chat(model, messages, 80);
+      console.log(`  [OK] Response from ${result.model}: "${result.content.slice(0, 60)}..."`);
+
+      await job.reportUsage({
+        model: result.model,
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+      });
+
+      return { model: result.model, content: result.content };
+    } catch (err: any) {
+      console.log(`  [FAIL] ${err.message.slice(0, 80)}`);
+      throw err;
+    }
+  }, {
+    connection: CONNECTION,
+    concurrency: 1,
+    stalledInterval: 30_000,
+  });
+
+  worker.on('completed', (_job, result) => { completedResult = result; });
+
+  // Primary model is bogus - will fail. Fallbacks are real models.
+  const job = await queue.add('llm-query', {
+    prompt: 'Explain message queues in one sentence.',
+    primaryModel: 'nonexistent/bogus-model-v99',
+  }, {
+    attempts: 3,
+    backoff: { type: 'fixed', delay: 500 },
+    fallbacks: [
+      { model: MODELS.nano, provider: 'nvidia' },
+      { model: MODELS.fast, provider: 'liquid' },
+    ],
+  });
+
+  if (!job) {
+    console.error('Failed to add job');
+    await cleanup(worker, queue);
+    process.exit(1);
+  }
+
+  console.log(`Job ${job.id} added with fallback chain: bogus -> nano -> fast\n`);
+
+  // Wait for completion or final failure
+  const deadline = Date.now() + 60_000;
+  while (!completedResult && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  if (completedResult) {
+    console.log(`\n--- Final Result ---`);
+    console.log(`  Served by: ${completedResult.model}`);
+    console.log(`  Content: ${completedResult.content.slice(0, 120)}`);
+  } else {
+    console.log('\n[WARN] Job did not complete in time');
+  }
+
+  await cleanup(worker, queue);
+  console.log('\n[OK] Model failover example complete');
+  process.exit(0);
+}
+
+async function cleanup(worker: Worker, queue: Queue) {
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/rag-pipeline.ts
+++ b/examples/rag-pipeline.ts
@@ -1,0 +1,152 @@
+/**
+ * RAG Pipeline - streaming + usage tracking + budget + per-job lock
+ *
+ * Combines multiple AI primitives in a retrieval-augmented generation flow:
+ * 1. Embed query (fast model, short lock)
+ * 2. Vector search (simulated - returns fake docs)
+ * 3. Generate response (large model, streaming, long lock)
+ * Parent aggregates results. Budget caps the entire flow.
+ *
+ * Run: npx tsx examples/rag-pipeline.ts
+ */
+import { Queue, Worker, FlowProducer } from '../dist/index';
+import { chat, streamChat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `rag-pipeline-${Date.now()}`;
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  const flow = new FlowProducer({ connection: CONNECTION });
+  let parentDone = false;
+
+  const worker = new Worker(QUEUE, async (job) => {
+    const { step } = job.data;
+
+    if (step === 'embed') {
+      console.log('[embed] Creating query embedding...');
+      const result = await chat(MODELS.fast, [
+        { role: 'user', content: `Represent this for retrieval: "${job.data.query}"` },
+      ], 30);
+      await job.reportUsage({ model: result.model, inputTokens: result.inputTokens, outputTokens: result.outputTokens });
+      console.log(`[embed] Done (${result.totalTokens} tokens)`);
+      return { embedding: '[0.12, -0.45, 0.78, ...]', tokens: result.totalTokens };
+    }
+
+    if (step === 'search') {
+      console.log('[search] Searching vector store (simulated)...');
+      await new Promise(r => setTimeout(r, 200));
+      const docs = [
+        'Message queues enable async processing by decoupling producers from consumers.',
+        'Valkey is a high-performance key-value store forked from Redis.',
+        'glide-mq uses Valkey server functions for atomic queue operations.',
+      ];
+      return { docs, tokens: 0 };
+    }
+
+    if (step === 'generate') {
+      const docs = job.data.context || [];
+      const query = job.data.query;
+      console.log(`[generate] Streaming response (${docs.length} context docs)...`);
+      console.log('');
+
+      const messages: Message[] = [
+        { role: 'system', content: `Answer based on these documents:\n${docs.join('\n')}` },
+        { role: 'user', content: query },
+      ];
+
+      let full = '';
+      let inTok = 0, outTok = 0;
+      for await (const chunk of streamChat(MODELS.fast, messages, 150)) {
+        if (chunk.type === 'token') {
+          process.stdout.write(chunk.content);
+          await job.stream({ t: chunk.content });
+          full += chunk.content;
+        } else {
+          inTok = chunk.inputTokens ?? 0;
+          outTok = chunk.outputTokens ?? 0;
+          await job.stream({ t: '', done: '1' });
+        }
+      }
+      console.log('\n');
+
+      await job.reportUsage({ model: MODELS.fast, inputTokens: inTok, outputTokens: outTok });
+      console.log(`[generate] Done (in=${inTok}, out=${outTok})`);
+      return { content: full, inputTokens: inTok, outputTokens: outTok };
+    }
+
+    if (step === 'aggregate') {
+      const children = await job.getChildrenValues();
+      parentDone = true;
+      return { childCount: Object.keys(children).length };
+    }
+
+    return null;
+  }, { connection: CONNECTION, concurrency: 2 });
+
+  const query = 'How does glide-mq handle queue operations?';
+
+  const node = await flow.add(
+    {
+      name: 'rag',
+      queueName: QUEUE,
+      data: { step: 'aggregate', query },
+      children: [
+        { name: 'embed', queueName: QUEUE, data: { step: 'embed', query }, opts: { lockDuration: 5_000 } },
+        { name: 'search', queueName: QUEUE, data: { step: 'search', query }, opts: { lockDuration: 5_000 } },
+        {
+          name: 'generate', queueName: QUEUE,
+          data: { step: 'generate', query, context: [
+            'Message queues enable async processing by decoupling producers from consumers.',
+            'glide-mq uses Valkey server functions for atomic queue operations.',
+          ]},
+          opts: { lockDuration: 60_000 },
+        },
+      ],
+    },
+    { budget: { maxTotalTokens: 1000 } },
+  );
+
+  console.log(`RAG flow created: parent=${node.job.id}, budget=1000 tokens`);
+  console.log(`Query: "${query}"\n`);
+
+  // Also poll the generate job's stream for live output
+  const genJobId = node.children!.find(c => c.job.name === 'generate')!.job.id;
+  let streamLastId: string | undefined;
+  let streamDone = false;
+
+  const deadline = Date.now() + 60_000;
+  while (!parentDone && Date.now() < deadline) {
+    if (!streamDone) {
+      const entries = await queue.readStream(genJobId, { lastId: streamLastId, count: 50 });
+      for (const e of entries) {
+        streamLastId = e.id;
+        if (e.fields.done === '1') streamDone = true;
+      }
+    }
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  // Print flow usage
+  const usage = await queue.getFlowUsage(node.job.id);
+  console.log('--- Flow Usage ---');
+  console.log(`  Jobs: ${usage.jobCount}, Input: ${usage.totalInputTokens}, Output: ${usage.totalOutputTokens}`);
+  console.log(`  Models: ${JSON.stringify(usage.models)}`);
+
+  const budget = await queue.getFlowBudget(node.job.id);
+  if (budget) {
+    console.log(`  Budget: ${budget.usedTokens}/${budget.maxTotalTokens} tokens`);
+  }
+
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+  await flow.close();
+
+  console.log('\n[OK] RAG pipeline example complete');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/search-dashboard.ts
+++ b/examples/search-dashboard.ts
@@ -1,0 +1,149 @@
+/**
+ * Search Dashboard - Job search and monitoring
+ *
+ * Real scenario: Enqueue 20 AI inference jobs with varied metadata, process
+ * most of them (some succeed, some fail), leave a few waiting, then demonstrate
+ * the search and monitoring APIs: getJobCounts, searchJobs, getMetrics, getJobs.
+ *
+ * Run: npx tsx examples/search-dashboard.ts
+ */
+import { Queue, Worker } from '../dist/index';
+import { chat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `search-dashboard-${Date.now()}`;
+
+const TASKS = [
+  { userId: 'user-1', model: 'gpt-4', taskType: 'inference', priority: 1 },
+  { userId: 'user-1', model: 'gpt-4', taskType: 'inference', priority: 2 },
+  { userId: 'user-1', model: 'gpt-3.5', taskType: 'summarize', priority: 3 },
+  { userId: 'user-2', model: 'gpt-4', taskType: 'inference', priority: 1 },
+  { userId: 'user-2', model: 'gpt-4', taskType: 'translate', priority: 2 },
+  { userId: 'user-2', model: 'gpt-3.5', taskType: 'inference', priority: 3 },
+  { userId: 'user-3', model: 'gpt-4', taskType: 'inference', priority: 1 },
+  { userId: 'user-3', model: 'gpt-3.5', taskType: 'summarize', priority: 2 },
+  { userId: 'user-1', model: 'gpt-4', taskType: 'inference', priority: 1 },
+  { userId: 'user-2', model: 'gpt-4', taskType: 'inference', priority: 2 },
+  { userId: 'user-3', model: 'gpt-3.5', taskType: 'translate', priority: 3 },
+  { userId: 'user-1', model: 'gpt-4', taskType: 'inference', priority: 1 },
+  { userId: 'user-2', model: 'gpt-3.5', taskType: 'summarize', priority: 2 },
+  { userId: 'user-3', model: 'gpt-4', taskType: 'inference', priority: 1 },
+  { userId: 'user-1', model: 'gpt-4', taskType: 'inference', priority: 2 },
+  { userId: 'user-2', model: 'gpt-3.5', taskType: 'translate', priority: 3 },
+  { userId: 'user-3', model: 'gpt-4', taskType: 'inference', priority: 1 },
+  { userId: 'user-1', model: 'gpt-3.5', taskType: 'summarize', priority: 2 },
+  { userId: 'user-2', model: 'gpt-4', taskType: 'inference', priority: 1 },
+  { userId: 'user-3', model: 'gpt-4', taskType: 'inference', priority: 2 },
+];
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+
+  // Enqueue all 20 jobs
+  console.log('Enqueueing 20 AI jobs...');
+  const jobs = await queue.addBulk(
+    TASKS.map((t, i) => ({
+      name: t.taskType,
+      data: { ...t, prompt: `Task ${i}: ${t.taskType} for ${t.userId}`, index: i },
+      opts: { priority: t.priority },
+    })),
+  );
+  console.log(`  Added ${jobs.length} jobs\n`);
+
+  // Process 15: 12 succeed, 3 fail deliberately
+  let processed = 0;
+  const failIndices = new Set([3, 7, 11]);
+
+  const worker = new Worker(QUEUE, async (job) => {
+    processed++;
+    if (processed > 15) {
+      // Leave remaining 5 as waiting - skip by delaying
+      throw new Error('skip');
+    }
+
+    if (failIndices.has(job.data.index)) {
+      throw new Error(`Simulated failure for task ${job.data.index}`);
+    }
+
+    // Lightweight call to keep the example fast
+    const messages: Message[] = [{ role: 'user', content: 'Say "ok" in one word.' }];
+    const result = await chat(MODELS.fast, messages, 10);
+
+    await job.reportUsage({
+      model: result.model,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+    });
+
+    return { response: result.content.slice(0, 20) };
+  }, { connection: CONNECTION, concurrency: 3, stalledInterval: 30_000 });
+
+  // Wait for processing to settle
+  const completedIds: string[] = [];
+  const failedIds: string[] = [];
+  worker.on('completed', (job) => completedIds.push(job.id));
+  worker.on('failed', (job) => failedIds.push(job.id));
+
+  const deadline = Date.now() + 90_000;
+  while (completedIds.length + failedIds.length < 15 && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  // Pause worker so remaining 5 stay waiting
+  await worker.close(true);
+
+  console.log('=== Dashboard ===\n');
+
+  // 1. Job counts overview
+  console.log('--- Job Counts ---');
+  const counts = await queue.getJobCounts();
+  console.log(`  waiting=${counts.waiting} active=${counts.active} completed=${counts.completed} failed=${counts.failed} delayed=${counts.delayed}\n`);
+
+  // 2. Search completed inference jobs
+  console.log('--- Search: completed inference jobs ---');
+  const completedInf = await queue.searchJobs({ state: 'completed', name: 'inference' });
+  console.log(`  Found ${completedInf.length} completed inference job(s)`);
+  for (const j of completedInf.slice(0, 3)) {
+    console.log(`    id=${j.id} user=${j.data.userId} model=${j.data.model}`);
+  }
+  if (completedInf.length > 3) console.log(`    ... and ${completedInf.length - 3} more`);
+
+  // 3. Search by user
+  console.log('\n--- Search: all jobs from user-1 ---');
+  const user1Jobs = await queue.searchJobs({ data: { userId: 'user-1' } });
+  console.log(`  Found ${user1Jobs.length} job(s) for user-1`);
+
+  // 4. Metrics for completed jobs
+  console.log('\n--- Metrics: completed ---');
+  const metrics = await queue.getMetrics('completed');
+  console.log(`  count=${metrics.count}, data points=${metrics.data?.length ?? 0}`);
+
+  // 5. Failed jobs - show and retry one
+  console.log('\n--- Failed Jobs ---');
+  const failedJobs = await queue.getJobs('failed');
+  console.log(`  ${failedJobs.length} failed job(s)`);
+  for (const j of failedJobs) {
+    console.log(`    id=${j.id} name=${j.name} reason="${j.failedReason?.slice(0, 40)}"`);
+  }
+
+  if (failedJobs.length > 0) {
+    console.log(`\n  Retrying job ${failedJobs[0].id}...`);
+    await failedJobs[0].retry();
+    console.log('  [OK] Job moved back to waiting');
+  }
+
+  // Final counts
+  console.log('\n--- Final Counts ---');
+  const finalCounts = await queue.getJobCounts();
+  console.log(`  waiting=${finalCounts.waiting} completed=${finalCounts.completed} failed=${finalCounts.failed}`);
+
+  await queue.obliterate({ force: true });
+  await queue.close();
+
+  console.log('\n[OK] Search dashboard example complete');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/testing-mode.ts
+++ b/examples/testing-mode.ts
@@ -1,0 +1,196 @@
+/**
+ * Testing Mode - Unit testing without Valkey
+ *
+ * Real scenario: Validate glide-mq AI features using in-memory TestQueue
+ * and TestWorker. No Valkey connection, no API keys needed. Each test uses
+ * mock processors to verify: reportUsage, streaming, suspend/signal, and
+ * fallback chains.
+ *
+ * Run: npx tsx examples/testing-mode.ts
+ */
+import { TestQueue, TestWorker } from 'glide-mq/testing';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, msg: string) {
+  if (condition) {
+    console.log(`  [PASS] ${msg}`);
+    passed++;
+  } else {
+    console.error(`  [FAIL] ${msg}`);
+    failed++;
+  }
+}
+
+// --- Test 1: reportUsage ---
+async function testReportUsage() {
+  console.log('\nTest 1: reportUsage');
+  const queue = new TestQueue('usage-test');
+
+  let capturedUsage: any = null;
+  const worker = new TestWorker(queue, async (job) => {
+    await job.reportUsage({
+      model: 'gpt-4',
+      provider: 'openai',
+      inputTokens: 100,
+      outputTokens: 50,
+      latencyMs: 200,
+    });
+    capturedUsage = job.usage;
+    return { answer: 42 };
+  });
+
+  const job = await queue.add('inference', { prompt: 'What is 6*7?' });
+  assert(job !== null, 'Job added');
+
+  // Wait for processing
+  await new Promise(r => setTimeout(r, 100));
+
+  const fetched = await queue.getJob(job!.id);
+  assert(fetched !== null, 'Job fetched');
+  assert(fetched!.returnvalue?.answer === 42, 'Return value correct');
+
+  // Usage is captured during processing (on the processor's job instance)
+  assert(capturedUsage?.model === 'gpt-4', 'Usage model is gpt-4');
+  assert(capturedUsage?.inputTokens === 100, 'Input tokens = 100');
+  assert(capturedUsage?.outputTokens === 50, 'Output tokens = 50');
+  assert(capturedUsage?.latencyMs === 200, 'Latency = 200ms');
+
+  await worker.close();
+  await queue.close();
+}
+
+// --- Test 2: Streaming ---
+async function testStreaming() {
+  console.log('\nTest 2: stream + readStream');
+  const queue = new TestQueue('stream-test');
+
+  const worker = new TestWorker(queue, async (job) => {
+    const words = ['Hello', ' ', 'world', '!'];
+    for (const w of words) {
+      await job.stream({ t: w });
+    }
+    await job.stream({ t: '', done: '1' });
+    return { length: words.length };
+  });
+
+  const job = await queue.add('generate', { prompt: 'Say hello' });
+  await new Promise(r => setTimeout(r, 100));
+
+  const entries = await queue.readStream(job!.id);
+  assert(entries.length === 5, `Stream has 5 entries (got ${entries.length})`);
+  assert(entries[0].fields.t === 'Hello', 'First chunk is "Hello"');
+  assert(entries[entries.length - 1].fields.done === '1', 'Last chunk has done flag');
+
+  // Test resume from midpoint
+  if (entries.length >= 3) {
+    const resumed = await queue.readStream(job!.id, { lastId: entries[1].id });
+    assert(resumed.length === entries.length - 2, `Resume skips first 2 entries (got ${resumed.length})`);
+  }
+
+  await worker.close();
+  await queue.close();
+}
+
+// --- Test 3: Suspend and Signal ---
+async function testSuspendSignal() {
+  console.log('\nTest 3: suspend + signal');
+  const queue = new TestQueue('suspend-test');
+
+  let invocations = 0;
+  const worker = new TestWorker(queue, async (job) => {
+    invocations++;
+
+    if (job.signals.length > 0) {
+      const sig = job.signals[0];
+      const data = typeof sig.data === 'string' ? JSON.parse(sig.data) : sig.data;
+      return { approved: true, reviewer: data.reviewer };
+    }
+
+    await job.suspend({ reason: 'awaiting-approval' });
+  });
+
+  const job = await queue.add('review', { doc: 'quarterly report' });
+  await new Promise(r => setTimeout(r, 100));
+
+  // Job should be suspended
+  const info = await queue.getSuspendInfo(job!.id);
+  assert(info !== null, 'Job is suspended');
+  assert(info?.reason === 'awaiting-approval', 'Suspend reason matches');
+
+  // Send approval signal
+  await queue.signal(job!.id, 'approval', { reviewer: 'alice' });
+  await new Promise(r => setTimeout(r, 200));
+
+  // Job should now be completed
+  const fetched = await queue.getJob(job!.id);
+  assert(fetched!.returnvalue?.approved === true, 'Job approved after signal');
+  assert(fetched!.returnvalue?.reviewer === 'alice', 'Reviewer is alice');
+  assert(invocations === 2, `Processor invoked twice (got ${invocations})`);
+
+  await worker.close();
+  await queue.close();
+}
+
+// --- Test 4: Fallback Chain ---
+async function testFallbackChain() {
+  console.log('\nTest 4: fallback chain on failure');
+  const queue = new TestQueue('fallback-test');
+
+  const attempts: { model: string; index: number }[] = [];
+
+  const worker = new TestWorker(queue, async (job) => {
+    const fallback = job.currentFallback;
+    const model = fallback ? fallback.model : 'primary-model';
+    const idx = job.fallbackIndex;
+    attempts.push({ model, index: idx });
+
+    if (model === 'primary-model') {
+      throw new Error('Primary model unavailable');
+    }
+    if (model === 'fallback-1') {
+      throw new Error('Fallback 1 also down');
+    }
+    return { model, content: 'Success from fallback-2' };
+  });
+
+  const job = await queue.add('inference', { prompt: 'test' }, {
+    attempts: 3,
+    backoff: { type: 'fixed', delay: 50 },
+    fallbacks: [
+      { model: 'fallback-1', provider: 'provider-a' },
+      { model: 'fallback-2', provider: 'provider-b' },
+    ],
+  });
+
+  // Wait for retries to complete
+  await new Promise(r => setTimeout(r, 1000));
+
+  const fetched = await queue.getJob(job!.id);
+  assert(attempts.length >= 2, `Multiple attempts made (got ${attempts.length})`);
+  assert(fetched!.returnvalue?.model === 'fallback-2', 'Final model is fallback-2');
+  assert(fetched!.returnvalue?.content === 'Success from fallback-2', 'Content from fallback-2');
+
+  await worker.close();
+  await queue.close();
+}
+
+// --- Run all tests ---
+async function main() {
+  console.log('=== glide-mq Testing Mode ===');
+  console.log('No Valkey, no API keys - pure in-memory tests\n');
+
+  await testReportUsage();
+  await testStreaming();
+  await testSuspendSignal();
+  await testFallbackChain();
+
+  console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/token-streaming.ts
+++ b/examples/token-streaming.ts
@@ -1,0 +1,103 @@
+/**
+ * Token Streaming - job.stream / queue.readStream
+ *
+ * Real scenario: Stream a blog post generation to the terminal in real-time.
+ * The worker generates a response using streamChat, publishing each token
+ * chunk via job.stream(). A consumer polls readStream() and prints tokens
+ * as they arrive. Demonstrates resume from a known lastId.
+ *
+ * Run: npx tsx examples/token-streaming.ts
+ */
+import { Queue, Worker } from '../dist/index';
+import { streamChat, MODELS, CONNECTION } from './llm';
+
+const QUEUE = `token-streaming-${Date.now()}`;
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+
+  const worker = new Worker(QUEUE, async (job) => {
+    const { prompt, model } = job.data;
+    let full = '';
+    let totalIn = 0;
+    let totalOut = 0;
+
+    for await (const chunk of streamChat(model, [{ role: 'user', content: prompt }], 200)) {
+      if (chunk.type === 'token') {
+        await job.stream({ t: chunk.content });
+        full += chunk.content;
+      } else {
+        totalIn = chunk.inputTokens ?? 0;
+        totalOut = chunk.outputTokens ?? 0;
+        await job.stream({ t: '', done: '1' });
+      }
+    }
+
+    return { content: full, inputTokens: totalIn, outputTokens: totalOut };
+  }, { connection: CONNECTION, concurrency: 1 });
+
+  const job = await queue.add('blog-post', {
+    prompt: 'Write a short paragraph about why message queues matter in AI applications.',
+    model: MODELS.fast,
+  });
+
+  if (!job) {
+    console.error('Failed to add job');
+    await cleanup(worker, queue);
+    process.exit(1);
+  }
+
+  console.log(`Job ${job.id} added. Streaming output:\n`);
+
+  // Poll readStream for tokens
+  let lastId: string | undefined;
+  let done = false;
+  let tokenCount = 0;
+
+  while (!done) {
+    const entries = await queue.readStream(job.id, { lastId, count: 50 });
+
+    for (const entry of entries) {
+      lastId = entry.id;
+      if (entry.fields.done === '1') {
+        done = true;
+        break;
+      }
+      process.stdout.write(entry.fields.t);
+      tokenCount++;
+    }
+
+    if (!done && entries.length === 0) {
+      await new Promise(r => setTimeout(r, 100));
+    }
+  }
+
+  console.log(`\n\n--- Stream complete: ${tokenCount} chunks received ---`);
+
+  // Demonstrate resume: re-read from midpoint
+  const allEntries = await queue.readStream(job.id);
+  const midpoint = allEntries[Math.floor(allEntries.length / 2)]?.id;
+  if (midpoint) {
+    const resumed = await queue.readStream(job.id, { lastId: midpoint });
+    console.log(`Resume from midpoint (${midpoint}): got ${resumed.length} remaining chunks`);
+  }
+
+  // Wait for job completion
+  const state = await job.waitUntilFinished(500, 30_000);
+  console.log(`Job state: ${state}`);
+
+  await cleanup(worker, queue);
+  console.log('[OK] Token streaming example complete');
+  process.exit(0);
+}
+
+async function cleanup(worker: Worker, queue: Queue) {
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/tpm-throttle.ts
+++ b/examples/tpm-throttle.ts
@@ -1,0 +1,95 @@
+/**
+ * TPM Throttle - tokenLimiter (dual-axis rate limiting)
+ *
+ * Real scenario: Batch AI processing with provider rate limit compliance.
+ * The worker is configured with a token limiter (300 tokens per 10s window).
+ * After the first few jobs consume the budget, processing pauses until
+ * the window resets.
+ *
+ * Run: npx tsx examples/tpm-throttle.ts
+ */
+import { Queue, Worker } from '../dist/index';
+import { chat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `tpm-throttle-${Date.now()}`;
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  const timeline: { job: string; tokens: number; elapsed: number }[] = [];
+  const start = Date.now();
+  let completed = 0;
+
+  const worker = new Worker(QUEUE, async (job) => {
+    const messages: Message[] = [
+      { role: 'user', content: job.data.prompt },
+    ];
+
+    const result = await chat(MODELS.fast, messages, 30);
+    const tokens = result.totalTokens;
+
+    // Report tokens so the limiter tracks them
+    await job.reportTokens(tokens);
+
+    const elapsed = Date.now() - start;
+    timeline.push({ job: job.name, tokens, elapsed });
+    console.log(`  [${(elapsed / 1000).toFixed(1)}s] ${job.name}: ${tokens} tokens`);
+
+    return { tokens, content: result.content.slice(0, 40) };
+  }, {
+    connection: CONNECTION,
+    concurrency: 1,
+    tokenLimiter: {
+      maxTokens: 300,
+      duration: 10_000,
+    },
+  });
+
+  worker.on('completed', () => { completed++; });
+
+  // Enqueue 10 short tasks
+  const prompts = [
+    'What is 2+2?', 'Name one planet.', 'Say hello.', 'What color is the sky?',
+    'Name a fruit.', 'What is gravity?', 'Count to 3.', 'Name a city.',
+    'What is water?', 'Name an animal.',
+  ];
+
+  console.log(`Enqueuing ${prompts.length} jobs with tokenLimiter: 300 tokens per 10s\n`);
+
+  for (let i = 0; i < prompts.length; i++) {
+    await queue.add(`task-${i + 1}`, { prompt: prompts[i] });
+  }
+
+  // Wait for all to complete (with generous timeout for throttling)
+  const deadline = Date.now() + 120_000;
+  while (completed < prompts.length && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  console.log(`\n--- Timeline ---`);
+  console.log(`  Total jobs: ${completed}/${prompts.length}`);
+  const totalTokens = timeline.reduce((s, t) => s + t.tokens, 0);
+  console.log(`  Total tokens: ${totalTokens}`);
+  const totalTime = (Date.now() - start) / 1000;
+  console.log(`  Total time: ${totalTime.toFixed(1)}s`);
+
+  if (timeline.length >= 2) {
+    const firstBatch = timeline.filter(t => t.elapsed < 10_000);
+    const secondBatch = timeline.filter(t => t.elapsed >= 10_000);
+    console.log(`  First window (<10s): ${firstBatch.length} jobs, ${firstBatch.reduce((s, t) => s + t.tokens, 0)} tokens`);
+    if (secondBatch.length > 0) {
+      console.log(`  After throttle (>=10s): ${secondBatch.length} jobs`);
+    }
+  }
+
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+
+  console.log('\n[OK] TPM throttle example complete');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/usage-tracking.ts
+++ b/examples/usage-tracking.ts
@@ -1,0 +1,107 @@
+/**
+ * Usage Tracking - reportUsage / getFlowUsage
+ *
+ * Real scenario: Track token costs across an AI content pipeline.
+ * A flow with 3 steps (research -> draft -> edit) each calls an LLM,
+ * reports usage, and the parent aggregates results with getFlowUsage().
+ *
+ * Run: npx tsx examples/usage-tracking.ts
+ */
+import { Queue, Worker, FlowProducer } from '../dist/index';
+import { chat, MODELS, CONNECTION, type Message } from './llm';
+
+const QUEUE = `usage-tracking-${Date.now()}`;
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  const flow = new FlowProducer({ connection: CONNECTION });
+
+  const worker = new Worker(QUEUE, async (job) => {
+    const { task, topic } = job.data;
+    const model = task === 'research' ? MODELS.fast
+      : task === 'draft' ? MODELS.nano
+      : MODELS.fast;
+
+    const messages: Message[] = [
+      { role: 'system', content: `You are a helpful ${task} assistant.` },
+      { role: 'user', content: topic },
+    ];
+
+    const start = Date.now();
+    const result = await chat(model, messages, 100);
+    const latency = Date.now() - start;
+
+    await job.reportUsage({
+      model: result.model,
+      provider: 'openrouter',
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      latencyMs: latency,
+    });
+
+    console.log(`[${task}] ${result.model} - ${result.totalTokens} tokens, ${latency}ms`);
+    return { content: result.content, tokens: result.totalTokens };
+  }, { connection: CONNECTION, concurrency: 3 });
+
+  const completedJobs: string[] = [];
+  worker.on('completed', (job) => { completedJobs.push(job.id); });
+
+  const node = await flow.add({
+    name: 'content-pipeline',
+    queueName: QUEUE,
+    data: { task: 'aggregate', topic: 'AI in healthcare' },
+    children: [
+      { name: 'research', queueName: QUEUE, data: { task: 'research', topic: 'List 3 key facts about AI in healthcare' } },
+      { name: 'draft', queueName: QUEUE, data: { task: 'draft', topic: 'Write a one-paragraph draft about AI in healthcare' } },
+      { name: 'edit', queueName: QUEUE, data: { task: 'edit', topic: 'Improve this text: AI helps doctors diagnose diseases faster' } },
+    ],
+  });
+
+  console.log(`Flow created: parent=${node.job.id}, children=${node.children!.map(c => c.job.id).join(', ')}`);
+
+  // Wait for all children to complete
+  const deadline = Date.now() + 60_000;
+  while (completedJobs.length < 3 && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+
+  if (completedJobs.length < 3) {
+    console.error('Timed out waiting for children');
+    await cleanup(worker, queue, flow);
+    process.exit(1);
+  }
+
+  // Print per-job usage
+  console.log('\n--- Per-Job Usage ---');
+  for (const child of node.children!) {
+    const job = await queue.getJob(child.job.id);
+    if (job?.usage) {
+      console.log(`  ${job.name}: model=${job.usage.model}, in=${job.usage.inputTokens}, out=${job.usage.outputTokens}, latency=${job.usage.latencyMs}ms`);
+    }
+  }
+
+  // Aggregate flow usage
+  const flowUsage = await queue.getFlowUsage(node.job.id);
+  console.log('\n--- Flow Usage (aggregated) ---');
+  console.log(`  Jobs with usage: ${flowUsage.jobCount}`);
+  console.log(`  Total input tokens: ${flowUsage.totalInputTokens}`);
+  console.log(`  Total output tokens: ${flowUsage.totalOutputTokens}`);
+  console.log(`  Total tokens: ${flowUsage.totalInputTokens + flowUsage.totalOutputTokens}`);
+  console.log(`  Model distribution:`, flowUsage.models);
+
+  await cleanup(worker, queue, flow);
+  console.log('\n[OK] Usage tracking example complete');
+  process.exit(0);
+}
+
+async function cleanup(worker: Worker, queue: Queue, flow: FlowProducer) {
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+  await flow.close();
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/vector-search.ts
+++ b/examples/vector-search.ts
@@ -1,0 +1,173 @@
+/**
+ * Vector Search - Semantic search with Valkey
+ *
+ * Real scenario: Store documents as JSON with vector embeddings, TAG, and
+ * NUMERIC fields, then query by KNN similarity with optional tag pre-filters.
+ *
+ * Uses speedkey GlideFt/GlideJson directly (no glide-mq Queue needed).
+ * Vectors are synthetic (hash-based) since OpenRouter lacks embedding endpoints.
+ *
+ * Run: npx tsx examples/vector-search.ts
+ */
+import { GlideClient, GlideFt, GlideJson } from '@glidemq/speedkey';
+
+const CONNECTION = { addresses: [{ host: 'localhost', port: 6379 }] };
+
+const DIM = 32;
+const INDEX = `vec-idx-${Date.now()}`;
+const PREFIX = `doc:${Date.now()}:`;
+
+const DOCS = [
+  { id: 'ml-intro', category: 'ml', score: 95, title: 'Introduction to Machine Learning', body: 'Machine learning is a subset of artificial intelligence.' },
+  { id: 'queue-basics', category: 'infra', score: 88, title: 'Message Queue Fundamentals', body: 'Message queues decouple producers from consumers.' },
+  { id: 'vector-db', category: 'ml', score: 92, title: 'Vector Databases Explained', body: 'Vector databases store high-dimensional embeddings.' },
+  { id: 'llm-serving', category: 'infra', score: 90, title: 'Serving Large Language Models', body: 'LLM serving requires GPU infrastructure and batching.' },
+  { id: 'rag-pattern', category: 'ml', score: 97, title: 'Retrieval-Augmented Generation', body: 'RAG grounds LLM responses in relevant documents.' },
+];
+
+/** Deterministic hash-based embedding: maps text to a normalized float32 vector. */
+function hashEmbed(text: string, dim: number): number[] {
+  const vec = new Array(dim).fill(0);
+  for (let i = 0; i < text.length; i++) {
+    const idx = i % dim;
+    vec[idx] += text.charCodeAt(i) * (1 + (i / text.length));
+  }
+  const mag = Math.sqrt(vec.reduce((s, v) => s + v * v, 0)) || 1;
+  return vec.map(v => v / mag);
+}
+
+function toBuffer(vec: number[]): Buffer {
+  const buf = Buffer.alloc(vec.length * 4);
+  vec.forEach((v, i) => buf.writeFloatLE(v, i * 4));
+  return buf;
+}
+
+/** Parse FT.SEARCH result fields into a flat object, extracting JSON doc fields. */
+function parseResultFields(value: any): Record<string, string> {
+  const fields: Record<string, string> = {};
+  if (!Array.isArray(value)) return fields;
+  for (const f of value) {
+    const k = String(f.key);
+    const v = String(f.value);
+    if (k === '$') {
+      // JSON document - parse and merge
+      try {
+        const doc = JSON.parse(v);
+        for (const [dk, dv] of Object.entries(doc)) {
+          if (dk !== 'vec') fields[dk] = String(dv);
+        }
+      } catch {}
+    } else {
+      fields[k] = v;
+    }
+  }
+  return fields;
+}
+
+async function main() {
+  const client = await GlideClient.createClient({ addresses: CONNECTION.addresses });
+
+  // 1. Create index with TAG + NUMERIC + VECTOR fields on JSON docs
+  console.log(`Creating index "${INDEX}" with TAG, NUMERIC, and VECTOR fields...`);
+  await GlideFt.create(client, INDEX, [
+    { type: 'TAG', name: '$.category', alias: 'category' },
+    { type: 'NUMERIC', name: '$.score', alias: 'score' },
+    {
+      type: 'VECTOR',
+      name: '$.vec',
+      alias: 'VEC',
+      attributes: {
+        algorithm: 'HNSW',
+        dimensions: DIM,
+        distanceMetric: 'COSINE',
+        type: 'FLOAT32',
+        numberOfEdges: 16,
+      },
+    },
+  ], { dataType: 'JSON', prefixes: [PREFIX] });
+  console.log('[OK] Index created\n');
+
+  // 2. Store documents with embeddings
+  console.log('Storing 5 documents...');
+  for (const doc of DOCS) {
+    const vec = hashEmbed(doc.title + ' ' + doc.body, DIM);
+    const payload = JSON.stringify({
+      category: doc.category,
+      score: doc.score,
+      title: doc.title,
+      body: doc.body,
+      vec,
+    });
+    await GlideJson.set(client, `${PREFIX}${doc.id}`, '$', payload);
+    console.log(`  ${doc.id}: "${doc.title}" [${doc.category}]`);
+  }
+
+  // Brief pause for indexing
+  await new Promise(r => setTimeout(r, 500));
+
+  // 3. KNN search - find 3 docs most similar to "AI models and embeddings"
+  console.log('\n--- KNN Search: "AI models and embeddings" (top 3) ---');
+  const queryVec = hashEmbed('AI models and embeddings', DIM);
+  const queryBuf = toBuffer(queryVec);
+
+  const knnResults = await GlideFt.search(
+    client, INDEX, '*=>[KNN 3 @VEC $query_vec]',
+    { params: [{ key: 'query_vec', value: queryBuf }] },
+  );
+  console.log(`  ${knnResults[0]} result(s)`);
+  if (knnResults[1]) {
+    for (const entry of knnResults[1]) {
+      const fields = parseResultFields(entry.value);
+      console.log(`  key=${entry.key}  category=${fields.category}  score=${fields.score}  distance=${fields.__VEC_score}`);
+    }
+  }
+
+  // 4. Filtered KNN - only "ml" category documents
+  console.log('\n--- Filtered KNN: category=ml (top 3) ---');
+  const filteredResults = await GlideFt.search(
+    client, INDEX, '(@category:{ml})=>[KNN 3 @VEC $query_vec]',
+    { params: [{ key: 'query_vec', value: queryBuf }] },
+  );
+  console.log(`  ${filteredResults[0]} result(s) (ml only)`);
+  if (filteredResults[1]) {
+    for (const entry of filteredResults[1]) {
+      const fields = parseResultFields(entry.value);
+      console.log(`  key=${entry.key}  category=${fields.category}  distance=${fields.__VEC_score}`);
+    }
+  }
+
+  // 5. Different query vector - "distributed systems and queues"
+  console.log('\n--- KNN Search: "distributed systems and queues" (top 2) ---');
+  const q2Vec = hashEmbed('distributed systems and queues', DIM);
+  const q2Buf = toBuffer(q2Vec);
+  const infraResults = await GlideFt.search(
+    client, INDEX, '*=>[KNN 2 @VEC $query_vec]',
+    { params: [{ key: 'query_vec', value: q2Buf }] },
+  );
+  console.log(`  ${infraResults[0]} result(s)`);
+  if (infraResults[1]) {
+    for (const entry of infraResults[1]) {
+      const fields = parseResultFields(entry.value);
+      console.log(`  key=${entry.key}  category=${fields.category}  distance=${fields.__VEC_score}`);
+    }
+  }
+
+  // 6. Index info
+  console.log('\n--- Index Info ---');
+  const info = await GlideFt.info(client, INDEX);
+  console.log(`  index_name=${info.index_name}, num_docs=${info.num_docs}, status=${info.index_status}`);
+
+  // Cleanup
+  console.log('\nCleaning up...');
+  await GlideFt.dropindex(client, INDEX);
+  for (const doc of DOCS) await client.del([`${PREFIX}${doc.id}`]);
+  client.close();
+
+  console.log('[OK] Vector search example complete');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/with-langchain.ts
+++ b/examples/with-langchain.ts
@@ -1,0 +1,176 @@
+/**
+ * LangChain Integration - Durable chain execution via glide-mq
+ *
+ * Real scenario: LangChain chains (prompt | model | parser) run inside
+ * glide-mq workers for durable, retryable execution. Each pipeline step
+ * (research -> summarize -> format) uses a different chain. Token usage
+ * is reported from LangChain's response metadata.
+ *
+ * Run: npx tsx examples/with-langchain.ts
+ */
+import { ChatOpenAI } from '@langchain/openai';
+import { ChatPromptTemplate } from '@langchain/core/prompts';
+import { StringOutputParser } from '@langchain/core/output_parsers';
+import { Queue, Worker, FlowProducer } from '../dist/index';
+import { CONNECTION } from './llm';
+
+const QUEUE = `langchain-${Date.now()}`;
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+if (!OPENROUTER_API_KEY) {
+  console.error('Set OPENROUTER_API_KEY env var');
+  process.exit(1);
+}
+
+const llm = new ChatOpenAI({
+  model: 'arcee-ai/trinity-large-preview:free',
+  configuration: { baseURL: 'https://openrouter.ai/api/v1' },
+  apiKey: OPENROUTER_API_KEY,
+  maxTokens: 150,
+  temperature: 0.7,
+});
+
+const parser = new StringOutputParser();
+
+// Three chains for the pipeline steps
+const researchChain = ChatPromptTemplate.fromMessages([
+  ['system', 'You are a research assistant. List 3 key facts about the topic.'],
+  ['user', '{topic}'],
+]).pipe(llm).pipe(parser);
+
+const summarizeChain = ChatPromptTemplate.fromMessages([
+  ['system', 'Summarize the following research into one concise paragraph.'],
+  ['user', '{research}'],
+]).pipe(llm).pipe(parser);
+
+const formatChain = ChatPromptTemplate.fromMessages([
+  ['system', 'Format this text as a professional brief with a title and bullet points.'],
+  ['user', '{summary}'],
+]).pipe(llm).pipe(parser);
+
+async function invokeWithUsage(chain: any, input: Record<string, string>) {
+  // Invoke the model directly to capture usage metadata, then run through parser
+  const prompt = chain.first; // ChatPromptTemplate
+  const messages = await prompt.formatMessages(input);
+  const response = await llm.invoke(messages);
+  const text = String(response.content);
+  const usage = (response.response_metadata as any)?.tokenUsage;
+  return { text, usage };
+}
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+  const flow = new FlowProducer({ connection: CONNECTION });
+  const results: Record<string, any> = {};
+
+  const worker = new Worker(QUEUE, async (job) => {
+    const { step, topic, research, summary } = job.data;
+
+    if (step === 'aggregate') {
+      const children = await job.getChildrenValues();
+      return { children: Object.keys(children).length };
+    }
+
+    let output: string;
+
+    if (step === 'research') {
+      const r = await invokeWithUsage(researchChain, { topic });
+      output = r.text;
+      if (r.usage) {
+        await job.reportUsage({
+          model: 'arcee-ai/trinity-large-preview:free',
+          provider: 'openrouter',
+          inputTokens: r.usage.promptTokens ?? 0,
+          outputTokens: r.usage.completionTokens ?? 0,
+        });
+      }
+    } else if (step === 'summarize') {
+      const r = await invokeWithUsage(summarizeChain, { research });
+      output = r.text;
+      if (r.usage) {
+        await job.reportUsage({
+          model: 'arcee-ai/trinity-large-preview:free',
+          provider: 'openrouter',
+          inputTokens: r.usage.promptTokens ?? 0,
+          outputTokens: r.usage.completionTokens ?? 0,
+        });
+      }
+    } else {
+      const r = await invokeWithUsage(formatChain, { summary });
+      output = r.text;
+      if (r.usage) {
+        await job.reportUsage({
+          model: 'arcee-ai/trinity-large-preview:free',
+          provider: 'openrouter',
+          inputTokens: r.usage.promptTokens ?? 0,
+          outputTokens: r.usage.completionTokens ?? 0,
+        });
+      }
+    }
+
+    console.log(`[${step}] ${output.slice(0, 80)}...`);
+    results[step] = output;
+    return { output };
+  }, { connection: CONNECTION, concurrency: 1 });
+
+  const completedCount = { n: 0 };
+  worker.on('completed', (job) => {
+    if (job.data.step !== 'aggregate') completedCount.n++;
+  });
+
+  console.log('Running 3-step LangChain pipeline: research -> summarize -> format\n');
+
+  // Step 1: Research
+  const researchJob = await queue.add('research', {
+    step: 'research',
+    topic: 'The impact of AI on healthcare',
+  });
+  const deadline = Date.now() + 90_000;
+  while (completedCount.n < 1 && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  // Step 2: Summarize using research output
+  const sumJob = await queue.add('summarize', {
+    step: 'summarize',
+    research: results.research ?? '',
+  });
+  while (completedCount.n < 2 && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  // Step 3: Format using summary
+  const fmtJob = await queue.add('format', {
+    step: 'format',
+    summary: results.summarize ?? '',
+  });
+  while (completedCount.n < 3 && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  // Final output
+  console.log('\n--- Final Brief ---');
+  console.log(results.format ?? '(not available)');
+
+  // Per-job usage
+  console.log('\n--- Per-Job Usage ---');
+  for (const id of [researchJob?.id, sumJob?.id, fmtJob?.id]) {
+    if (!id) continue;
+    const j = await queue.getJob(id);
+    if (j?.usage) {
+      console.log(`  ${j.name}: in=${j.usage.inputTokens}, out=${j.usage.outputTokens}`);
+    }
+  }
+
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+  await flow.close();
+
+  console.log('\n[OK] LangChain example complete');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/examples/with-vercel-ai-sdk.ts
+++ b/examples/with-vercel-ai-sdk.ts
@@ -1,0 +1,166 @@
+/**
+ * Vercel AI SDK Integration - Durable LLM execution via glide-mq
+ *
+ * Real scenario: Use Vercel AI SDK (generateText, streamText) inside a
+ * glide-mq worker for durable, retryable AI inference. OpenRouter provides
+ * the model backend. Token usage is reported from the AI SDK response.
+ *
+ * Run: npx tsx examples/with-vercel-ai-sdk.ts
+ */
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateText, streamText } from 'ai';
+import { Queue, Worker } from '../dist/index';
+import { CONNECTION, MODELS } from './llm';
+
+const QUEUE = `vercel-ai-${Date.now()}`;
+
+const openrouter = createOpenAI({
+  baseURL: 'https://openrouter.ai/api/v1',
+  apiKey: process.env.OPENROUTER_API_KEY,
+  name: 'openrouter',
+  compatibility: 'compatible',
+});
+
+async function main() {
+  const queue = new Queue(QUEUE, { connection: CONNECTION });
+
+  // --- Example 1: generateText ---
+  console.log('=== Example 1: generateText ===\n');
+
+  const genWorker = new Worker(QUEUE, async (job) => {
+    const { prompt, model } = job.data;
+
+    if (job.data.mode === 'stream') {
+      // Example 2 handler below
+      const result = streamText({
+        model: openrouter.chat(model),
+        prompt,
+        maxTokens: 150,
+      });
+
+      for await (const chunk of result.textStream) {
+        await job.stream({ t: chunk });
+      }
+      await job.stream({ t: '', done: '1' });
+
+      const usage = await result.usage;
+      await job.reportUsage({
+        model,
+        provider: 'openrouter',
+        inputTokens: usage.inputTokens ?? 0,
+        outputTokens: usage.outputTokens ?? 0,
+      });
+
+      const text = await result.text;
+      return { content: text, inputTokens: usage.inputTokens, outputTokens: usage.outputTokens };
+    }
+
+    // Default: generateText
+    const result = await generateText({
+      model: openrouter.chat(model),
+      prompt,
+      maxTokens: 150,
+    });
+
+    await job.reportUsage({
+      model,
+      provider: 'openrouter',
+      inputTokens: result.usage.inputTokens ?? 0,
+      outputTokens: result.usage.outputTokens ?? 0,
+    });
+
+    return {
+      content: result.text,
+      inputTokens: result.usage.inputTokens,
+      outputTokens: result.usage.outputTokens,
+      finishReason: result.finishReason,
+    };
+  }, { connection: CONNECTION, concurrency: 1 });
+
+  let genResult: any = null;
+  genWorker.on('completed', (_job, result) => { genResult = result; });
+
+  const genJob = await queue.add('generate', {
+    prompt: 'Explain why message queues are important for AI applications in 2-3 sentences.',
+    model: MODELS.fast,
+    mode: 'generate',
+  });
+
+  // Wait for generation
+  const deadline = Date.now() + 60_000;
+  while (!genResult && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  if (genResult) {
+    console.log(`Response: ${genResult.content}`);
+    console.log(`Tokens: in=${genResult.inputTokens}, out=${genResult.outputTokens}`);
+    console.log(`Finish reason: ${genResult.finishReason}\n`);
+  }
+
+  // --- Example 2: streamText with job.stream ---
+  console.log('=== Example 2: streamText + job.stream ===\n');
+
+  let streamDone = false;
+  genWorker.on('completed', () => { streamDone = true; });
+
+  const streamJob = await queue.add('stream', {
+    prompt: 'Write a haiku about distributed systems.',
+    model: MODELS.fast,
+    mode: 'stream',
+  });
+
+  if (!streamJob) {
+    console.error('Failed to add stream job');
+    await cleanup(genWorker, queue);
+    process.exit(1);
+  }
+
+  // Read stream from consumer side
+  let lastId: string | undefined;
+  let done = false;
+  process.stdout.write('Streaming: ');
+
+  while (!done) {
+    const entries = await queue.readStream(streamJob.id, { lastId, count: 50 });
+    for (const entry of entries) {
+      lastId = entry.id;
+      if (entry.fields.done === '1') {
+        done = true;
+        break;
+      }
+      process.stdout.write(entry.fields.t);
+    }
+    if (!done && entries.length === 0) {
+      await new Promise(r => setTimeout(r, 100));
+    }
+  }
+
+  console.log('\n');
+
+  // Wait for stream job to fully complete
+  while (!streamDone && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 200));
+  }
+
+  // Check usage on completed job
+  const finishedJob = await queue.getJob(streamJob.id);
+  if (finishedJob?.usage) {
+    console.log(`Stream job usage: model=${finishedJob.usage.model}, in=${finishedJob.usage.inputTokens}, out=${finishedJob.usage.outputTokens}`);
+  }
+
+  await cleanup(genWorker, queue);
+  console.log('\n[OK] Vercel AI SDK example complete');
+  process.exit(0);
+}
+
+async function cleanup(worker: Worker, queue: Queue) {
+  await worker.close(true);
+  await queue.obliterate({ force: true });
+  await queue.close();
+}
+
+main().catch((err) => {
+  console.error('[ERROR]', err);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,29 @@
 {
   "name": "glide-mq",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glide-mq",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@glidemq/speedkey": "^0.2.0"
       },
       "devDependencies": {
+        "@ai-sdk/openai": "^3.0.48",
+        "@langchain/core": "^1.1.36",
+        "@langchain/openai": "^1.3.1",
         "@types/express": "^5.0.6",
         "@types/node": "^22",
+        "ai": "^6.0.138",
         "bullmq": "^5.69.2",
         "eslint": "^10.0.1",
         "eslint-config-prettier": "^10.1.8",
         "express": "^5.2.1",
         "ioredis": "^5.9.3",
+        "langchain": "^1.2.37",
         "prettier": "^3.8.1",
         "tsx": "^4.21.0",
         "typescript": "^5",
@@ -40,6 +45,79 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.80",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.80.tgz",
+      "integrity": "sha512-uM7kpZB5l977lW7+2X1+klBUxIZQ78+1a9jHlaHFEzcOcmmslTl3sdP0QqfuuBcO0YBM2gwOiqVdp8i4TRQYcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.21",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.48",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.48.tgz",
+      "integrity": "sha512-ALmj/53EXpcRqMbGpPJPP4UOSWw0q4VGpnDo7YctvsynjkrKDmoneDG/1a7VQnSPYHnJp6tTRMf5ZdxZ5whulg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.21"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.21.tgz",
+      "integrity": "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -769,6 +847,205 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@langchain/core": {
+      "version": "1.1.36",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.36.tgz",
+      "integrity": "sha512-9NWsdzU3uZD13lJwunXK0t6SIwew+UwcbHggW5yUdaiMmzKeNkDpp1lRD6p49N8+D0Vv4qmQBEKB4Ukh2jfnvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@langchain/langgraph": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.5.tgz",
+      "integrity": "sha512-O/ROF1oaXN7VK6+WTpXsDvJp7L+YyTOHa9rt3L85jrvwxBqQQRIlRLOWT8ehB/ywE3M1K7WAWOAXbmorCYzviQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph-checkpoint": "^1.0.1",
+        "@langchain/langgraph-sdk": "~1.8.0",
+        "@standard-schema/spec": "1.1.0",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.16",
+        "zod": "^3.25.32 || ^4.2.0",
+        "zod-to-json-schema": "^3.x"
+      },
+      "peerDependenciesMeta": {
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
+      "integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.1"
+      }
+    },
+    "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.0.tgz",
+      "integrity": "sha512-TPowjgfLjRll4zUDiOUVgd8qLgSOhy5uHt0sWhpvxgQd+dcUs4x/3nKjrepSvmp24KQKbF6GJy6MaHBDj3Ubtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^9.0.1",
+        "p-retry": "^7.1.1",
+        "uuid": "^13.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.16",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
+      "integrity": "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/openai": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.3.1.tgz",
+      "integrity": "sha512-6yN3XFRUKUsGREGk4VtCvnMp5NHh2gWujiuWdn/G7cCeHboYrdKLWnwGqopuFOm7Tivv423gtMN1GQ7EJ3kg+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12",
+        "openai": "^6.27.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.36"
+      }
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
@@ -852,6 +1129,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1267,6 +1554,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1402,6 +1696,13 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
@@ -1666,6 +1967,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1818,6 +2129,25 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/ai": {
+      "version": "6.0.138",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.138.tgz",
+      "integrity": "sha512-49OfPe0f5uxJ6jUdA5BBXjIinP6+ZdYfAtpF2aEH64GA5wPcxH2rf/TBUQQ0bbamBz/D+TLMV18xilZqOC+zaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.80",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.21",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1833,6 +2163,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/assertion-error": {
@@ -1854,6 +2197,27 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -1985,6 +2349,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -2000,6 +2377,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/check-error": {
@@ -2020,6 +2410,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/console-table-printer": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
+      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "simple-wcswidth": "^1.1.2"
       }
     },
     "node_modules/content-disposition": {
@@ -2110,6 +2510,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/deep-eql": {
@@ -2480,6 +2890,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -2920,6 +3347,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2934,6 +3374,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -2947,6 +3397,13 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -2970,6 +3427,79 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/langchain": {
+      "version": "1.2.37",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.2.37.tgz",
+      "integrity": "sha512-zjd0TpMfX8V440XJVavRmzLSvojVv5WZ7M9LWNtgYo0MDFTiWlCdnFNdHo1sZlNoI+8aSdLsVl/WXKtucyhwEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/langgraph": "^1.1.2",
+        "@langchain/langgraph-checkpoint": "^1.0.0",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.1.36"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.14.tgz",
+      "integrity": "sha512-4CBoZQrBOO1xXMVmAcinBoqzXXUel+Irr1rMslSMz6zgz8tGXOBWxMJXdhmNK3h2j35cZgJ/q9MbjDQZGsAkMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "^10.0.0",
+        "chalk": "^5.6.2",
+        "console-table-printer": "^2.12.1",
+        "p-queue": "^6.6.2",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/levn": {
@@ -3165,6 +3695,16 @@
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
       }
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3260,6 +3800,28 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openai": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.33.0.tgz",
+      "integrity": "sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3276,6 +3838,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -3308,6 +3880,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/parseurl": {
@@ -3807,6 +4425,13 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-wcswidth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -4321,6 +4946,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -54,13 +54,18 @@
     "@glidemq/speedkey": "^0.2.0"
   },
   "devDependencies": {
+    "@ai-sdk/openai": "^3.0.48",
+    "@langchain/core": "^1.1.36",
+    "@langchain/openai": "^1.3.1",
     "@types/express": "^5.0.6",
     "@types/node": "^22",
+    "ai": "^6.0.138",
     "bullmq": "^5.69.2",
     "eslint": "^10.0.1",
     "eslint-config-prettier": "^10.1.8",
     "express": "^5.2.1",
     "ioredis": "^5.9.3",
+    "langchain": "^1.2.37",
     "prettier": "^3.8.1",
     "tsx": "^4.21.0",
     "typescript": "^5",


### PR DESCRIPTION
## Summary

18 production-ready examples exercising all AI-native primitives, Valkey Search, and real framework integrations.

### Per-Primitive (10)
- `usage-tracking` - reportUsage / getFlowUsage cost breakdown
- `token-streaming` - job.stream / readStream with resume
- `human-approval` - suspend / signal with stdin interaction
- `adaptive-timeout` - per-job lockDuration (5s/30s/120s)
- `model-failover` - fallback chains (bogus -> nemotron -> liquid)
- `tpm-throttle` - tokenLimiter 300 TPM enforcement
- `budget-cap` - flow budget 200 tokens, exceeded at 201
- `rag-pipeline` - embed + search + streaming generate with budget
- `ai-agent-loop` - ReAct loop with suspend + fallbacks
- `content-pipeline` - classify + approve + polish with streaming

### Production Patterns (5)
- `vector-search` - Valkey FT.CREATE, HNSW, KNN, filtered search
- `embedding-pipeline` - batch embed with rate limiting + budget
- `agent-memory` - multi-turn chat with searchJobs + Valkey hash
- `search-dashboard` - searchJobs, getMetrics, retry, getJobCounts
- `broadcast-events` - 3 BroadcastWorkers with subject filters

### Framework Integrations (2)
- `with-vercel-ai-sdk` - AI SDK v6 generateText + streamText -> job.stream
- `with-langchain` - ChatOpenAI + chain pipeline with token callbacks

### Testing (1)
- `testing-mode` - 19 assertions, no Valkey or API key needed

### Infrastructure
- compose.yaml: standalone uses `valkey/valkey-bundle` (search+json modules)
- devDeps: ai, @ai-sdk/openai, @langchain/core, @langchain/openai, langchain

## Test plan

- [x] All 18 examples verified with real LLM calls (OpenRouter free tier)
- [x] Vector search verified against valkey-bundle
- [x] Framework integrations verified (AI SDK v6, LangChain)
- [x] testing-mode.ts: 19/19 assertions pass (no deps)
- [x] `npm run build` clean
- [x] No hardcoded secrets