### PR TITLE
fix: cap group promotions for maxConcurrency to prevent unbounded Lua loop

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -46,7 +46,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 84: glidemq_reclaimStalled / glidemq_reclaimStalledListJobs accept workerLockDuration arg - per-entry threshold falls back to it before minIdleMs, so per-job opts.lockDuration overrides still fire under XAUTOCLAIM gating (#213).
 // Version 85: extractLockDurationFromOpts clamps to >=1000ms (1s) to prevent tight-heartbeat DoS via per-job lockDuration; sub-second values fall back to worker lockDuration / minIdleMs (#225).
 // Version 86: glidemq_reclaimStalledListJobs refreshes lastActive on detection to dedupe stalled-recovery across concurrent worker schedulers - same stale list job counted at most once per interval (#228).
-export const LIBRARY_VERSION = '86';
+// Version 87: releaseGroupSlotAndPromote caps maxConcurrency promotion budget at 1000 to prevent unbounded Lua loop on large maxConcurrency settings (#236).
+export const LIBRARY_VERSION = '87';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -295,7 +295,7 @@ local function releaseGroupSlotAndPromote(jobKey, jobId, now, hintGroupKey)
   -- Calculate how many slots are available for promotion
   local available = 1
   if maxConc > 0 then
-    available = maxConc - newActive
+    available = math.min(maxConc - newActive, 1000)
   else
     available = math.min(waitLen, 1000)
   end


### PR DESCRIPTION
### Motivation
- Prevent producer-controlled `ordering.concurrency` from causing an unbounded server-side promotion loop in `releaseGroupSlotAndPromote`, which can block Valkey/Redis by performing excessive atomic promotions.

### Description
- Apply the existing 1000-job hard cap to the `maxConcurrency` branch in `src/functions/index.ts` by using `available = math.min(maxConc - newActive, 1000)`, ensuring promotions per call are bounded.

### Testing
- `npm run build` completed successfully; `npm test -- tests/rate-limiting.test.ts` was executed but the suite failed in this environment due to missing local Valkey/Redis services (`localhost:6379` timed out and `127.0.0.1:7000` connection refused`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f769ff004483338eea0344c576b58e)