### PR TITLE
fix(serverless-pool): hash credentials into cache key instead of bypassing cache

### DIFF
--- a/src/serverless-pool.ts
+++ b/src/serverless-pool.ts
@@ -4,8 +4,39 @@
  * Caches Producer instances by queue name + connection fingerprint so that
  * warm invocations reuse existing connections instead of creating new ones.
  */
+import { createHash } from 'crypto';
 import { Producer } from './producer';
 import type { ProducerOptions } from './producer';
+import type { ConnectionOptions } from './types';
+
+/**
+ * Hash credentials into the fingerprint so different identities do not collide
+ * on the same cache entry, while still allowing the same identity to share a
+ * cached producer. Plaintext secrets are never embedded in the cache key.
+ */
+function credentialsFingerprint(creds: ConnectionOptions['credentials']): string {
+  if (!creds) return 'none';
+  const h = createHash('sha256');
+  if ('type' in creds && creds.type === 'iam') {
+    h.update('iam');
+    h.update('\0');
+    h.update(creds.serviceType);
+    h.update('\0');
+    h.update(creds.region);
+    h.update('\0');
+    h.update(creds.userId);
+    h.update('\0');
+    h.update(creds.clusterName);
+  } else {
+    const pwd = creds as { username?: string; password: string };
+    h.update('password');
+    h.update('\0');
+    h.update(pwd.username ?? '');
+    h.update('\0');
+    h.update(pwd.password);
+  }
+  return h.digest('hex');
+}
 
 function fingerprint(name: string, opts: ProducerOptions): string {
   const addresses = opts.connection?.addresses ?? [];
@@ -23,6 +54,7 @@ function fingerprint(name: string, opts: ProducerOptions): string {
     compression: opts.compression ?? 'none',
     serializer: serializerKey,
     useTLS: opts.connection?.useTLS ?? false,
+    credentials: credentialsFingerprint(opts.connection?.credentials),
   });
 }
 
@@ -41,9 +73,12 @@ export class ServerlessPool {
     if (this.closing) {
       throw new Error('ServerlessPool is closing');
     }
-    // Custom serializers, injected clients, or explicit credentials bypass the cache
-    // intentionally to avoid state and authentication-context collisions.
-    if (opts.client || opts.serializer || opts.connection?.credentials) {
+    // Custom serializers or injected clients bypass the cache intentionally -
+    // serializer instances may hold state and must not be shared across callers.
+    // Credentials are folded into the fingerprint (hashed) so different identities
+    // do not collide on the same cache entry while still allowing reuse for the
+    // same identity.
+    if (opts.client || opts.serializer) {
       return new Producer(name, opts);
     }
 

--- a/tests/serverless-pool.test.ts
+++ b/tests/serverless-pool.test.ts
@@ -55,7 +55,7 @@ describeEachMode('ServerlessPool - caching', (CONNECTION) => {
     expect(pool.size).toBe(2);
   });
 
-  it('does not cache producers when credentials are provided', () => {
+  it('reuses cached producer for identical credentials', () => {
     const connWithCreds = {
       ...CONNECTION,
       credentials: {
@@ -65,8 +65,34 @@ describeEachMode('ServerlessPool - caching', (CONNECTION) => {
     };
     const p1 = pool.getProducer(Q1, { connection: connWithCreds });
     const p2 = pool.getProducer(Q1, { connection: connWithCreds });
-    expect(p1).not.toBe(p2);
-    expect(pool.size).toBe(0);
+    expect(p1).toBe(p2);
+    expect(pool.size).toBe(1);
+  });
+
+  it('returns separate cached producers for different credentials on the same queue', () => {
+    const connA = {
+      ...CONNECTION,
+      credentials: { username: 'user-a', password: 'secret-a' },
+    };
+    const connB = {
+      ...CONNECTION,
+      credentials: { username: 'user-b', password: 'secret-b' },
+    };
+    const pA = pool.getProducer(Q1, { connection: connA });
+    const pB = pool.getProducer(Q1, { connection: connB });
+    expect(pA).not.toBe(pB);
+    expect(pool.size).toBe(2);
+  });
+
+  it('does not collide credentialed and uncredentialed producers on the same queue', () => {
+    const connWithCreds = {
+      ...CONNECTION,
+      credentials: { username: 'user-a', password: 'secret-a' },
+    };
+    const pPlain = pool.getProducer(Q1, { connection: CONNECTION });
+    const pCreds = pool.getProducer(Q1, { connection: connWithCreds });
+    expect(pPlain).not.toBe(pCreds);
+    expect(pool.size).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #229. The original fix prevented credential collisions by bypassing the cache for any credentialed connection, but Gemini flagged that this:

- Defeats the pool's purpose in warm Lambda/Edge invocations (no reuse)
- Leaks connections - new Producers weren't tracked by `closeAll()`

This PR folds a sha256 digest of the credentials into the cache fingerprint instead. Same identity reuses the cached Producer, distinct identities get separate cache entries, and plaintext secrets never appear in the key.

## Behavior change

| Scenario | Before #229 | After #229 (current main) | This PR |
|---|---|---|---|
| Same creds, same queue | collision (bug) | new Producer each call | reused (cached) |
| Different creds, same queue | collision (bug) | new Producer each call | distinct cache entries |
| No creds vs creds, same queue | n/a | new Producer for creds | distinct cache entries |
| `opts.client` or `opts.serializer` provided | bypass | bypass | bypass (unchanged) |

## Verification

- `npm run build` passes
- `tests/serverless-pool.test.ts` 20/20 pass (3 new tests added)
- No plaintext credential material in cache keys (sha256-digested)

## Test plan

- [ ] CI green
- [ ] Replies to Gemini's #229 review threads referencing this PR