### PR TITLE
fix(queue): prevent concurrent Queue client initialization races

### DIFF
--- a/src/queue.ts
+++ b/src/queue.ts
@@ -261,6 +261,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
   readonly name: string;
   private opts: QueueOptions;
   private client: Client | null = null;
+  private clientInitPromise: Promise<Client> | null = null;
   private clientOwned = true;
   private queueMetaConfigSynced = false;
   private _clusterMode: boolean | undefined;
@@ -511,40 +512,53 @@ export class Queue<D = any, R = any> extends EventEmitter {
       throw new GlideMQError('Queue is closing');
     }
     if (!this.client) {
-      if (this.opts.client) {
-        const injected = this.opts.client;
-        try {
-          await ensureFunctionLibraryOnce(
-            injected,
-            LIBRARY_SOURCE,
-            this.opts.connection?.clusterMode ?? isClusterClient(injected),
-          );
-        } catch (err) {
-          this.emit('error', err);
-          throw err;
-        }
-        this.client = injected;
-        this.clientOwned = false;
-      } else {
-        let client: Client;
-        try {
-          client = await createClient(this.opts.connection!);
-          await ensureFunctionLibrary(client, LIBRARY_SOURCE, this.opts.connection!.clusterMode ?? false);
-        } catch (err) {
-          // Don't cache a failed client - next getClient() call will retry
-          this.emit('error', err);
-          throw err;
-        }
-        this.client = client;
-        this.clientOwned = true;
+      if (!this.clientInitPromise) {
+        this.clientInitPromise = (async () => {
+          if (this.opts.client) {
+            const injected = this.opts.client;
+            try {
+              await ensureFunctionLibraryOnce(
+                injected,
+                LIBRARY_SOURCE,
+                this.opts.connection?.clusterMode ?? isClusterClient(injected),
+              );
+            } catch (err) {
+              this.emit('error', err);
+              throw err;
+            }
+            this.client = injected;
+            this.clientOwned = false;
+            return injected;
+          }
+
+          let client: Client;
+          try {
+            client = await createClient(this.opts.connection!);
+            await ensureFunctionLibrary(client, LIBRARY_SOURCE, this.opts.connection!.clusterMode ?? false);
+          } catch (err) {
+            // Don't cache a failed client - next getClient() call will retry
+            this.emit('error', err);
+            throw err;
+          }
+          this.client = client;
+          this.clientOwned = true;
+          return client;
+        })().finally(() => {
+          this.clientInitPromise = null;
+        });
       }
+      await this.clientInitPromise;
+    }
+    const client = this.client;
+    if (!client) {
+      throw new GlideMQError('Queue client initialization failed');
     }
     if (!this.queueMetaConfigSynced) {
-      await this.syncQueueMetaConfig(this.client);
+      await this.syncQueueMetaConfig(client);
       this.queueMetaConfigSynced = true;
     }
-    this.ensureSuspendSweepLoop(this.client);
-    return this.client;
+    this.ensureSuspendSweepLoop(client);
+    return client;
   }
 
   private async syncQueueMetaConfig(client: Client): Promise<void> {


### PR DESCRIPTION
### Motivation
- The HTTP bulk endpoint can trigger many concurrent `Queue.add()` calls that race in `Queue.getClient()`, allowing a single bulk request to create many Valkey clients and leak resources. 
- `Queue.getClient()` previously had no in-flight initialization guard, so concurrent callers on a cold queue each created their own client and only the last assigned client was tracked for cleanup.

### Description
- Add a shared `clientInitPromise` field and use it inside `Queue.getClient()` so concurrent callers await a single initialization path instead of creating multiple clients. 
- Clear `clientInitPromise` in a `finally` handler so failed initializations are not permanently cached and future calls can retry. 
- Add a defensive null check after initialization and use a local `client` variable for subsequent metadata sync and sweep loop setup to preserve type safety and correctness. 
- The change targets only client initialization; no bulk endpoint behavior or batching semantics were altered.

### Testing
- `npm run build` was executed and completed successfully. 
- Ran targeted tests (`npm test -- tests/proxy.test.ts -t "POST /queues/:name/jobs/bulk - adds 3 jobs"`) but they failed due to an unavailable Valkey/Redis at `localhost:6379` in this environment, not due to the code change (connection timeout during integration setup). 
- The fix is minimal and compiled cleanly; integration tests that require a local Valkey/Redis should be re-run in an environment with the service available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75bfac9248333a2aa2f609979274a)