### PR TITLE
fix: release leaked list-active slot on non-processing moveToActive outcomes

### DIFF
--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -861,7 +861,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       // Already handled server-side by checkExpired in Lua.
       // For list-backed jobs (entryId=''), release the reserved list-active slot.
       if (entryId === '') {
-        await this.commandClient.decrBy(this.queueKeys.listActive, 1);
+        await this.releaseListActiveSlot();
       }
       return true;
     }
@@ -875,11 +875,27 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       // Job was parked/rejected before entering processor execution.
       // For list-backed jobs (entryId=''), release the reserved list-active slot.
       if (entryId === '') {
-        await this.commandClient.decrBy(this.queueKeys.listActive, 1);
+        await this.releaseListActiveSlot();
       }
       return true;
     }
     return false;
+  }
+
+  /**
+   * Release a reserved list-active slot. Used for list-backed jobs that exit
+   * before processor execution (e.g. EXPIRED, GROUP_FULL, GROUP_RATE_LIMITED,
+   * GROUP_TOKEN_LIMITED, GROUP_ORDERED, ERR:COST_EXCEEDS_CAPACITY).
+   * Errors are emitted rather than thrown so a transient DECR failure does not
+   * abort the caller's loop and leak more slots.
+   */
+  protected async releaseListActiveSlot(): Promise<void> {
+    if (!this.commandClient) return;
+    try {
+      await this.commandClient.decrBy(this.queueKeys.listActive, 1);
+    } catch (err) {
+      this.emit('error', new Error('list-active release failed', { cause: err }));
+    }
   }
 
   /**

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -858,7 +858,11 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       return true;
     }
     if (moveResult === 'EXPIRED') {
-      // Already handled server-side by checkExpired in Lua
+      // Already handled server-side by checkExpired in Lua.
+      // For list-backed jobs (entryId=''), release the reserved list-active slot.
+      if (entryId === '') {
+        await this.commandClient.decrBy(this.queueKeys.listActive, 1);
+      }
       return true;
     }
     if (
@@ -868,6 +872,11 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       moveResult === 'GROUP_ORDERED' ||
       moveResult === 'ERR:COST_EXCEEDS_CAPACITY'
     ) {
+      // Job was parked/rejected before entering processor execution.
+      // For list-backed jobs (entryId=''), release the reserved list-active slot.
+      if (entryId === '') {
+        await this.commandClient.decrBy(this.queueKeys.listActive, 1);
+      }
       return true;
     }
     return false;


### PR DESCRIPTION
### Motivation
- A list-backed job path increments the `list-active` counter before `moveToActive` proves the job will enter processor execution, and several early-exit results (e.g. `EXPIRED`, `GROUP_FULL`, rate/token gates, ordering deferral) previously returned without decrementing, which can permanently consume `globalConcurrency` capacity.

### Description
- Update `handleMoveToActiveEdgeCase` in `src/base-worker.ts` to call `decrBy` on `this.queueKeys.listActive` when `moveToActive` returns early outcomes for list-sourced jobs (`entryId === ''`).
- Covered early-return outcomes include `EXPIRED`, `GROUP_FULL`, `GROUP_RATE_LIMITED`, `GROUP_TOKEN_LIMITED`, `GROUP_ORDERED`, and `ERR:COST_EXCEEDS_CAPACITY` so reserved slots are balanced.
- The fix is intentionally scoped to list-backed jobs (`entryId === ''`) to avoid changing stream-backed activation semantics.

### Testing
- Built the project with `npm -s run build -- --pretty false` and the build succeeded.
- Ran the relevant test file with `npx vitest run tests/worker-saturation.test.ts` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76288d5708333bcacf7a3cf735738)