### PR TITLE
fix: fully clean up timed-out suspended jobs

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -3480,6 +3480,9 @@ redis.register_function('glidemq_sweepSuspended', function(keys, args)
     local jState = redis.call('HGET', jobKey, 'state')
     if jState == 'suspended' then
       local processedOn = tonumber(redis.call('HGET', jobKey, 'processedOn')) or now
+      local ordKey = redis.call('HGET', jobKey, 'orderingKey')
+      local ordSeq = tonumber(redis.call('HGET', jobKey, 'orderingSeq')) or 0
+      local grpKey = redis.call('HGET', jobKey, 'groupKey')
       redis.call('ZADD', failedKey, now, id)
       redis.call('HSET', jobKey,
         'state', 'failed',
@@ -3487,8 +3490,13 @@ redis.register_function('glidemq_sweepSuspended', function(keys, args)
         'finishedOn', tostring(now),
         'processedOn', tostring(now)
       )
-      markOrderingDone(jobKey, id)
-      releaseGroupSlotAndPromote(jobKey, id, now)
+      markOrderingDone(jobKey, id, ordKey, ordSeq)
+      -- Only release the group slot for ordered jobs. Non-ordered jobs already
+      -- released their slot in glidemq_suspend; releasing again would double-
+      -- decrement the group's active counter.
+      if ordSeq > 0 then
+        releaseGroupSlotAndPromote(jobKey, id, now, grpKey)
+      end
       emitEvent(eventsKey, 'failed', id, {'failedReason', 'Suspend timeout exceeded'})
       recordMetrics(metricsKey, now, now - processedOn)
       count = count + 1

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -3465,6 +3465,8 @@ end)
 redis.register_function('glidemq_sweepSuspended', function(keys, args)
   local suspendedKey = keys[1]
   local eventsKey = keys[2]
+  local failedKey = keys[3]
+  local metricsKey = keys[4]
   local now = tonumber(args[1]) or 0
   local keyPrefix = args[2] or ''
 
@@ -3477,8 +3479,18 @@ redis.register_function('glidemq_sweepSuspended', function(keys, args)
     local jobKey = keyPrefix .. 'job:' .. id
     local jState = redis.call('HGET', jobKey, 'state')
     if jState == 'suspended' then
-      redis.call('HSET', jobKey, 'state', 'failed', 'failedReason', 'Suspend timeout exceeded')
+      local processedOn = tonumber(redis.call('HGET', jobKey, 'processedOn')) or now
+      redis.call('ZADD', failedKey, now, id)
+      redis.call('HSET', jobKey,
+        'state', 'failed',
+        'failedReason', 'Suspend timeout exceeded',
+        'finishedOn', tostring(now),
+        'processedOn', tostring(now)
+      )
+      markOrderingDone(jobKey, id)
+      releaseGroupSlotAndPromote(jobKey, id, now)
       emitEvent(eventsKey, 'failed', id, {'failedReason', 'Suspend timeout exceeded'})
+      recordMetrics(metricsKey, now, now - processedOn)
       count = count + 1
     end
     redis.call('ZREM', suspendedKey, id)
@@ -4714,7 +4726,7 @@ export async function sweepSuspended(
 ): Promise<number> {
   const result = await client.fcall(
     'glidemq_sweepSuspended',
-    [k.suspended, k.events],
+    [k.suspended, k.events, k.failed, k.metricsFailed],
     [timestamp.toString(), keyPrefix],
   );
   return Number(result) || 0;


### PR DESCRIPTION
### Motivation
- Timed-out suspended jobs were marked `failed` only in the job hash and removed from the suspended set, which left ordering/group slots held and could permanently block ordered/grouped queues.
- The suspend-timeout path did not perform the same terminal-failure cleanup as the normal `glidemq_fail` path, causing queue availability and integrity issues for human-in-the-loop workflows.

### Description
- Update the Lua `glidemq_sweepSuspended` to perform full failure cleanup for expired suspended jobs: add to the `failed` ZSET, set `finishedOn`/`processedOn`, call `markOrderingDone`, call `releaseGroupSlotAndPromote`, emit the `failed` event, and `recordMetrics`.
- Pass the additional Redis keys into the FCALL wrapper by updating the TypeScript `sweepSuspended` helper to call `glidemq_sweepSuspended` with `[k.suspended, k.events, k.failed, k.metricsFailed]`.
- Changed file: `src/functions/index.ts` (Lua function and TS FCALL wrapper updated).

### Testing
- Ran `npm run build` which initially failed with a TypeScript key mismatch error during patch development and then succeeded after adding the correct keys, producing a clean TypeScript build. 
- No further automated integration tests were run in this environment due to external Redis requirements; the build completed successfully (`tsc` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75c0c02b08333afd95e23dcebe29f)