### PR TITLE
fix(proxy): reject unsupported `opts` keys to block cross-queue parent injection

### DIFF
--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -413,6 +413,27 @@ function validateJobOpts(
   options?: { allowWaitTimeout?: boolean },
 ): string | null {
   if (!optsIn) return null;
+  const allowedKeys = new Set([
+    'jobId',
+    'delay',
+    'priority',
+    'attempts',
+    'backoff',
+    'timeout',
+    'removeOnComplete',
+    'removeOnFail',
+    'deduplication',
+    'ttl',
+    'ordering',
+    'cost',
+    'lifo',
+    ...(options?.allowWaitTimeout ? (['waitTimeout'] as const) : []),
+  ]);
+  for (const key of Object.keys(optsIn)) {
+    if (!allowedKeys.has(key)) {
+      return `${prefix}opts.${key} is not allowed`;
+    }
+  }
 
   if (optsIn.jobId !== undefined) {
     if (typeof optsIn.jobId !== 'string' || optsIn.jobId === '') {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1232,6 +1232,33 @@ describe('HTTP Proxy - Queue Allowlist', () => {
     expect(res.status).toBe(403);
   });
 
+  it('rejects opts.parent on add endpoint', async () => {
+    const res = await fetch(`${baseUrl}/queues/${allowedQueue}/jobs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'child',
+        opts: { parent: { queue: blockedQueue, id: 'parent-1' } },
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('opts.parent is not allowed');
+  });
+
+  it('rejects opts.parent on bulk add endpoint', async () => {
+    const res = await fetch(`${baseUrl}/queues/${allowedQueue}/jobs/bulk`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jobs: [{ name: 'child', opts: { parent: { queue: blockedQueue, id: 'parent-2' } } }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('jobs[0]: opts.parent is not allowed');
+  });
+
   it('health endpoint is not blocked by allowlist', async () => {
     const res = await fetch(`${baseUrl}/health`);
     expect(res.status).toBe(200);


### PR DESCRIPTION
### Motivation
- The HTTP proxy forwarded JSON `opts` directly to `Queue.add`, allowing callers of an allowlisted queue to set `opts.parent.queue` and mutate another queue's dependency set. This bypassed queue isolation and could corrupt or stall victim flows. 
- The TypeScript `AddJobRequest` type omitted `parent`, but that is erased at runtime, so runtime validation was required to enforce the narrower proxy schema.

### Description
- Added a runtime allowlist of supported job option keys and an early rejection when unknown keys are present by extending `validateJobOpts` to check allowed keys (in `src/proxy/routes.ts`).
- This blocks `opts.parent` and any other unsupported keys from being accepted by the proxy before calling `Queue.add`.
- Added integration tests exercising the allowlist to assert that both single-job (`POST /queues/:name/jobs`) and bulk-job (`POST /queues/:name/jobs/bulk`) endpoints return `400` when `opts.parent` is supplied (`tests/proxy.test.ts`).
- Changes touch `src/proxy/routes.ts` and `tests/proxy.test.ts` and preserve existing accepted option semantics.

### Testing
- `npm run build` completed successfully after the changes.
- `npx vitest run tests/proxy.test.ts` was executed in this environment but the suite could not fully run due to inability to connect to the Valkey server at `localhost:6379`, causing timeouts and test failures unrelated to the validation logic; integration tests are expected to pass when run against a running Valkey instance. 
- The added validation is self-contained and operates before any `Queue.add` calls, reducing the attack surface without changing queue internals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7623d681c8333983f627b634ec5a3)