### PR TITLE
fix: dedupe list stalled recovery across schedulers

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1591,6 +1591,10 @@ redis.register_function('glidemq_reclaimStalledListJobs', function(keys, args)
           effectiveIdle = minIdleMs
         end
         if isListSourced and lastActive and (timestamp - lastActive) >= effectiveIdle then
+          -- Claim this stalled check by refreshing lastActive. This preserves
+          -- XAUTOCLAIM-like de-duplication semantics across worker schedulers
+          -- so the same stale list job is counted at most once per interval.
+          redis.call('HSET', jk, 'lastActive', tostring(timestamp))
           local jobId = string.sub(jk, #prefix + 5)
           local shouldDecr = false
           if checkExpired(jk, jobId, prefix, timestamp) then

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -45,7 +45,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 83: glidemq_getActiveListJobIds - bounded SCAN that returns active list-sourced jobIds for getJobs('active') visibility (#213).
 // Version 84: glidemq_reclaimStalled / glidemq_reclaimStalledListJobs accept workerLockDuration arg - per-entry threshold falls back to it before minIdleMs, so per-job opts.lockDuration overrides still fire under XAUTOCLAIM gating (#213).
 // Version 85: extractLockDurationFromOpts clamps to >=1000ms (1s) to prevent tight-heartbeat DoS via per-job lockDuration; sub-second values fall back to worker lockDuration / minIdleMs (#225).
-export const LIBRARY_VERSION = '85';
+// Version 86: glidemq_reclaimStalledListJobs refreshes lastActive on detection to dedupe stalled-recovery across concurrent worker schedulers - same stale list job counted at most once per interval (#228).
+export const LIBRARY_VERSION = '86';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/tests/lifo.test.ts
+++ b/tests/lifo.test.ts
@@ -779,11 +779,13 @@ describeEachMode('LIFO: Stalled list-sourced job recovery', (CONNECTION) => {
     const la1 = await cleanupClient.get(k.listActive);
     expect(la1).toBe('1');
 
-    // Second call: stalledCount goes from 1 to 2 (> maxStalledCount), job moves to failed
+    // Second call: stalledCount goes from 1 to 2 (> maxStalledCount), job moves to failed.
+    // Advance timestamp past minIdleMs (5000) so the dedup refresh from the first call no
+    // longer suppresses detection in this fresh recovery window.
     const count2 = await cleanupClient.fcall(
       'glidemq_reclaimStalledListJobs',
       [k.stream, k.events],
-      ['5000', '1', (now + 1).toString(), k.failed],
+      ['5000', '1', (now + 6000).toString(), k.failed],
     );
     expect(Number(count2)).toBe(1);
     const state2 = await cleanupClient.hget(k.job(jobId), 'state');
@@ -841,11 +843,13 @@ describeEachMode('LIFO: Stalled list-sourced job recovery', (CONNECTION) => {
     const la1 = await cleanupClient.get(k.listActive);
     expect(la1).toBe('1');
 
-    // Second call: stalledCount 1 -> 2 (> maxStalledCount), job moves to failed
+    // Second call: stalledCount 1 -> 2 (> maxStalledCount), job moves to failed.
+    // Advance timestamp past minIdleMs (5000) so the dedup refresh from the first call no
+    // longer suppresses detection in this fresh recovery window.
     const count2 = await cleanupClient.fcall(
       'glidemq_reclaimStalledListJobs',
       [k.stream, k.events],
-      ['5000', '1', (now + 1).toString(), k.failed],
+      ['5000', '1', (now + 6000).toString(), k.failed],
     );
     expect(Number(count2)).toBe(1);
     const state2 = await cleanupClient.hget(k.job(jobId), 'state');

--- a/tests/lifo.test.ts
+++ b/tests/lifo.test.ts
@@ -864,6 +864,46 @@ describeEachMode('LIFO: Stalled list-sourced job recovery', (CONNECTION) => {
     await flushQueue(cleanupClient, Q);
   });
 
+  it('reclaimStalledListJobs de-duplicates list stall accounting for the same timestamp', async () => {
+    const Q = `stall-lifo-dedupe-${Date.now()}`;
+    const k = buildKeys(Q);
+    const jobId = 'stalled-lifo-dedupe-1';
+    const staleTime = Date.now() - 60000;
+    const now = Date.now();
+
+    await cleanupClient.hset(k.job(jobId), {
+      name: 'stalled-task',
+      data: '{}',
+      opts: '{}',
+      state: 'active',
+      lifo: '1',
+      processedOn: staleTime.toString(),
+      lastActive: staleTime.toString(),
+      stalledCount: '0',
+      attemptsMade: '0',
+    });
+    await cleanupClient.set(k.listActive, '1');
+
+    const count1 = await cleanupClient.fcall(
+      'glidemq_reclaimStalledListJobs',
+      [k.stream, k.events],
+      ['5000', '1', now.toString(), k.failed],
+    );
+    const count2 = await cleanupClient.fcall(
+      'glidemq_reclaimStalledListJobs',
+      [k.stream, k.events],
+      ['5000', '1', now.toString(), k.failed],
+    );
+
+    expect(Number(count1)).toBe(1);
+    expect(Number(count2)).toBe(0);
+    expect(await cleanupClient.hget(k.job(jobId), 'state')).toBe('active');
+    expect(await cleanupClient.hget(k.job(jobId), 'stalledCount')).toBe('1');
+    expect(await cleanupClient.get(k.listActive)).toBe('1');
+
+    await flushQueue(cleanupClient, Q);
+  });
+
   it('deferActive DECRs list-active when entryId is empty (list-sourced job)', async () => {
     const Q = `defer-active-decr-${Date.now()}`;
     const k = buildKeys(Q);


### PR DESCRIPTION
### Motivation
- The SCAN-based list stalled recovery path could be observed and executed by every worker scheduler and did not claim a stale list-sourced job before incrementing `stalledCount`, allowing multiple schedulers to double-count and prematurely move an in-flight list job to `failed` and DECR `list-active` multiple times.
- This produced corrupted `list-active`/global concurrency accounting and contradictory job state when the original processor later completed the job.

### Description
- In the `glidemq_reclaimStalledListJobs` Lua function, refresh `lastActive` (`HSET jk 'lastActive' timestamp`) when a stale list-sourced active job is first observed to claim the stalled check and prevent other schedulers from counting the same job in the same recovery window.
- Added a regression test in `tests/lifo.test.ts` that calls `glidemq_reclaimStalledListJobs` twice with the same timestamp and asserts the second call does not increment `stalledCount`, does not fail the job, and does not decrement `list-active`.
- The change preserves existing stalled/failed semantics and only introduces an atomic refresh of `lastActive` to provide XAUTOCLAIM-like de-duplication for the list path.

### Testing
- `npm run build` completed successfully (TypeScript `tsc` build passed).
- `npm run test -- tests/lifo.test.ts` was executed but could not fully complete in this environment because Redis at `localhost:6379` is unavailable, causing integration tests to time out or be skipped; as a result the added regression test cannot be validated end-to-end here though it is present and intended to pass when a Redis instance is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7611e0bd48333843fb7a4728e4754)