### PR TITLE
fix: avoid credential collisions in ServerlessPool cache

### DIFF
--- a/src/serverless-pool.ts
+++ b/src/serverless-pool.ts
@@ -41,9 +41,9 @@ export class ServerlessPool {
     if (this.closing) {
       throw new Error('ServerlessPool is closing');
     }
-    // Custom serializers or injected clients bypass the cache intentionally -
-    // serializer instances may hold state and must not be shared across callers.
-    if (opts.client || opts.serializer) {
+    // Custom serializers, injected clients, or explicit credentials bypass the cache
+    // intentionally to avoid state and authentication-context collisions.
+    if (opts.client || opts.serializer || opts.connection?.credentials) {
       return new Producer(name, opts);
     }
 

--- a/tests/serverless-pool.test.ts
+++ b/tests/serverless-pool.test.ts
@@ -54,6 +54,20 @@ describeEachMode('ServerlessPool - caching', (CONNECTION) => {
     pool.getProducer(Q1, { connection: CONNECTION });
     expect(pool.size).toBe(2);
   });
+
+  it('does not cache producers when credentials are provided', () => {
+    const connWithCreds = {
+      ...CONNECTION,
+      credentials: {
+        username: 'user-a',
+        password: 'secret-a',
+      },
+    };
+    const p1 = pool.getProducer(Q1, { connection: connWithCreds });
+    const p2 = pool.getProducer(Q1, { connection: connWithCreds });
+    expect(p1).not.toBe(p2);
+    expect(pool.size).toBe(0);
+  });
 });
 
 describeEachMode('ServerlessPool - closeAll', (CONNECTION) => {


### PR DESCRIPTION
### Motivation
- The `ServerlessPool` cache key omitted `connection.credentials`, allowing a Producer created with one Valkey identity to be reused by callers that provided different credentials, which can cause authorization bypass.
- Apply a minimal, safe remediation that preserves caching for non-credentialed connections while preventing cross-identity reuse.

### Description
- Update `ServerlessPool.getProducer()` to bypass the cache when `opts.connection?.credentials` is present so credentialed connections are not shared across callers (`src/serverless-pool.ts`).
- Clarify comments explaining that injected clients, custom serializers, and credentialed connections intentionally bypass caching to avoid state or authentication-context collisions (`src/serverless-pool.ts`).
- Add a regression test asserting credentialed connections are not cached and do not increase the pool size (`tests/serverless-pool.test.ts`).

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm test -- tests/serverless-pool.test.ts` after building; the test runner executed but the integration suite requires a local Valkey service and could not connect to `localhost:6379` (tests were skipped/timed out in this environment), so full integration verification could not be completed here.
- The change is intentionally minimal; CI with access to the test Valkey endpoints should run the full integration suite to confirm the regression test and end-to-end scenarios pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f760788a788333b4f32fb0c606608b)