### PR TITLE
fix: count expired jobs toward MAX_PROMOTIONS in glidemq_promote

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -47,7 +47,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 85: extractLockDurationFromOpts clamps to >=1000ms (1s) to prevent tight-heartbeat DoS via per-job lockDuration; sub-second values fall back to worker lockDuration / minIdleMs (#225).
 // Version 86: glidemq_reclaimStalledListJobs refreshes lastActive on detection to dedupe stalled-recovery across concurrent worker schedulers - same stale list job counted at most once per interval (#228).
 // Version 87: releaseGroupSlotAndPromote caps maxConcurrency promotion budget at 1000 to prevent unbounded Lua loop on large maxConcurrency settings (#236).
-export const LIBRARY_VERSION = '87';
+// Version 88: glidemq_promote counts expired scheduled jobs toward MAX_PROMOTIONS budget - prevents unbounded scans when many expired jobs sit in scheduled set (#235).
+export const LIBRARY_VERSION = '88';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -755,6 +756,7 @@ redis.register_function('glidemq_promote', function(keys, args)
       local prefix = string.sub(scheduledKey, 1, #scheduledKey - 9)
       local jobKey = prefix .. 'job:' .. jobId
       redis.call('ZREM', scheduledKey, member)
+      count = count + 1
       if not checkExpired(jobKey, jobId, prefix, now) then
         local jobLifo = redis.call('HGET', jobKey, 'lifo')
         if jobLifo == '1' then
@@ -775,8 +777,8 @@ redis.register_function('glidemq_promote', function(keys, args)
         end
         redis.call('HSET', jobKey, 'state', 'waiting')
         emitEvent(eventsKey, 'promoted', jobId, nil)
-        count = count + 1
       end
+      if count >= MAX_PROMOTIONS then break end
     end
     cursorMin = (priority + 1) * PRIORITY_SHIFT
   end


### PR DESCRIPTION
### Motivation
- Prevent an availability regression where expired scheduled jobs processed by `glidemq_promote` did not charge the `MAX_PROMOTIONS` budget, allowing a single FCALL to do unbounded work and impact Redis/Valkey event loop.

### Description
- In `src/functions/index.ts` update `glidemq_promote` so each scheduled member increments the `count` immediately after `ZREM` and add an in-loop guard to `break` when `count >= MAX_PROMOTIONS`, ensuring expired jobs are counted toward the per-call promotion cap.

### Testing
- Ran `npm run build` which completed successfully; the TypeScript build passed. 
- Attempted `npm test -- --run tests/ttl.test.ts` in this environment but the suite could not complete due to missing local Valkey/Redis at `localhost:6379` (connection timeouts), so integration tests were not fully exercisable here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76652b9c48333884a6bb3707fdcdc)