### PR TITLE
fix(dlq): scope shared DLQ entries to owning queue

### DIFF
--- a/src/queue.ts
+++ b/src/queue.ts
@@ -2377,8 +2377,10 @@ export class Queue<D = any, R = any> extends EventEmitter {
 
       for (let offset = 0; offset < candidateJobIds.length; offset += PIPELINE_CHUNK_SIZE) {
         const chunkJobIds = candidateJobIds.slice(offset, offset + PIPELINE_CHUNK_SIZE);
+        // Always load data internally so the ownership envelope is available, then
+        // strip data on the way out when the caller asked for excludeData.
         const chunkJobs = await this.loadJobsByIdsForKeys(client, dlqKeys, chunkJobIds, {
-          excludeData: opts?.excludeData,
+          excludeData: false,
           serializer: undefined,
         });
         const scopedChunkJobs = chunkJobs.filter((job) => this.isDeadLetterJobOwnedByQueue(job));
@@ -2390,7 +2392,14 @@ export class Queue<D = any, R = any> extends EventEmitter {
 
         const sliceStart = Math.max(0, start - seenExisting);
         const remaining = Number.isFinite(targetCount) ? targetCount - selected.length : undefined;
-        selected.push(...scopedChunkJobs.slice(sliceStart, remaining != null ? sliceStart + remaining : undefined));
+        const pageSlice = scopedChunkJobs.slice(sliceStart, remaining != null ? sliceStart + remaining : undefined);
+        if (opts?.excludeData) {
+          for (const job of pageSlice) {
+            (job as { data: unknown }).data = undefined;
+            (job as { returnvalue: unknown }).returnvalue = undefined;
+          }
+        }
+        selected.push(...pageSlice);
         seenExisting += scopedChunkJobs.length;
 
         if (Number.isFinite(targetCount) && selected.length >= targetCount) {
@@ -2430,12 +2439,18 @@ export class Queue<D = any, R = any> extends EventEmitter {
     const dlqName = await this.resolveDeadLetterQueueName(client);
     if (!dlqName) return null;
     const dlqKeys = buildKeys(dlqName, this.opts.prefix);
+    // Always load data internally so the ownership envelope is available; strip it
+    // afterwards when the caller asked for excludeData.
     const jobs = await this.loadJobsByIdsForKeys(client, dlqKeys, [jobId], {
-      excludeData: opts?.excludeData,
+      excludeData: false,
       serializer: undefined,
     });
     const job = jobs[0] ?? null;
     if (!job || !this.isDeadLetterJobOwnedByQueue(job)) return null;
+    if (opts?.excludeData) {
+      (job as { data: unknown }).data = undefined;
+      (job as { returnvalue: unknown }).returnvalue = undefined;
+    }
     return job;
   }
 
@@ -2448,6 +2463,8 @@ export class Queue<D = any, R = any> extends EventEmitter {
     const dlqName = await this.resolveDeadLetterQueueName(client);
     if (!dlqName) return false;
     const dlqKeys = buildKeys(dlqName, this.opts.prefix);
+    // Ownership check requires the envelope (originalQueue lives in data); excludeData
+    // is honoured inside getDeadLetterJob, which still loads the envelope internally.
     const existing = await this.getDeadLetterJob(jobId, { excludeData: true });
     if (!existing) return false;
     await removeJob(client, dlqKeys, jobId);

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -2381,16 +2381,17 @@ export class Queue<D = any, R = any> extends EventEmitter {
           excludeData: opts?.excludeData,
           serializer: undefined,
         });
+        const scopedChunkJobs = chunkJobs.filter((job) => this.isDeadLetterJobOwnedByQueue(job));
 
-        if (seenExisting + chunkJobs.length <= start) {
-          seenExisting += chunkJobs.length;
+        if (seenExisting + scopedChunkJobs.length <= start) {
+          seenExisting += scopedChunkJobs.length;
           continue;
         }
 
         const sliceStart = Math.max(0, start - seenExisting);
         const remaining = Number.isFinite(targetCount) ? targetCount - selected.length : undefined;
-        selected.push(...chunkJobs.slice(sliceStart, remaining != null ? sliceStart + remaining : undefined));
-        seenExisting += chunkJobs.length;
+        selected.push(...scopedChunkJobs.slice(sliceStart, remaining != null ? sliceStart + remaining : undefined));
+        seenExisting += scopedChunkJobs.length;
 
         if (Number.isFinite(targetCount) && selected.length >= targetCount) {
           break;
@@ -2433,7 +2434,9 @@ export class Queue<D = any, R = any> extends EventEmitter {
       excludeData: opts?.excludeData,
       serializer: undefined,
     });
-    return jobs[0] ?? null;
+    const job = jobs[0] ?? null;
+    if (!job || !this.isDeadLetterJobOwnedByQueue(job)) return null;
+    return job;
   }
 
   /**
@@ -2459,23 +2462,14 @@ export class Queue<D = any, R = any> extends EventEmitter {
     const dlqJob = await this.getDeadLetterJob(jobId);
     if (!dlqJob) return null;
 
-    const envelope = dlqJob.data as
-      | {
-          attemptsMade?: number;
-          data?: unknown;
-          failedReason?: string;
-          originalJobId?: string;
-          originalQueue?: string;
-        }
-      | undefined;
-
-    if (!envelope?.originalQueue || typeof envelope.originalQueue !== 'string') {
+    const originalQueueName = this.getDeadLetterOriginalQueue(dlqJob);
+    if (!originalQueueName) {
       throw new GlideMQError('DLQ entry is missing originalQueue metadata');
     }
-    validateQueueName(envelope.originalQueue);
+    validateQueueName(originalQueueName);
 
     const client = await this.getClient();
-    const originalQueue = new Queue<any, any>(envelope.originalQueue, {
+    const originalQueue = new Queue<any, any>(originalQueueName, {
       client,
       compression: this.opts.compression,
       connection: this.opts.connection,
@@ -2484,10 +2478,10 @@ export class Queue<D = any, R = any> extends EventEmitter {
     });
 
     try {
-      let replayData = envelope.data;
+      const envelope = dlqJob.data as { originalJobId?: string; data?: unknown } | undefined;
+      let replayData = envelope?.data;
       let replayOpts: JobOptions | undefined;
-
-      if (envelope.originalJobId) {
+      if (envelope?.originalJobId) {
         const originalJob = await originalQueue.getJob(envelope.originalJobId);
         if (originalJob) {
           replayData = originalJob.data;
@@ -2512,6 +2506,15 @@ export class Queue<D = any, R = any> extends EventEmitter {
     } finally {
       await originalQueue.close().catch(() => undefined);
     }
+  }
+
+  private getDeadLetterOriginalQueue(job: Job<any, any>): string | null {
+    const data = job.data as { originalQueue?: unknown } | undefined;
+    return typeof data?.originalQueue === 'string' ? data.originalQueue : null;
+  }
+
+  private isDeadLetterJobOwnedByQueue(job: Job<any, any>): boolean {
+    return this.getDeadLetterOriginalQueue(job) === this.name;
   }
 
   /**

--- a/tests/deep-dlq.test.ts
+++ b/tests/deep-dlq.test.ts
@@ -711,8 +711,9 @@ describeEachMode('Dead Letter Queue', (CONNECTION) => {
       await blockedQueue.add('blocked-job', { secret: true }, { attempts: 1 });
 
       await waitFor(async () => {
-        const jobs = await allowedQueue.getDeadLetterJobs();
-        return jobs.length === 1;
+        const allowed = await allowedQueue.getDeadLetterJobs();
+        const blocked = await blockedQueue.getDeadLetterJobs();
+        return allowed.length === 1 && blocked.length === 1;
       });
 
       const allowedJobs = await allowedQueue.getDeadLetterJobs();

--- a/tests/deep-dlq.test.ts
+++ b/tests/deep-dlq.test.ts
@@ -675,4 +675,63 @@ describeEachMode('Dead Letter Queue', (CONNECTION) => {
     const dlqData = dlqJobs[0].data as any;
     expect(dlqData.originalQueue).toBe(queueName);
   });
+
+  it('shared DLQ methods scope jobs to the owning queue', async () => {
+    const sharedDlqName = `${uid()}-shared`;
+    const allowedQueueName = uid();
+    const blockedQueueName = uid();
+    const allowedQueue = new Queue(allowedQueueName, {
+      connection: CONNECTION,
+      deadLetterQueue: { name: sharedDlqName },
+    });
+    const blockedQueue = new Queue(blockedQueueName, {
+      connection: CONNECTION,
+      deadLetterQueue: { name: sharedDlqName },
+    });
+    const allowedWorker = new Worker(
+      allowedQueueName,
+      async () => {
+        throw new Error('allowed failure');
+      },
+      { connection: CONNECTION, deadLetterQueue: { name: sharedDlqName }, stalledInterval: 60000 },
+    );
+    const blockedWorker = new Worker(
+      blockedQueueName,
+      async () => {
+        throw new Error('blocked failure');
+      },
+      { connection: CONNECTION, deadLetterQueue: { name: sharedDlqName }, stalledInterval: 60000 },
+    );
+
+    try {
+      await allowedWorker.waitUntilReady();
+      await blockedWorker.waitUntilReady();
+
+      await allowedQueue.add('allowed-job', { ok: true }, { attempts: 1 });
+      await blockedQueue.add('blocked-job', { secret: true }, { attempts: 1 });
+
+      await waitFor(async () => {
+        const jobs = await allowedQueue.getDeadLetterJobs();
+        return jobs.length === 1;
+      });
+
+      const allowedJobs = await allowedQueue.getDeadLetterJobs();
+      expect(allowedJobs).toHaveLength(1);
+      const blockedJobs = await blockedQueue.getDeadLetterJobs();
+      expect(blockedJobs).toHaveLength(1);
+
+      const blockedDlqId = blockedJobs[0].id;
+      expect(await allowedQueue.getDeadLetterJob(blockedDlqId)).toBeNull();
+      expect(await allowedQueue.removeDeadLetterJob(blockedDlqId)).toBe(false);
+      expect(await allowedQueue.replayDeadLetterJob(blockedDlqId)).toBeNull();
+    } finally {
+      await blockedWorker.close(true).catch(() => undefined);
+      await allowedWorker.close(true).catch(() => undefined);
+      await blockedQueue.close();
+      await allowedQueue.close();
+      await flushQueue(cleanupClient, allowedQueueName);
+      await flushQueue(cleanupClient, blockedQueueName);
+      await flushQueue(cleanupClient, sharedDlqName);
+    }
+  });
 });


### PR DESCRIPTION
### Motivation
- Proxy DLQ endpoints previously returned and acted on every entry in a resolved DLQ, which allowed entries owned by other queues (when multiple queues share one DLQ) to be listed, replayed, or deleted via an allowlisted route.  
- The intent of the change is to enforce queue ownership for DLQ operations so that a queue may only inspect or mutate DLQ entries whose `originalQueue` matches the requesting queue.

### Description
- Filtered results in `getDeadLetterJobs` so only DLQ jobs whose `data.originalQueue` equals `this.name` are counted and returned.  
- Made `getDeadLetterJob` return `null` when the looked-up DLQ job is not owned by the current queue.  
- Hardened `replayDeadLetterJob` to derive the original queue name from the DLQ entry and operate on that name only after validation, ensuring it cannot replay an entry owned by another queue via a shared DLQ.  
- Added helper methods `getDeadLetterOriginalQueue` and `isDeadLetterJobOwnedByQueue`, and a regression test `shared DLQ methods scope jobs to the owning queue` in `tests/deep-dlq.test.ts` that exercises two queues sharing one DLQ to validate isolation.

### Testing
- Built the project successfully with `npm run build` after the changes.  
- Added and ran the new regression test locally via `npx vitest` but the test run in this environment could not complete due to missing Redis/Valkey services (failed connecting to `localhost:6379` and cluster nodes), so the integration test run was skipped/failed for infrastructure reasons.  
- The change is minimal and focused on filtering/ownership checks and the added test reproduces the reported cross-queue DLQ leakage scenario.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75adecd7883338e6e480b1d1ff697)