### PR TITLE
fix(worker): cap XREADGROUP count to `batch.size` in batch mode

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -24,6 +24,9 @@ export class Worker<D = any, R = any> extends BaseWorker<D, R> {
     }
 
     let fetchCount = available;
+    if (this.batchMode) {
+      fetchCount = Math.min(fetchCount, this.batchSize);
+    }
 
     // Only check global concurrency if configured. Skipping this FCALL entirely
     // saves one Valkey round trip per poll cycle (~0.2ms).

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -143,6 +143,39 @@ describe('Worker', () => {
     await worker.close(true);
   });
 
+
+  it('should cap batch-mode xreadgroup count to batch size when prefetch is larger', async () => {
+    const processor = vi.fn().mockResolvedValue([]);
+
+    let resolveXRead: ((value: any) => void) | null = null;
+    mockBlockingClient.xreadgroup = vi.fn().mockImplementation(() => {
+      return new Promise((resolve) => {
+        resolveXRead = resolve;
+      });
+    });
+
+    const worker = new Worker('test-queue', processor, {
+      ...defaultWorkerOpts,
+      concurrency: 3,
+      prefetch: 12,
+      batch: { size: 4 },
+      blockTimeout: 2000,
+    });
+    await worker.waitUntilReady();
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(mockBlockingClient.xreadgroup).toHaveBeenCalledWith(
+      CONSUMER_GROUP,
+      expect.any(String),
+      { [keys.stream]: '>' },
+      { count: 4, block: 2000 },
+    );
+
+    resolveXRead!(null);
+    await worker.close(true);
+  });
+
   it('should call xreadgroup with correct parameters', async () => {
     const processor = vi.fn().mockResolvedValue('done');
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -143,7 +143,6 @@ describe('Worker', () => {
     await worker.close(true);
   });
 
-
   it('should cap batch-mode xreadgroup count to batch size when prefetch is larger', async () => {
     const processor = vi.fn().mockResolvedValue([]);
 


### PR DESCRIPTION
### Motivation
- Batch-mode workers could request up to `prefetch` (default `concurrency * batchSize`) entries and then only process the first `batch.size`, leaving the remainder delivered into the consumer-group PEL but never activated or acknowledged, which can lead to stranded jobs and later incorrect reclamation/failure. 
- The change prevents over-reading from the stream so that delivered entries always correspond to what the worker will activate and process.

### Description
- In `src/worker.ts` the `fetchCount` used for `xreadgroup` is now capped to `this.batchSize` when `batchMode` is enabled, so `xreadgroup` will not request more entries than one batch can process. 
- Added a unit test in `tests/worker.test.ts` asserting that when `batch` is set and `prefetch` is larger than `batch.size`, the worker calls `xreadgroup` with `{ count: batch.size }`. 
- The change is intentionally minimal and preserves existing batch processing semantics while preventing excess delivered entries from being stranded in the PEL.

### Testing
- Ran the targeted unit test with `npx vitest run tests/worker.test.ts -t "cap batch-mode xreadgroup count" --exclude tests/fuzzer/index.test.ts`, and the test passed. 
- Attempting the repository's default `npm test` in this environment failed due to missing build artifacts required by `tests/fuzzer/index.test.ts`, which is unrelated to the change. 
- The new test is included in the test suite to prevent regression of the over-read behaviour and passes in the same test environment used for development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7629150608333be99e9e57219d10d)