### PR TITLE
Harden Claude comment-triggered workflow and remove id-token permission

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,16 +13,21 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event.sender.type == 'User') &&
+      (contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) ||
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Motivation
- Fix a security issue where untrusted issue/PR comments containing `@claude` could trigger a workflow that receives `secrets.CLAUDE_CODE_OAUTH_TOKEN` and `id-token: write`, enabling secret exfiltration or abuse. 
- Reduce blast radius by ensuring only trusted repository actors can trigger the secret-bearing action and by removing unnecessary OIDC write privileges.

### Description
- Require `github.event.sender.type == 'User'` and that the event author association is one of `OWNER`, `MEMBER`, or `COLLABORATOR` before honoring any `@claude` text trigger in `.github/workflows/claude.yml`.
- Preserve the original supported events and the `@claude` keyword flow for trusted authors while blocking untrusted authors from invoking the action.
- Remove the `id-token: write` permission from the workflow job to reduce OIDC exposure.
- Keep the action invocation and optional prompt settings unchanged so intended functionality for trusted users remains intact.

### Testing
- Inspected the modified workflow file with `sed -n '1,220p' .github/workflows/claude.yml` and `nl -ba .github/workflows/claude.yml | sed -n '1,140p'` to verify the new conditional and removed permission; these checks succeeded.
- Verified the file diff with `git diff -- .github/workflows/claude.yml` to confirm only the intended changes were applied and the conditional logic matches the new guard; this check succeeded.
- No repository unit tests were modified or required for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7685918d48333a5227e42d1204ff0)