### PR TITLE
Ensure reclaimed (XAUTOCLAIM) jobs are dispatched by workers

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -44,12 +44,20 @@ export class Worker<D = any, R = any> extends BaseWorker<D, R> {
     // Check priority list first (priority > LIFO > FIFO), then LIFO, before blocking on stream
     if (await this.tryPopFromLists(fetchCount)) return;
 
-    // XREADGROUP GROUP {group} {consumerId} COUNT {fetchCount} BLOCK {blockTimeout}
-    // STREAMS {streamKey} >
-    const result = await this.blockingClient.xreadgroup(CONSUMER_GROUP, this.consumerId, this.xreadStreams, {
-      count: fetchCount,
-      block: this.blockTimeout,
-    });
+    // First drain this consumer's pending entries (e.g. reclaimed via XAUTOCLAIM),
+    // then block for never-delivered entries.
+    const pendingResult = await this.blockingClient.xreadgroup(
+      CONSUMER_GROUP,
+      this.consumerId,
+      { [this.queueKeys.stream]: '0' },
+      { count: fetchCount },
+    );
+    const result =
+      pendingResult ??
+      (await this.blockingClient.xreadgroup(CONSUMER_GROUP, this.consumerId, this.xreadStreams, {
+        count: fetchCount,
+        block: this.blockTimeout,
+      }));
 
     if (!result) {
       // Stream empty - check priority and LIFO lists for jobs added while we were blocking

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -45,19 +45,23 @@ export class Worker<D = any, R = any> extends BaseWorker<D, R> {
     if (await this.tryPopFromLists(fetchCount)) return;
 
     // First drain this consumer's pending entries (e.g. reclaimed via XAUTOCLAIM),
-    // then block for never-delivered entries.
+    // then block for never-delivered entries. With id '0', XREADGROUP returns the
+    // consumer's PEL even when empty (an empty entries array), so check entry count
+    // before deciding whether to fall through to the blocking call.
     const pendingResult = await this.blockingClient.xreadgroup(
       CONSUMER_GROUP,
       this.consumerId,
       { [this.queueKeys.stream]: '0' },
       { count: fetchCount },
     );
-    const result =
-      pendingResult ??
-      (await this.blockingClient.xreadgroup(CONSUMER_GROUP, this.consumerId, this.xreadStreams, {
-        count: fetchCount,
-        block: this.blockTimeout,
-      }));
+    const pendingHasEntries =
+      pendingResult != null && pendingResult.some((stream) => Object.keys(stream.value).length > 0);
+    const result = pendingHasEntries
+      ? pendingResult
+      : await this.blockingClient.xreadgroup(CONSUMER_GROUP, this.consumerId, this.xreadStreams, {
+          count: fetchCount,
+          block: this.blockTimeout,
+        });
 
     if (!result) {
       // Stream empty - check priority and LIFO lists for jobs added while we were blocking

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -196,11 +196,12 @@ describe('Worker', () => {
     // Wait for poll loop to call xreadgroup
     await vi.advanceTimersByTimeAsync(10);
 
-    expect(mockBlockingClient.xreadgroup).toHaveBeenCalledWith(
+    expect(mockBlockingClient.xreadgroup).toHaveBeenNthCalledWith(
+      1,
       CONSUMER_GROUP,
       expect.any(String),
-      { [keys.stream]: '>' },
-      { count: 10, block: 2000 },
+      { [keys.stream]: '0' },
+      { count: 10 },
     );
 
     // Resolve to prevent hanging

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -164,11 +164,12 @@ describe('Worker', () => {
 
     await vi.advanceTimersByTimeAsync(10);
 
-    expect(mockBlockingClient.xreadgroup).toHaveBeenCalledWith(
+    expect(mockBlockingClient.xreadgroup).toHaveBeenNthCalledWith(
+      1,
       CONSUMER_GROUP,
       expect.any(String),
-      { [keys.stream]: '>' },
-      { count: 4, block: 2000 },
+      { [keys.stream]: '0' },
+      { count: 4 },
     );
 
     resolveXRead!(null);


### PR DESCRIPTION
### Motivation
- Reclaimed stalled jobs moved by `XAUTOCLAIM` were being attached to a worker's PEL but the worker only read new entries (`'>'`), so reclaimed entries were never dispatched and could be failed without processing.
- This breaks at-least-once delivery and allows long-running healthy jobs to be incorrectly reclaimed and failed.

### Description
- In `Worker.pollOnce` drain this consumer's pending entries first with a non-blocking `XREADGROUP ... STREAMS <stream> 0`, then fall back to the existing blocking read (`'>'`) for never-delivered entries.
- Updated unit test expectations in `tests/worker.test.ts` to assert the worker first calls `xreadgroup` with `'0'` and count-only, matching the new read order.
- Change is minimal and localized to the worker poll path to ensure reclaimed PEL entries are processed by the worker that received the claim.

### Testing
- Ran `npx vitest run tests/worker.test.ts` and the entire `tests/worker.ts` suite passed after the change.
- Running `npm test -- --run tests/worker.test.ts` in this environment previously surfaced an unrelated failure due to missing built artifacts under `dist/` (not caused by this change).
- Updated unit test `tests/worker.test.ts` now verifies the pending-drain `xreadgroup` call and passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76dcdd0dc833392ba5ebe6731c3f5)