### PR TITLE
Ensure periodic job heartbeats so long-running jobs aren't treated as stalled

### DIFF
--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -884,11 +884,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     const ac = new AbortController();
     this.activeAbortControllers.set(jobId, ac);
     job.abortSignal = ac.signal;
-    // Force periodic heartbeat when a pre-processor wait could exceed stalledInterval.
-    // Without this, default 30s/30s configs skip the periodic heartbeat (see startHeartbeat
-    // guard) and a long TPM/rate limiter wait can be reclaimed as stalled.
-    const willWait = Boolean(this.opts.limiter || this.globalRateLimitEnabled || this.opts.tokenLimiter);
-    this.startHeartbeat(jobId, job.opts.lockDuration, willWait);
+    this.startHeartbeat(jobId, job.opts.lockDuration);
 
     if (this.opts.limiter || this.globalRateLimitEnabled) await this.waitForRateLimit();
     if (this.opts.tokenLimiter) await this.waitForTokenLimit();
@@ -1534,7 +1530,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     return false;
   }
 
-  protected startHeartbeat(jobId: string, jobLockDuration?: number, force = false): void {
+  protected startHeartbeat(jobId: string, jobLockDuration?: number): void {
     if (!this.commandClient) return;
     // Use per-job lockDuration when specified, otherwise fall back to worker-level.
     const effectiveLock = jobLockDuration ?? this.lockDuration;

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -1538,14 +1538,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     if (!this.commandClient) return;
     // Use per-job lockDuration when specified, otherwise fall back to worker-level.
     const effectiveLock = jobLockDuration ?? this.lockDuration;
-    // Only start periodic heartbeat for long lockDurations where stall detection matters.
-    // moveToActive already writes the initial lastActive - protects against immediate stall reclaim.
-    // For the default 30s lockDuration with 30s stalledInterval, the heartbeat fires at 15s.
-    // Skip entirely if lockDuration >= stalledInterval (initial write is sufficient for one cycle).
-    // `force=true` bypasses this guard when a pre-processor wait (rate/token limiter) is possible
-    // and the job could otherwise be reclaimed as stalled while sleeping.
-    if (!force && effectiveLock >= this.stalledInterval) return;
     const interval = effectiveLock / 2;
+    if (interval <= 0) return;
     const client = this.commandClient;
     const jobKey = this.queueKeys.job(jobId);
     const timer = setInterval(() => {


### PR DESCRIPTION
### Motivation
- A recent change skipped scheduling per-job heartbeats when `lockDuration >= stalledInterval`, which can let legitimately running jobs stop refreshing `lastActive` and be reclaimed/marked failed as stalled.

### Description
- Remove the early-return guard and instead always schedule periodic heartbeat updates in `startHeartbeat` (file `src/base-worker.ts`) using `effectiveLock / 2`, adding only a minimal safety check `if (interval <= 0) return;` to avoid invalid timers.

### Testing
- Ran `npm run build`, which completed successfully.
- Ran `npm test`, which failed during test collection because `tests/helpers/fixture.ts` could not resolve `../../dist/utils` (test harness requires built `dist/` artefacts), so the unit test suite did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76caa08688333bd789b38131e007c)