### PR TITLE
fix: validate and clamp per-job lockDuration

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -481,7 +481,9 @@ local function extractLockDurationFromOpts(optsJson)
   if not optsJson or optsJson == '' then return 0 end
   local ok, decoded = pcall(cjson.decode, optsJson)
   if not ok or type(decoded) ~= 'table' then return 0 end
-  return tonumber(decoded['lockDuration']) or 0
+  local lockDuration = tonumber(decoded['lockDuration']) or 0
+  if lockDuration <= 0 or lockDuration > 86400000 then return 0 end
+  return lockDuration
 end
 
 -- Apply stall logic to a job: increment stalledCount, fail if over max, else emit stalled event.

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -44,7 +44,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 82: Guard every list-active DECR with > 0 check via decrListActive() helper - prevents counter underflow on duplicate complete/fail/suspend, reclaim races, etc. (#217).
 // Version 83: glidemq_getActiveListJobIds - bounded SCAN that returns active list-sourced jobIds for getJobs('active') visibility (#213).
 // Version 84: glidemq_reclaimStalled / glidemq_reclaimStalledListJobs accept workerLockDuration arg - per-entry threshold falls back to it before minIdleMs, so per-job opts.lockDuration overrides still fire under XAUTOCLAIM gating (#213).
-export const LIBRARY_VERSION = '84';
+// Version 85: extractLockDurationFromOpts clamps to >=1000ms (1s) to prevent tight-heartbeat DoS via per-job lockDuration; sub-second values fall back to worker lockDuration / minIdleMs (#225).
+export const LIBRARY_VERSION = '85';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -482,7 +483,11 @@ local function extractLockDurationFromOpts(optsJson)
   local ok, decoded = pcall(cjson.decode, optsJson)
   if not ok or type(decoded) ~= 'table' then return 0 end
   local lockDuration = tonumber(decoded['lockDuration']) or 0
-  if lockDuration <= 0 or lockDuration > 86400000 then return 0 end
+  -- Bounds must mirror MIN/MAX_JOB_LOCK_DURATION_MS in src/queue.ts and
+  -- MIN/MAX_JOB_OPTS_LOCK_DURATION_MS in src/proxy/routes.ts. Out-of-range
+  -- values are treated as unset so server-side reclaim falls back to the
+  -- worker lockDuration / minIdleMs.
+  if lockDuration < 1000 or lockDuration > 86400000 then return 0 end
   return lockDuration
 end
 

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -12,6 +12,7 @@ import { buildKeys, compileSubjectMatcher, hashDataToRecord, validateJobId, vali
 import type { AddJobRequest, AddJobResponse, AddJobSkippedResponse, ProxyOptions } from './types';
 
 const MAX_BULK_SIZE = 1000;
+const MIN_JOB_OPTS_LOCK_DURATION_MS = 1000;
 const MAX_JOB_OPTS_LOCK_DURATION_MS = 86_400_000;
 const SSE_BLOCK_MS = 5000;
 const SSE_KEEPALIVE_MS = 15000;
@@ -475,10 +476,10 @@ function validateJobOpts(
     optsIn.lockDuration !== undefined &&
     (typeof optsIn.lockDuration !== 'number' ||
       !Number.isFinite(optsIn.lockDuration) ||
-      optsIn.lockDuration <= 0 ||
+      optsIn.lockDuration < MIN_JOB_OPTS_LOCK_DURATION_MS ||
       optsIn.lockDuration > MAX_JOB_OPTS_LOCK_DURATION_MS)
   ) {
-    return `${prefix}opts.lockDuration must be a positive finite number <= ${MAX_JOB_OPTS_LOCK_DURATION_MS}`;
+    return `${prefix}opts.lockDuration must be a finite number between ${MIN_JOB_OPTS_LOCK_DURATION_MS} and ${MAX_JOB_OPTS_LOCK_DURATION_MS}`;
   }
 
   if (

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -12,6 +12,7 @@ import { buildKeys, compileSubjectMatcher, hashDataToRecord, validateJobId, vali
 import type { AddJobRequest, AddJobResponse, AddJobSkippedResponse, ProxyOptions } from './types';
 
 const MAX_BULK_SIZE = 1000;
+const MAX_JOB_OPTS_LOCK_DURATION_MS = 86_400_000;
 const SSE_BLOCK_MS = 5000;
 const SSE_KEEPALIVE_MS = 15000;
 type QueueState = 'waiting' | 'active' | 'delayed' | 'completed' | 'failed';
@@ -468,6 +469,16 @@ function validateJobOpts(
 
   if (optsIn.lifo !== undefined && typeof optsIn.lifo !== 'boolean') {
     return `${prefix}opts.lifo must be a boolean`;
+  }
+
+  if (
+    optsIn.lockDuration !== undefined &&
+    (typeof optsIn.lockDuration !== 'number' ||
+      !Number.isFinite(optsIn.lockDuration) ||
+      optsIn.lockDuration <= 0 ||
+      optsIn.lockDuration > MAX_JOB_OPTS_LOCK_DURATION_MS)
+  ) {
+    return `${prefix}opts.lockDuration must be a positive finite number <= ${MAX_JOB_OPTS_LOCK_DURATION_MS}`;
   }
 
   if (

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -98,6 +98,7 @@ const SUSPEND_SWEEP_LOCK_TTL_MS = 5000;
 const SUSPEND_NO_TIMEOUT_SCORE = 9_999_999_999_999;
 const DEFAULT_USAGE_WINDOW_MS = 60 * 60 * 1000;
 const MAX_USAGE_SUMMARY_KEY_READS = 100_000;
+const MAX_JOB_LOCK_DURATION_MS = 86_400_000;
 const USAGE_MODEL_FIELD_PREFIX = 'models:';
 const USAGE_TOKEN_FIELD_PREFIX = 'tokens:';
 const USAGE_COST_FIELD_PREFIX = 'costs:';
@@ -669,6 +670,12 @@ export class Queue<D = any, R = any> extends EventEmitter {
 
       if (opts?.ttl != null) {
         if (!Number.isFinite(opts.ttl) || opts.ttl < 0) throw new Error('ttl must be a non-negative finite number');
+      }
+
+      if (opts?.lockDuration != null) {
+        if (!Number.isFinite(opts.lockDuration) || opts.lockDuration <= 0 || opts.lockDuration > MAX_JOB_LOCK_DURATION_MS) {
+          throw new Error(`lockDuration must be a positive finite number <= ${MAX_JOB_LOCK_DURATION_MS}`);
+        }
       }
 
       // Payload size validation - prevent DoS via oversized jobs

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -98,6 +98,7 @@ const SUSPEND_SWEEP_LOCK_TTL_MS = 5000;
 const SUSPEND_NO_TIMEOUT_SCORE = 9_999_999_999_999;
 const DEFAULT_USAGE_WINDOW_MS = 60 * 60 * 1000;
 const MAX_USAGE_SUMMARY_KEY_READS = 100_000;
+const MIN_JOB_LOCK_DURATION_MS = 1000;
 const MAX_JOB_LOCK_DURATION_MS = 86_400_000;
 const USAGE_MODEL_FIELD_PREFIX = 'models:';
 const USAGE_TOKEN_FIELD_PREFIX = 'tokens:';
@@ -675,10 +676,12 @@ export class Queue<D = any, R = any> extends EventEmitter {
       if (opts?.lockDuration != null) {
         if (
           !Number.isFinite(opts.lockDuration) ||
-          opts.lockDuration <= 0 ||
+          opts.lockDuration < MIN_JOB_LOCK_DURATION_MS ||
           opts.lockDuration > MAX_JOB_LOCK_DURATION_MS
         ) {
-          throw new Error(`lockDuration must be a positive finite number <= ${MAX_JOB_LOCK_DURATION_MS}`);
+          throw new Error(
+            `lockDuration must be a finite number between ${MIN_JOB_LOCK_DURATION_MS} and ${MAX_JOB_LOCK_DURATION_MS}`,
+          );
         }
       }
 
@@ -907,6 +910,17 @@ export class Queue<D = any, R = any> extends EventEmitter {
       }
       if (opts.ttl != null) {
         if (!Number.isFinite(opts.ttl) || opts.ttl < 0) throw new Error('ttl must be a non-negative finite number');
+      }
+      if (opts.lockDuration != null) {
+        if (
+          !Number.isFinite(opts.lockDuration) ||
+          opts.lockDuration < MIN_JOB_LOCK_DURATION_MS ||
+          opts.lockDuration > MAX_JOB_LOCK_DURATION_MS
+        ) {
+          throw new Error(
+            `lockDuration must be a finite number between ${MIN_JOB_LOCK_DURATION_MS} and ${MAX_JOB_LOCK_DURATION_MS}`,
+          );
+        }
       }
       const deduplication = opts.deduplication;
       const customJobId = opts.jobId ?? '';

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -673,7 +673,11 @@ export class Queue<D = any, R = any> extends EventEmitter {
       }
 
       if (opts?.lockDuration != null) {
-        if (!Number.isFinite(opts.lockDuration) || opts.lockDuration <= 0 || opts.lockDuration > MAX_JOB_LOCK_DURATION_MS) {
+        if (
+          !Number.isFinite(opts.lockDuration) ||
+          opts.lockDuration <= 0 ||
+          opts.lockDuration > MAX_JOB_LOCK_DURATION_MS
+        ) {
           throw new Error(`lockDuration must be a positive finite number <= ${MAX_JOB_LOCK_DURATION_MS}`);
         }
       }


### PR DESCRIPTION
### Motivation
- Per-job `lockDuration` was introduced but trusted from producer input with no runtime bounds, allowing tiny/invalid values to produce near-tight heartbeats and huge values to suppress stall reclaim indefinitely.  
- The goal is to harden ingress and consumption points so an untrusted enqueue caller cannot cause resource exhaustion or break recovery guarantees.  
- Preserve the per-job override feature for valid values while enforcing safe, conservative bounds.

### Description
- Add a proxy-side runtime validation constant `MAX_JOB_OPTS_LOCK_DURATION_MS = 86_400_000` and a check in `validateJobOpts` that requires `opts.lockDuration` to be a positive finite number ≤ `86_400_000` (24h) in `src/proxy/routes.ts`.  
- Add a queue-side validation in `Queue.add` that enforces the same `lockDuration` constraints before serializing/persisting job `opts` in `src/queue.ts`.  
- Harden the Lua helper `extractLockDurationFromOpts` to parse and clamp the value, returning `0` for out-of-range or non-positive values so server-side reclaim logic cannot be bypassed, in `src/functions/index.ts`.

### Testing
- Ran the TypeScript build with `npm run build -- --pretty false` which completed successfully.  
- Ran the per-job lock tests with `npm test -- tests/per-job-lock.test.ts`; the test run executed but the specific per-job tests were skipped due to unavailable Valkey/Redis connectivity in this environment (Vitest reported the tests as skipped).  
- The change is minimal and unit-friendly; full verification including Lua reclaim behavior requires an environment with a live Valkey/Redis instance and was not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75b946a048333af0b6d82b39d422c)