### PR TITLE
chore: release 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.15.2] - 2026-05-08
+
+### Fixed
+
+- **Priority/LIFO jobs in batch-mode workers** (#212, #216): `Worker.tryPopFromLists` dispatched list-popped jobs through the single-job processor, which is a throwing sentinel in batch mode (`Single-job processor called in batch mode`). Any job enqueued with `priority` (or `lifo: true`) to a batch worker would fail. List-popped jobs are now routed through `activateAndProcessBatch`, chunked by `batch.size` so concurrency > 1 doesn't overflow the user's contract.
+
+- **`list-active` counter underflow on duplicate complete/fail/reclaim races** (#217, #218): 10 unguarded `DECR list-active` sites in the Lua FCALL library would underflow the per-queue counter on any path that produced two DECRs for one INCR (duplicate `complete`/`fail`, reclaim race, suspend-then-fail). Once underflowed, `getJobCounts()` returned negative `active` and `glidemq_healListActive` couldn't recover (its `<= 0` early-out is intentional - it only repairs positive drift). All 12 DECR sites now route through a single `decrListActive(listActiveKey)` Lua helper that guards on `> 0`. Note: counters that already underflowed under v0.15.1 are not auto-repaired; drain the queue or manually `SET <prefix>:list-active 0`. `LIBRARY_VERSION` bumped to `82`.
+
+- **Priority/LIFO active jobs invisible in dashboard, list-backed jobs reclaimed despite worker `lockDuration`** (#213, #219): two related bugs.
+  - `Queue.getJobs('active')` only read the stream consumer-group PEL, so priority/LIFO active jobs were invisible (the count and the listing disagreed by exactly the list-backed count). Added `glidemq_getActiveListJobIds` Lua FCALL (bounded SCAN, cluster-safe via `{queueName}` hash tag) and merged into `getJobs('active')`. Pre-existing batched-xrange shape mismatch in `resolveActiveJobIds` also fixed - stream-PEL → jobId resolution had been silently returning empty since speedkey changed format.
+  - The scheduler conflated `stalledInterval` (cadence) with the stall threshold; both reclaim FCALLs received `stalledInterval` as `minIdleMs`. With `{ lockDuration: 300_000, stalledInterval: 30_000 }`, jobs were reclaimed after 30s despite the 5min lock. The contract is now restored: `lockDuration` is the threshold, `stalledInterval` is the cadence. `glidemq_reclaimStalled` and `glidemq_reclaimStalledListJobs` accept a new `workerLockDuration` arg; per-entry threshold falls back to it before `minIdleMs`. Per-job `opts.lockDuration` overrides still win. `LIBRARY_VERSION` bumped to `84`.
+
+### Behavior change
+
+- Workers that previously relied on a short `stalledInterval` for fast stall recovery (without setting `lockDuration`) will see slower recovery. Default `lockDuration` is 30s, so the new threshold is 30s for those configurations. To preserve the old behavior, set `lockDuration` explicitly to match `stalledInterval`.
+
+---
+
 ## [0.15.1] - 2026-04-06
 
 ### Fixed

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -207,8 +207,8 @@ const worker = new Worker(
     connection,
     concurrency: 10, // process up to 10 jobs in parallel (default: 1)
     blockTimeout: 5_000, // XREADGROUP BLOCK timeout in ms
-    stalledInterval: 30_000, // how often to check for stalled jobs
-    lockDuration: 30_000, // stall detection window per job
+    stalledInterval: 30_000, // how often the scheduler checks for stalled jobs (cadence)
+    lockDuration: 30_000, // stall detection window per job (threshold) - jobs idle this long are reclaimed
     limiter: { max: 100, duration: 60_000 }, // rate limit: 100 jobs / min
     deadLetterQueue: { name: 'dlq' }, // inherited from QueueOptions - can also set on Queue constructor
     backoffStrategies: {
@@ -832,6 +832,8 @@ Jobs report token consumption via job.reportTokens(count) or automatically via j
 
 Override the worker-level lockDuration for individual jobs via opts.lockDuration. Useful for mixed workloads where some jobs are fast and others are long-running. The per-job lockDuration is read by glidemq_reclaimStalled and glidemq_reclaimStalledListJobs to set the stall threshold per job.
 
+The stall threshold resolution chain is: per-job `opts.lockDuration` (if set) > worker-level `lockDuration` > `stalledInterval`. Use a short `stalledInterval` only to make the scheduler check more often - it is not the threshold. To get fast stall recovery, set `lockDuration` to the small value, not `stalledInterval`.
+
 ### Vector Search (createJobIndex / storeVector / vectorSearch)
 
 Create a Valkey Search index over job hashes, store vector embeddings, and run KNN similarity search. Requires the Valkey Search module.
@@ -860,53 +862,53 @@ proxy.app.listen(3000);
 - Add your own auth/rate-limit middleware before exposing the proxy to a network. The proxy does not ship built-in authentication.
 - Queue-wide SSE (`/queues/:name/events`) and broadcast SSE (`/broadcast/:name/events`) require `connection`, not just a shared `client`, because they allocate blocking readers internally.
 
-| Method | Path                                 | Description                                                                                                                                                 |
-| ------ | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| POST   | /queues/:name/jobs                   | Add a single job.                                                                                                                                           |
-| POST   | /queues/:name/jobs/bulk              | Add multiple jobs in one request.                                                                                                                           |
-| GET    | /queues/:name/jobs?state=waiting     | List jobs by state. Supports `start`, `end`, and `excludeData=true`.                                                                                        |
-| POST   | /queues/:name/jobs/wait              | Add a job and wait for the final worker result in the same request.                                                                                         |
-| GET    | /queues/:name/jobs/:id               | Fetch one job by ID.                                                                                                                                        |
-| POST   | /queues/:name/jobs/:id/priority      | Change a waiting/prioritized/delayed job's priority.                                                                                                        |
-| POST   | /queues/:name/jobs/:id/delay         | Change a job's delay or move it into delayed state.                                                                                                         |
-| POST   | /queues/:name/jobs/:id/promote       | Promote a delayed job immediately.                                                                                                                          |
-| GET    | /queues/:name/jobs/:id/stream        | SSE stream of job output chunks. Supports `Last-Event-ID` and `?lastId=`.                                                                                   |
-| GET    | /queues/:name/jobs/:id/events        | SSE stream of lifecycle events for one job only. Supports `Last-Event-ID` and `?lastId=` replay.                                                           |
-| GET    | /queues/:name/jobs/:id/suspend       | Read suspend metadata for one suspended job.                                                                                                                |
-| POST   | /queues/:name/jobs/:id/signal        | Send a signal to a suspended job. Body: `{ "name": "...", "data": ... }`.                                                                                   |
-| POST   | /queues/:name/jobs/:id/revoke        | Revoke a job. Returns `{ status: "revoked" }` or `{ status: "flagged" }`.                                                                                 |
-| GET    | /queues/:name/dlq                    | List dead-letter jobs for the queue. Supports `start` and `end`.                                                                                            |
-| GET    | /queues/:name/dlq/:id                | Fetch one dead-letter job by DLQ job ID.                                                                                                                    |
-| POST   | /queues/:name/dlq/:id/replay         | Replay one dead-letter job back into its original queue.                                                                                                    |
-| POST   | /queues/:name/dlq/replay-all         | Replay multiple dead-letter jobs. Optional body/query `count`.                                                                                              |
-| DELETE | /queues/:name/dlq/:id                | Permanently remove one dead-letter job.                                                                                                                     |
-| GET    | /queues/:name/events                 | Queue-wide SSE stream of lifecycle events. Supports `Last-Event-ID` and `?lastId=` replay.                                                                  |
-| POST   | /queues/:name/pause                  | Pause the queue.                                                                                                                                            |
-| POST   | /queues/:name/resume                 | Resume the queue.                                                                                                                                           |
-| GET    | /queues/:name/counts                 | Return waiting/active/delayed/completed/failed counts.                                                                                                      |
-| GET    | /queues/:name/metrics?type=completed | Return total count plus per-minute metrics data.                                                                                                            |
-| GET    | /queues/:name/workers                | List live workers for the queue.                                                                                                                            |
-| GET    | /queues/:name/suspended              | List jobs currently in the suspended state, including suspend metadata.                                                                                     |
-| GET    | /queues/:name/rate-limit             | Read the current queue-wide global rate limit.                                                                                                              |
-| PUT    | /queues/:name/rate-limit             | Set the queue-wide global rate limit. Body: `{ max, duration }`.                                                                                            |
-| DELETE | /queues/:name/rate-limit             | Remove the queue-wide global rate limit.                                                                                                                    |
-| POST   | /queues/:name/drain                  | Remove waiting jobs. Pass `?delayed=true` to also remove delayed jobs.                                                                                      |
-| POST   | /queues/:name/retry                  | Retry failed jobs. Optional body/query `count`.                                                                                                             |
-| DELETE | /queues/:name/clean                  | Remove old completed/failed jobs. Requires `state` and `age` seconds; optional `limit`.                                                                     |
-| GET    | /queues/:name/schedulers             | List registered schedulers.                                                                                                                                 |
-| GET    | /queues/:name/schedulers/:id         | Fetch one scheduler entry by name.                                                                                                                          |
-| PUT    | /queues/:name/schedulers/:id         | Upsert a scheduler. Body: `{ schedule, template? }`.                                                                                                        |
-| DELETE | /queues/:name/schedulers/:id         | Remove a scheduler by name.                                                                                                                                 |
-| POST   | /flows                               | Create a tree flow or DAG over HTTP. Body: `{ flow, budget? }` or `{ dag }`. `budget` is currently supported for tree flows only.                         |
-| GET    | /flows/:id                           | Read the current flow snapshot: nodes, roots, counts, usage, and budget state.                                                                              |
-| GET    | /flows/:id/tree                      | Read the nested tree view for a tree flow or DAG.                                                                                                           |
-| DELETE | /flows/:id                           | Revoke or flag remaining jobs in the flow and remove the HTTP flow record.                                                                                  |
-| GET    | /queues/:name/flows/:parentId/usage  | Aggregate AI usage across a flow.                                                                                                                           |
-| GET    | /queues/:name/flows/:flowId/budget   | Read current flow budget state.                                                                                                                             |
+| Method | Path                                 | Description                                                                                                                                              |
+| ------ | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| POST   | /queues/:name/jobs                   | Add a single job.                                                                                                                                        |
+| POST   | /queues/:name/jobs/bulk              | Add multiple jobs in one request.                                                                                                                        |
+| GET    | /queues/:name/jobs?state=waiting     | List jobs by state. Supports `start`, `end`, and `excludeData=true`.                                                                                     |
+| POST   | /queues/:name/jobs/wait              | Add a job and wait for the final worker result in the same request.                                                                                      |
+| GET    | /queues/:name/jobs/:id               | Fetch one job by ID.                                                                                                                                     |
+| POST   | /queues/:name/jobs/:id/priority      | Change a waiting/prioritized/delayed job's priority.                                                                                                     |
+| POST   | /queues/:name/jobs/:id/delay         | Change a job's delay or move it into delayed state.                                                                                                      |
+| POST   | /queues/:name/jobs/:id/promote       | Promote a delayed job immediately.                                                                                                                       |
+| GET    | /queues/:name/jobs/:id/stream        | SSE stream of job output chunks. Supports `Last-Event-ID` and `?lastId=`.                                                                                |
+| GET    | /queues/:name/jobs/:id/events        | SSE stream of lifecycle events for one job only. Supports `Last-Event-ID` and `?lastId=` replay.                                                         |
+| GET    | /queues/:name/jobs/:id/suspend       | Read suspend metadata for one suspended job.                                                                                                             |
+| POST   | /queues/:name/jobs/:id/signal        | Send a signal to a suspended job. Body: `{ "name": "...", "data": ... }`.                                                                                |
+| POST   | /queues/:name/jobs/:id/revoke        | Revoke a job. Returns `{ status: "revoked" }` or `{ status: "flagged" }`.                                                                                |
+| GET    | /queues/:name/dlq                    | List dead-letter jobs for the queue. Supports `start` and `end`.                                                                                         |
+| GET    | /queues/:name/dlq/:id                | Fetch one dead-letter job by DLQ job ID.                                                                                                                 |
+| POST   | /queues/:name/dlq/:id/replay         | Replay one dead-letter job back into its original queue.                                                                                                 |
+| POST   | /queues/:name/dlq/replay-all         | Replay multiple dead-letter jobs. Optional body/query `count`.                                                                                           |
+| DELETE | /queues/:name/dlq/:id                | Permanently remove one dead-letter job.                                                                                                                  |
+| GET    | /queues/:name/events                 | Queue-wide SSE stream of lifecycle events. Supports `Last-Event-ID` and `?lastId=` replay.                                                               |
+| POST   | /queues/:name/pause                  | Pause the queue.                                                                                                                                         |
+| POST   | /queues/:name/resume                 | Resume the queue.                                                                                                                                        |
+| GET    | /queues/:name/counts                 | Return waiting/active/delayed/completed/failed counts.                                                                                                   |
+| GET    | /queues/:name/metrics?type=completed | Return total count plus per-minute metrics data.                                                                                                         |
+| GET    | /queues/:name/workers                | List live workers for the queue.                                                                                                                         |
+| GET    | /queues/:name/suspended              | List jobs currently in the suspended state, including suspend metadata.                                                                                  |
+| GET    | /queues/:name/rate-limit             | Read the current queue-wide global rate limit.                                                                                                           |
+| PUT    | /queues/:name/rate-limit             | Set the queue-wide global rate limit. Body: `{ max, duration }`.                                                                                         |
+| DELETE | /queues/:name/rate-limit             | Remove the queue-wide global rate limit.                                                                                                                 |
+| POST   | /queues/:name/drain                  | Remove waiting jobs. Pass `?delayed=true` to also remove delayed jobs.                                                                                   |
+| POST   | /queues/:name/retry                  | Retry failed jobs. Optional body/query `count`.                                                                                                          |
+| DELETE | /queues/:name/clean                  | Remove old completed/failed jobs. Requires `state` and `age` seconds; optional `limit`.                                                                  |
+| GET    | /queues/:name/schedulers             | List registered schedulers.                                                                                                                              |
+| GET    | /queues/:name/schedulers/:id         | Fetch one scheduler entry by name.                                                                                                                       |
+| PUT    | /queues/:name/schedulers/:id         | Upsert a scheduler. Body: `{ schedule, template? }`.                                                                                                     |
+| DELETE | /queues/:name/schedulers/:id         | Remove a scheduler by name.                                                                                                                              |
+| POST   | /flows                               | Create a tree flow or DAG over HTTP. Body: `{ flow, budget? }` or `{ dag }`. `budget` is currently supported for tree flows only.                        |
+| GET    | /flows/:id                           | Read the current flow snapshot: nodes, roots, counts, usage, and budget state.                                                                           |
+| GET    | /flows/:id/tree                      | Read the nested tree view for a tree flow or DAG.                                                                                                        |
+| DELETE | /flows/:id                           | Revoke or flag remaining jobs in the flow and remove the HTTP flow record.                                                                               |
+| GET    | /queues/:name/flows/:parentId/usage  | Aggregate AI usage across a flow.                                                                                                                        |
+| GET    | /queues/:name/flows/:flowId/budget   | Read current flow budget state.                                                                                                                          |
 | GET    | /usage/summary                       | Rolling AI usage summary. Supports `windowMs` (or legacy `window`) in ms, `start`/`end` as epoch ms, and `queues=a,b` (for example `?windowMs=3600000`). |
-| POST   | /broadcast/:name                     | Publish a broadcast message. Body: `{ subject, data, opts? }`.                                                                                              |
-| GET    | /broadcast/:name/events              | SSE broadcast stream. Requires `subscription`; optional `subjects=a.*,b.>` filter.                                                                          |
-| GET    | /health                              | Health check and proxy uptime.                                                                                                                              |
+| POST   | /broadcast/:name                     | Publish a broadcast message. Body: `{ subject, data, opts? }`.                                                                                           |
+| GET    | /broadcast/:name/events              | SSE broadcast stream. Requires `subscription`; optional `subjects=a.*,b.>` filter.                                                                       |
+| GET    | /health                              | Health check and proxy uptime.                                                                                                                           |
 
 - `POST /flows` supports both FlowProducer-style trees and DAG payloads. Queue names inside the submitted flow must pass the proxy allowlist.
 - Flow budgets are persisted and returned through `/flows/:id` and `/queues/:name/flows/:id/budget`, but HTTP-submitted budgets are currently supported only for tree flows, not DAG payloads.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glide-mq",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glide-mq",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@glidemq/speedkey": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glide-mq",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "High-performance message queue for Node.js with AI-native primitives - built on Valkey/Redis with Rust NAPI bindings",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/skills/glide-mq/SKILL.md
+++ b/skills/glide-mq/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: glide-mq
-  version: "0.14.0"
+  version: '0.14.0'
   tags: glide-mq, message-queue, valkey, redis, job-queue, worker, streams, ai-native, llm, vector-search
   sources: docs/USAGE.md, docs/ADVANCED.md, docs/WORKFLOWS.md, docs/BROADCAST.md, docs/SERVERLESS.md, docs/TESTING.md, docs/OBSERVABILITY.md
 ---
@@ -34,10 +34,14 @@ const connection = { addresses: [{ host: 'localhost', port: 6379 }] };
 const queue = new Queue('tasks', { connection });
 await queue.add('send-email', { to: 'user@example.com', subject: 'Hello' });
 
-const worker = new Worker('tasks', async (job) => {
-  console.log(`Processing ${job.name}:`, job.data);
-  return { sent: true };
-}, { connection, concurrency: 10 });
+const worker = new Worker(
+  'tasks',
+  async (job) => {
+    console.log(`Processing ${job.name}:`, job.data);
+    return { sent: true };
+  },
+  { connection, concurrency: 10 },
+);
 
 worker.on('completed', (job) => console.log(`Done: ${job.id}`));
 worker.on('failed', (job, err) => console.error(`Failed: ${job.id}`, err.message));
@@ -46,6 +50,7 @@ worker.on('failed', (job, err) => console.error(`Failed: ${job.id}`, err.message
 ## When to Apply
 
 Use this skill when:
+
 - Creating or configuring queues, workers, or producers
 - Adding jobs (single, bulk, delayed, priority)
 - Setting up retries, backoff, or dead-letter queues
@@ -68,18 +73,18 @@ Use this skill when:
 
 ## Core API by Priority
 
-| Priority | Category | Impact | Reference |
-|----------|----------|--------|-----------|
-| 1 | Queue & Job Operations | CRITICAL | [references/queue.md](references/queue.md) |
-| 2 | Worker & Processing | CRITICAL | [references/worker.md](references/worker.md) |
-| 3 | Connection & Config | HIGH | [references/connection.md](references/connection.md) |
-| 4 | Workflows & FlowProducer | HIGH | [references/workflows.md](references/workflows.md) |
-| 5 | Broadcast (Fan-Out) | MEDIUM | [references/broadcast.md](references/broadcast.md) |
-| 6 | Schedulers (Cron/Interval) | MEDIUM | [references/schedulers.md](references/schedulers.md) |
-| 7 | Observability & Events | MEDIUM | [references/observability.md](references/observability.md) |
-| 8 | AI-Native Primitives | HIGH | [references/ai-native.md](references/ai-native.md) |
-| 9 | Vector Search | MEDIUM | [references/search.md](references/search.md) |
-| 10 | Serverless & Testing | LOW | [references/serverless.md](references/serverless.md) |
+| Priority | Category                   | Impact   | Reference                                                  |
+| -------- | -------------------------- | -------- | ---------------------------------------------------------- |
+| 1        | Queue & Job Operations     | CRITICAL | [references/queue.md](references/queue.md)                 |
+| 2        | Worker & Processing        | CRITICAL | [references/worker.md](references/worker.md)               |
+| 3        | Connection & Config        | HIGH     | [references/connection.md](references/connection.md)       |
+| 4        | Workflows & FlowProducer   | HIGH     | [references/workflows.md](references/workflows.md)         |
+| 5        | Broadcast (Fan-Out)        | MEDIUM   | [references/broadcast.md](references/broadcast.md)         |
+| 6        | Schedulers (Cron/Interval) | MEDIUM   | [references/schedulers.md](references/schedulers.md)       |
+| 7        | Observability & Events     | MEDIUM   | [references/observability.md](references/observability.md) |
+| 8        | AI-Native Primitives       | HIGH     | [references/ai-native.md](references/ai-native.md)         |
+| 9        | Vector Search              | MEDIUM   | [references/search.md](references/search.md)               |
+| 10       | Serverless & Testing       | LOW      | [references/serverless.md](references/serverless.md)       |
 
 ## Key Patterns
 
@@ -96,17 +101,17 @@ await queue.add('low-priority', data, { priority: 10 });
 // Retries with exponential backoff
 await queue.add('webhook', data, {
   attempts: 5,
-  backoff: { type: 'exponential', delay: 1000 }
+  backoff: { type: 'exponential', delay: 1000 },
 });
 ```
 
 ### Bulk Ingestion (10,000 jobs in ~350ms)
 
 ```typescript
-const jobs = items.map(item => ({
+const jobs = items.map((item) => ({
   name: 'process',
   data: item,
-  opts: { jobId: `item-${item.id}` }
+  opts: { jobId: `item-${item.id}` },
 }));
 await queue.addBulk(jobs);
 ```
@@ -114,21 +119,34 @@ await queue.addBulk(jobs);
 ### Batch Worker (Process Multiple Jobs at Once)
 
 ```typescript
-const worker = new Worker('analytics', async (jobs) => {
-  // jobs is Job[] when batch is enabled
-  await db.insertMany('events', jobs.map(j => j.data));
-}, {
-  connection,
-  batch: { size: 50, timeout: 5000 }
-});
+const worker = new Worker(
+  'analytics',
+  async (jobs) => {
+    // jobs is Job[] when batch is enabled
+    await db.insertMany(
+      'events',
+      jobs.map((j) => j.data),
+    );
+  },
+  {
+    connection,
+    batch: { size: 50, timeout: 5000 },
+  },
+);
 ```
+
+Batch mode is composable with `priority` and `lifo: true` jobs - list-popped jobs are dispatched into the same batch processor (chunked by `batch.size`).
 
 ### Request-Reply (addAndWait)
 
 ```typescript
-const result = await queue.addAndWait('compute', { input: 42 }, {
-  waitTimeout: 30_000
-});
+const result = await queue.addAndWait(
+  'compute',
+  { input: 42 },
+  {
+    waitTimeout: 30_000,
+  },
+);
 console.log(result); // processor return value
 ```
 
@@ -169,33 +187,33 @@ await worker.run();
 
 ## Problem-to-Reference Mapping
 
-| Problem | Start With |
-|---------|------------|
-| Need to create a queue and add jobs | [references/queue.md](references/queue.md) |
-| Need to process jobs with workers | [references/worker.md](references/worker.md) |
-| Jobs failing, need retries/backoff | [references/queue.md](references/queue.md) - Retry section |
-| Need parent-child job dependencies | [references/workflows.md](references/workflows.md) |
-| Need fan-out to multiple consumers | [references/broadcast.md](references/broadcast.md) |
-| Need cron or repeating jobs | [references/schedulers.md](references/schedulers.md) |
-| Connection errors or TLS/IAM setup | [references/connection.md](references/connection.md) |
-| Stalled jobs or lock issues | [references/worker.md](references/worker.md) - Stalled Jobs |
-| Need real-time job events | [references/observability.md](references/observability.md) |
-| Integrating with Fastify/NestJS/Hono | [Framework Integrations](https://www.glidemq.dev/integrations/) |
-| Deploying to Lambda/Vercel Edge | [references/serverless.md](references/serverless.md) |
-| Need deduplication or idempotent jobs | [references/queue.md](references/queue.md) - Dedup |
-| Need rate limiting | [references/queue.md](references/queue.md) - Rate Limit |
-| Running tests without Valkey | [references/serverless.md](references/serverless.md) - Testing |
-| Need to track LLM tokens/cost per job | [references/ai-native.md](references/ai-native.md) - Usage Metadata |
-| Need to stream LLM output tokens | [references/ai-native.md](references/ai-native.md) - Token Streaming |
-| Need human approval before proceeding | [references/ai-native.md](references/ai-native.md) - Suspend/Resume |
-| Need to cap token/cost budget on a flow | [references/ai-native.md](references/ai-native.md) - Budget |
-| Need model fallback on failure | [references/ai-native.md](references/ai-native.md) - Fallback Chains |
-| Need RPM + TPM rate limiting for LLM APIs | [references/ai-native.md](references/ai-native.md) - Dual-Axis Rate Limiting |
-| Need rolling usage/cost summary across queues | [references/ai-native.md](references/ai-native.md) - Usage Metadata |
-| Need vector similarity search over jobs | [references/search.md](references/search.md) |
-| Need to aggregate usage across a flow | [references/ai-native.md](references/ai-native.md) - Flow Usage |
-| Need to create or inspect flows over HTTP | [references/serverless.md](references/serverless.md) - HTTP Proxy |
-| Need cross-language HTTP or SSE access | [references/serverless.md](references/serverless.md) - HTTP Proxy |
+| Problem                                       | Start With                                                                   |
+| --------------------------------------------- | ---------------------------------------------------------------------------- |
+| Need to create a queue and add jobs           | [references/queue.md](references/queue.md)                                   |
+| Need to process jobs with workers             | [references/worker.md](references/worker.md)                                 |
+| Jobs failing, need retries/backoff            | [references/queue.md](references/queue.md) - Retry section                   |
+| Need parent-child job dependencies            | [references/workflows.md](references/workflows.md)                           |
+| Need fan-out to multiple consumers            | [references/broadcast.md](references/broadcast.md)                           |
+| Need cron or repeating jobs                   | [references/schedulers.md](references/schedulers.md)                         |
+| Connection errors or TLS/IAM setup            | [references/connection.md](references/connection.md)                         |
+| Stalled jobs or lock issues                   | [references/worker.md](references/worker.md) - Stalled Jobs                  |
+| Need real-time job events                     | [references/observability.md](references/observability.md)                   |
+| Integrating with Fastify/NestJS/Hono          | [Framework Integrations](https://www.glidemq.dev/integrations/)              |
+| Deploying to Lambda/Vercel Edge               | [references/serverless.md](references/serverless.md)                         |
+| Need deduplication or idempotent jobs         | [references/queue.md](references/queue.md) - Dedup                           |
+| Need rate limiting                            | [references/queue.md](references/queue.md) - Rate Limit                      |
+| Running tests without Valkey                  | [references/serverless.md](references/serverless.md) - Testing               |
+| Need to track LLM tokens/cost per job         | [references/ai-native.md](references/ai-native.md) - Usage Metadata          |
+| Need to stream LLM output tokens              | [references/ai-native.md](references/ai-native.md) - Token Streaming         |
+| Need human approval before proceeding         | [references/ai-native.md](references/ai-native.md) - Suspend/Resume          |
+| Need to cap token/cost budget on a flow       | [references/ai-native.md](references/ai-native.md) - Budget                  |
+| Need model fallback on failure                | [references/ai-native.md](references/ai-native.md) - Fallback Chains         |
+| Need RPM + TPM rate limiting for LLM APIs     | [references/ai-native.md](references/ai-native.md) - Dual-Axis Rate Limiting |
+| Need rolling usage/cost summary across queues | [references/ai-native.md](references/ai-native.md) - Usage Metadata          |
+| Need vector similarity search over jobs       | [references/search.md](references/search.md)                                 |
+| Need to aggregate usage across a flow         | [references/ai-native.md](references/ai-native.md) - Flow Usage              |
+| Need to create or inspect flows over HTTP     | [references/serverless.md](references/serverless.md) - HTTP Proxy            |
+| Need cross-language HTTP or SSE access        | [references/serverless.md](references/serverless.md) - HTTP Proxy            |
 
 ## Critical Notes
 


### PR DESCRIPTION
Patch release rolling up three community-bug fixes from @jonathanong.

## Includes

| PR | Issue | Summary |
|---|---|---|
| #216 | #212 | Route priority/LIFO jobs through batch processor in batch-mode workers |
| #218 | #217 | Guard every `list-active` DECR via `decrListActive` helper - prevents counter underflow |
| #219 | #213 | List-backed active jobs visible in `getJobs('active')`; stall reclaim respects `lockDuration` |

## Library version bumps in this release

- 81 → 82: `decrListActive` helper guard
- 82 → 83: `glidemq_getActiveListJobIds` SCAN
- 83 → 84: `workerLockDuration` arg on reclaim FCALLs

Existing standalone clients pick up the new Lua on next connection (`ensureFunctionLibrary` reloads on version mismatch).

## Behavior change

Workers configured with a short `stalledInterval` for fast stall recovery without setting `lockDuration` will see slower recovery (default `lockDuration` is 30s, which now dominates). Documented in the CHANGELOG entry under "Behavior change". Workaround: set `lockDuration` explicitly to match `stalledInterval`.

## Release procedure (after merge)

Tag `v0.15.2` on the merge commit - the `npm-cd.yml` workflow publishes on `v*.*.*` tags.

```
git tag -s v0.15.2 -m "Release v0.15.2"
git push origin v0.15.2
```

## Test plan
- [x] CHANGELOG.md entry follows the existing Keep-a-Changelog format
- [x] `package.json` / `package-lock.json` bumped to 0.15.2 via `npm version`
- [ ] Tag pushed after merge

https://claude.ai/code/session_0128GdoyGoJWcZQccPHTuRgx

---
_Generated by [Claude Code](https://claude.ai/code/session_0128GdoyGoJWcZQccPHTuRgx)_