### PR TITLE
fix(reclaim): redispatch under-threshold stalled jobs to a healthy worker

### DIFF
--- a/docs/DURABILITY.md
+++ b/docs/DURABILITY.md
@@ -104,8 +104,12 @@ If a worker crashes mid-processing:
 
 1. the job has already been claimed into the consumer group's pending entries list
 2. it is **not** removed from Valkey just because the worker died
-3. another worker's scheduler can reclaim the stalled entry via `XAUTOCLAIM`
-4. after enough stalled-recovery cycles, glide-mq moves the job to `failed` instead of leaving it in limbo
+3. another worker's scheduler reclaims the stalled entry via `XAUTOCLAIM`
+4. the reclaim path increments `stalledCount` and:
+   - **redispatches** the job back to the queue so a healthy worker can pick it up again, when `stalledCount <= maxStalledCount` (default `1`)
+   - **fails** the job (state = `failed`, reason = `job stalled more than maxStalledCount`) once `stalledCount` exceeds the limit, instead of leaving it in limbo
+
+This means a single crash gets a retry; chronic crashing produces a clean terminal failure. AI-style workloads that take minutes-to-hours per job benefit from the retry: a transient worker death does not cost the whole run, and processors that store progress via `job.moveToDelayed(timestamp, nextStep)` resume from the most recent checkpoint.
 
 This is an important difference from older queue designs that rely on destructive pops and app-side lock bookkeeping.
 

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -575,9 +575,24 @@ redis.register_function('glidemq_reclaimStalled', function(keys, args)
         emitEvent(eventsKey, 'failed', jobId, {
           'failedReason', 'job stalled more than maxStalledCount'
         })
-      else
-        -- Reclaimed: emit stalled event, job stays in PEL for the new consumer
+      elseif broadcastMode == '1' then
+        -- Broadcast mode keeps the original entry visible to all subscribers,
+        -- so we can't redispatch via XADD. Leave state=active and re-emit the
+        -- stalled event; if it stalls again next cycle, the > threshold branch
+        -- will mark it failed.
         redis.call('HSET', jobKey, 'state', 'active')
+        emitEvent(eventsKey, 'stalled', jobId, nil)
+      else
+        -- Under threshold: ACK+DEL the original PEL entry (which is now in
+        -- the scheduler's consumer after XAUTOCLAIM) and re-queue a fresh
+        -- stream entry so a healthy worker picks the job up. processedOn
+        -- and lastActive are cleared so the new run records its own metrics.
+        redis.call('XACK', streamKey, group, entryId)
+        redis.call('XDEL', streamKey, entryId)
+        local jobName = redis.call('HGET', jobKey, 'name') or ''
+        redis.call('HSET', jobKey, 'state', 'waiting')
+        redis.call('HDEL', jobKey, 'processedOn', 'lastActive')
+        redis.call('XADD', streamKey, '*', 'jobId', jobId, 'name', jobName)
         emitEvent(eventsKey, 'stalled', jobId, nil)
       end
 

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -50,7 +50,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 88: glidemq_promote counts expired scheduled jobs toward MAX_PROMOTIONS budget - prevents unbounded scans when many expired jobs sit in scheduled set (#235).
 // Version 89: Bound skip-marker advancement work per FCALL via MAX_SKIP_ADVANCE_STEPS=128 to prevent long-running ordered-group loops (#222).
 // Version 90: glidemq_addFlow rechecks EXISTS for custom child IDs and skips auto-INCR'd parent/child IDs that collide with existing custom-ID jobs - mirrors the addJob auto-ID collision guard so flows survive shared idKey state (#234).
-export const LIBRARY_VERSION = '90';
+// Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#239).
+export const LIBRARY_VERSION = '91';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -1563,8 +1564,23 @@ redis.register_function('glidemq_reclaimStalled', function(keys, args)
       if failed then
         if entryId ~= '' then redis.call('XACK', streamKey, group, entryId) end
         if entryId ~= '' and broadcastMode ~= '1' then redis.call('XDEL', streamKey, entryId) end
-      else
+      elseif broadcastMode == '1' then
+        -- Broadcast mode keeps the original entry visible to all subscribers,
+        -- so we can't redispatch via XADD. Leave state active for the next
+        -- reclaim cycle; if it stalls again, applyStalledLogic will fail it.
         redis.call('HSET', jobKey, 'state', 'active')
+      else
+        -- Under maxStalledCount threshold: redispatch the job to the stream
+        -- so a healthy worker picks it up. The original PEL entry now belongs
+        -- to the scheduler's consumer (XAUTOCLAIM moved it there) and would
+        -- otherwise sit unprocessed forever; ACK+DEL it and re-queue a fresh
+        -- stream entry. processedOn is cleared so metrics record the new run.
+        if entryId ~= '' then redis.call('XACK', streamKey, group, entryId) end
+        if entryId ~= '' then redis.call('XDEL', streamKey, entryId) end
+        local jobName = redis.call('HGET', jobKey, 'name') or ''
+        redis.call('HSET', jobKey, 'state', 'waiting')
+        redis.call('HDEL', jobKey, 'processedOn', 'lastActive')
+        xaddJob(streamKey, jobId, jobName)
       end
       count = count + 1
       end
@@ -1629,6 +1645,27 @@ redis.register_function('glidemq_reclaimStalledListJobs', function(keys, args)
             shouldDecr = true
           else
             if applyStalledLogic(jk, jobId, prefix, eventsKey, failedKey, maxStalledCount, timestamp) then
+              shouldDecr = true
+            else
+              -- Under threshold: re-queue the job onto its source list so a
+              -- healthy worker picks it up. LIFO -> RPUSH lifo, priority ->
+              -- LPUSH priority (RPOP returns highest priority first). Decrement
+              -- the list-active counter because the job is no longer active.
+              local isLifo = vals[2] == '1'
+              local pri = tonumber(vals[3]) or 0
+              redis.call('HSET', jk, 'state', 'waiting')
+              redis.call('HDEL', jk, 'processedOn', 'lastActive')
+              if isLifo then
+                redis.call('RPUSH', prefix .. 'lifo', jobId)
+              elseif pri > 0 then
+                redis.call('LPUSH', prefix .. 'priority', jobId)
+              else
+                -- Stream-sourced fallback (shouldn't normally hit this branch
+                -- because XAUTOCLAIM handles stream entries, but redispatch
+                -- safely if someone misclassifies).
+                redis.call('XADD', streamKey, '*', 'jobId', jobId, 'name',
+                  redis.call('HGET', jk, 'name') or '')
+              end
               shouldDecr = true
             end
           end

--- a/tests/bulletproof.test.ts
+++ b/tests/bulletproof.test.ts
@@ -990,15 +990,14 @@ describeEachMode('Sidekiq BRPOP loss: job not lost when worker crashes mid-proce
     cleanupClient.close();
   });
 
-  it('job transitions to failed via stalled recovery after worker crash - not lost', async () => {
+  it('job recovers via redispatch when a single worker crashes mid-processing', async () => {
     const queue = new Queue(Q, { connection: CONNECTION });
-    const MAX_STALLED = 1;
     const STALL_INTERVAL = 1000;
 
     // Add a job before starting any worker
     const job = await queue.add('crash-test', { important: true });
 
-    // Worker 1: starts processing but we force-close it mid-processing
+    // Worker 1: starts processing but we force-close it mid-processing.
     let jobPicked = false;
     const crashWorker = new Worker(
       Q,
@@ -1017,61 +1016,52 @@ describeEachMode('Sidekiq BRPOP loss: job not lost when worker crashes mid-proce
     );
     crashWorker.on('error', () => {});
 
-    // Wait for job to be picked up
-    await new Promise<void>((resolve) => {
-      const check = setInterval(() => {
-        if (jobPicked) {
-          clearInterval(check);
-          resolve();
-        }
-      }, 50);
-      setTimeout(() => {
-        clearInterval(check);
-        resolve();
-      }, 5000);
-    });
+    await waitFor(() => jobPicked, 5000);
     expect(jobPicked).toBe(true);
 
-    // Force-close worker 1 (simulates crash - no graceful ACK)
+    // Force-close worker 1 (simulates crash - no graceful ACK, heartbeat stops)
     await crashWorker.close(true);
 
-    // Wait for PEL entry to age past the stalled interval
+    // Let the PEL entry age past the stalled interval so the next
+    // scheduler classifies it stalled on its first reclaim cycle.
     await new Promise((r) => setTimeout(r, STALL_INTERVAL + 500));
 
-    // Recovery worker: its scheduler will reclaim the stalled entry via XAUTOCLAIM.
-    // After maxStalledCount cycles, the job moves to failed.
-    const recoveryWorker = new Worker(Q, async () => 'should-not-process', {
-      connection: CONNECTION,
-      concurrency: 1,
-      blockTimeout: 500,
-      stalledInterval: STALL_INTERVAL,
-      maxStalledCount: MAX_STALLED,
-      lockDuration: 200,
-    });
+    // Recovery worker is healthy: the reclaim path will redispatch the job
+    // to the stream, and this worker will pick it up and complete it. This
+    // is the at-least-once-with-retry contract documented in
+    // docs/DURABILITY.md (Worker Crash Behavior).
+    let recoveryProcessed = false;
+    const recoveryWorker = new Worker(
+      Q,
+      async () => {
+        recoveryProcessed = true;
+        return 'recovered';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 500,
+        stalledInterval: STALL_INTERVAL,
+        maxStalledCount: 1,
+        lockDuration: 200,
+      },
+    );
     recoveryWorker.on('error', () => {});
 
-    // Wait for enough stalled recovery cycles to exceed maxStalledCount
-    // stalledCount increments once per cycle, need > MAX_STALLED cycles
-    await new Promise((r) => setTimeout(r, STALL_INTERVAL * (MAX_STALLED + 2) + 1000));
-
+    await waitFor(() => recoveryProcessed, 15000);
     await recoveryWorker.close(true);
 
-    // The job must NOT be lost - it should be in 'failed' state
+    // The job must reach a terminal state - completed via redispatch.
     const k = buildKeys(Q);
     const state = await cleanupClient.hget(k.job(job!.id), 'state');
-    expect(String(state)).toBe('failed');
+    expect(String(state)).toBe('completed');
+    const completedScore = await cleanupClient.zscore(k.completed, job!.id);
+    expect(completedScore).not.toBeNull();
 
-    // Verify the failed reason references stalling
-    const reason = await cleanupClient.hget(k.job(job!.id), 'failedReason');
-    expect(String(reason)).toContain('stalled');
-
-    // Verify stalledCount was tracked
+    // stalledCount was tracked - the single reclaim cycle that triggered
+    // the redispatch counts as one stall attempt.
     const stalledCount = await cleanupClient.hget(k.job(job!.id), 'stalledCount');
-    expect(Number(stalledCount)).toBeGreaterThan(MAX_STALLED);
-
-    // The job is in the failed ZSet (not lost in limbo)
-    const failedScore = await cleanupClient.zscore(k.failed, job!.id);
-    expect(failedScore).not.toBeNull();
+    expect(Number(stalledCount)).toBeGreaterThanOrEqual(1);
 
     await queue.close();
   }, 25000);
@@ -1322,66 +1312,47 @@ describeEachMode('Bee-Queue #106: repeated stalling moves job to failed, not inf
     // Add a job
     const job = await queue.add('stall-forever', { doomed: true });
 
-    // Worker picks up job, then crashes (force close)
-    let jobPicked = false;
-    const crashWorker = new Worker(
-      Q,
-      async () => {
-        jobPicked = true;
-        await new Promise(() => {}); // hang forever
-        return 'never';
-      },
-      {
-        connection: CONNECTION,
-        concurrency: 2,
-        blockTimeout: 500,
-        stalledInterval: 60000,
-        lockDuration: 200,
-      },
-    );
-    crashWorker.on('error', () => {});
-
-    await new Promise<void>((resolve) => {
-      const check = setInterval(() => {
-        if (jobPicked) {
-          clearInterval(check);
-          resolve();
-        }
-      }, 50);
-      setTimeout(() => {
-        clearInterval(check);
-        resolve();
-      }, 5000);
-    });
-
-    // Force-close to leave PEL entry orphaned
-    await crashWorker.close(true);
-
-    // Wait for entry to age past the stalled interval
-    await new Promise((r) => setTimeout(r, STALL_INTERVAL + 500));
-
-    // Recovery worker: scheduler reclaims the stalled entry via XAUTOCLAIM.
-    // Each cycle increments stalledCount. After exceeding maxStalledCount,
-    // the job is moved to failed - NOT looped infinitely.
-    const recoveryWorker = new Worker(Q, async () => 'should-not-process', {
-      connection: CONNECTION,
-      concurrency: 1,
-      blockTimeout: 500,
-      stalledInterval: STALL_INTERVAL,
-      maxStalledCount: MAX_STALLED,
-      lockDuration: 200,
-    });
-    recoveryWorker.on('error', () => {});
-
-    // Wait for enough stalled recovery cycles
-    await new Promise((r) => setTimeout(r, STALL_INTERVAL * (MAX_STALLED + 2) + 1000));
-
-    await recoveryWorker.close(true);
-
-    // Job must be in failed state - NOT stuck in active forever (Bee-Queue #106 bug)
+    // Simulate a chronically broken pipeline where every worker that picks up
+    // the job dies before completing. Each crash + reclaim cycle increments
+    // stalledCount; once stalledCount > maxStalledCount the reclaim path
+    // stops redispatching and moves the job to failed. This is the
+    // no-infinite-loop guard Bee-Queue #106 was about.
+    //
+    // We can't reuse a single hanging worker like the original test, because
+    // PR #238's heartbeat keeps a live (hanging) worker's lastActive fresh -
+    // the entry never re-stalls while the worker is up. We need actual deaths.
     const k = buildKeys(Q);
-    const state = await cleanupClient.hget(k.job(job!.id), 'state');
-    expect(String(state)).toBe('failed');
+    let cycles = 0;
+    let finalState: string | null = null;
+    while (cycles < 6 && finalState !== 'failed') {
+      const w = new Worker(
+        Q,
+        async () => {
+          await new Promise(() => {}); // hang
+          return 'never';
+        },
+        {
+          connection: CONNECTION,
+          concurrency: 1,
+          blockTimeout: 500,
+          stalledInterval: STALL_INTERVAL,
+          maxStalledCount: MAX_STALLED,
+          lockDuration: 200,
+        },
+      );
+      w.on('error', () => {});
+      // Let the worker pick up the entry, then force-close so its heartbeat
+      // dies and the entry can age past lockDuration in the next cycle.
+      await new Promise((r) => setTimeout(r, 700));
+      await w.close(true);
+      // Wait past stallInterval so the next worker's scheduler can reclaim.
+      await new Promise((r) => setTimeout(r, STALL_INTERVAL + 200));
+      finalState = (await cleanupClient.hget(k.job(job!.id), 'state'))?.toString() ?? null;
+      cycles++;
+    }
+
+    // After enough crash cycles, reclaim path moved the job to failed.
+    expect(finalState).toBe('failed');
 
     // Verify stalledCount exceeds the limit
     const stalledCount = await cleanupClient.hget(k.job(job!.id), 'stalledCount');
@@ -1392,7 +1363,7 @@ describeEachMode('Bee-Queue #106: repeated stalling moves job to failed, not inf
     expect(String(reason)).toContain('stalled');
 
     await queue.close();
-  }, 25000);
+  }, 30000);
 });
 
 // ---------------------------------------------------------------------------
@@ -1672,36 +1643,45 @@ describeEachMode('Bee-Queue #120: bulk stalled job recovery reclaims all jobs', 
     // Wait for entries to age past the stalled interval
     await new Promise((r) => setTimeout(r, STALL_INTERVAL + 500));
 
-    // Recovery worker: its scheduler will reclaim all stalled entries
-    const recoveryWorker = new Worker(Q, async () => 'should-not-process', {
-      connection: CONNECTION,
-      concurrency: 1,
-      blockTimeout: 500,
-      stalledInterval: STALL_INTERVAL,
-      maxStalledCount: MAX_STALLED,
-      lockDuration: 200,
-    });
-    recoveryWorker.on('error', () => {});
-
-    // Poll until all jobs have transitioned to failed state.
-    // The scheduler needs MAX_STALLED + 1 reclaim cycles per job, but CI timing varies.
+    // Spawn a chain of crashing recovery workers. Each cycle: workers grab
+    // entries, hang, then we force-close them so heartbeats stop and the
+    // entries can re-stall. After enough cycles every job exceeds
+    // maxStalledCount and is moved to failed (no infinite loop guard at
+    // scale, which is what Bee-Queue #120 was about).
     const k = buildKeys(Q);
-    await waitFor(
-      async () => {
-        let failed = 0;
-        for (const id of jobIds) {
-          const state = await cleanupClient.hget(k.job(id), 'state');
-          if (String(state) === 'failed') failed++;
-        }
-        return failed >= TOTAL;
-      },
-      15000,
-      500,
-    );
+    let cycles = 0;
+    let allFailed = false;
+    while (cycles < 8 && !allFailed) {
+      const w = new Worker(
+        Q,
+        async () => {
+          await new Promise(() => {}); // hang
+          return 'never';
+        },
+        {
+          connection: CONNECTION,
+          concurrency: TOTAL,
+          blockTimeout: 500,
+          stalledInterval: STALL_INTERVAL,
+          maxStalledCount: MAX_STALLED,
+          lockDuration: 200,
+        },
+      );
+      w.on('error', () => {});
+      await new Promise((r) => setTimeout(r, 800));
+      await w.close(true);
+      await new Promise((r) => setTimeout(r, STALL_INTERVAL + 300));
 
-    await recoveryWorker.close(true);
+      let failed = 0;
+      for (const id of jobIds) {
+        const state = await cleanupClient.hget(k.job(id), 'state');
+        if (String(state) === 'failed') failed++;
+      }
+      allFailed = failed >= TOTAL;
+      cycles++;
+    }
 
-    // All 20 jobs must be in failed state - NOT stuck in active (Bee-Queue #120 bug)
+    // All 20 jobs must reach failed state - NOT stuck in active (Bee-Queue #120 bug)
     let failedCount = 0;
     for (const id of jobIds) {
       const state = await cleanupClient.hget(k.job(id), 'state');
@@ -1715,7 +1695,7 @@ describeEachMode('Bee-Queue #120: bulk stalled job recovery reclaims all jobs', 
     expect(failedZsetCount).toBeGreaterThanOrEqual(TOTAL);
 
     await queue.close();
-  }, 30000);
+  }, 60000);
 });
 
 // ===========================================================================
@@ -1796,36 +1776,39 @@ describeEachMode('Sidekiq BRPOP immunity: job in PEL survives worker crash and i
     // Wait for PEL entry to age past stall interval
     await new Promise((r) => setTimeout(r, STALL_INTERVAL + 500));
 
-    // Worker 2: recovery worker's scheduler reclaims the stalled entry
-    const recoveryWorker = new Worker(Q, async () => 'should-not-process', {
-      connection: CONNECTION,
-      concurrency: 1,
-      blockTimeout: 500,
-      stalledInterval: STALL_INTERVAL,
-      maxStalledCount: MAX_STALLED,
-      lockDuration: 200,
-    });
+    // Worker 2 is healthy: the reclaim path will redispatch the stalled
+    // entry to the stream, and this worker will process it. Contract is
+    // "reclaimed and not lost" - the new at-least-once-with-retry path
+    // satisfies it by completing the job rather than failing it.
+    let recoveryProcessed = false;
+    const recoveryWorker = new Worker(
+      Q,
+      async () => {
+        recoveryProcessed = true;
+        return 'recovered';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 500,
+        stalledInterval: STALL_INTERVAL,
+        maxStalledCount: MAX_STALLED,
+        lockDuration: 200,
+      },
+    );
     recoveryWorker.on('error', () => {});
 
-    // Wait for enough stalled recovery cycles to exceed maxStalledCount
-    await new Promise((r) => setTimeout(r, STALL_INTERVAL * (MAX_STALLED + 2) + 1000));
-
+    await waitFor(() => recoveryProcessed, 15000);
     await recoveryWorker.close(true);
 
-    // The job must NOT be lost - stalled recovery moved it to failed
+    // The job must reach a terminal state via recovery - not lost in limbo.
     const finalState = await cleanupClient.hget(k.job(job!.id), 'state');
-    expect(String(finalState)).toBe('failed');
-
-    // Verify stalled reason
-    const reason = await cleanupClient.hget(k.job(job!.id), 'failedReason');
-    expect(String(reason)).toContain('stalled');
-
-    // Job is in the failed ZSet (not lost in limbo)
-    const failedScore = await cleanupClient.zscore(k.failed, job!.id);
-    expect(failedScore).not.toBeNull();
+    expect(String(finalState)).toBe('completed');
+    const completedScore = await cleanupClient.zscore(k.completed, job!.id);
+    expect(completedScore).not.toBeNull();
 
     await queue.close();
-  }, 25000);
+  }, 30000);
 });
 
 // ---------------------------------------------------------------------------
@@ -2419,6 +2402,86 @@ describeEachMode('Sidekiq large payload: 500KB job data roundtrips without corru
 
     await queue.close();
   }, 25000);
+});
+
+// ---------------------------------------------------------------------------
+// AI workload contract: stalled-recovery redispatches under-threshold jobs.
+// The "Sidekiq BRPOP loss" + "Sidekiq BRPOP immunity" tests above already
+// cover the single-crash recovery path; this test pins the explicit contract
+// that stalledCount is incremented even on the redispatch branch (so a
+// chronically failing job still hits the maxStalledCount fail guard).
+// ---------------------------------------------------------------------------
+
+describeEachMode('Reclaim contract: redispatch increments stalledCount', (CONNECTION) => {
+  const Q = 'bp-reclaim-counter-' + Date.now();
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    await flushQueue(cleanupClient, Q);
+    cleanupClient.close();
+  });
+
+  it('a single crash + recovery leaves stalledCount = 1 on the completed job', async () => {
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('counter-test', { v: 1 });
+
+    let picked = false;
+    const w1 = new Worker(
+      Q,
+      async () => {
+        picked = true;
+        await new Promise(() => {});
+        return 'never';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 500,
+        stalledInterval: 60000,
+        lockDuration: 200,
+      },
+    );
+    w1.on('error', () => {});
+    await waitFor(() => picked, 5000);
+    await w1.close(true);
+
+    await new Promise((r) => setTimeout(r, 1500));
+
+    let recovered = false;
+    const w2 = new Worker(
+      Q,
+      async () => {
+        recovered = true;
+        return 'recovered';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 500,
+        stalledInterval: 1000,
+        maxStalledCount: 1,
+        lockDuration: 200,
+      },
+    );
+    w2.on('error', () => {});
+    await waitFor(() => recovered, 15000);
+    await w2.close(true);
+
+    const k = buildKeys(Q);
+    const state = await cleanupClient.hget(k.job(job!.id), 'state');
+    expect(String(state)).toBe('completed');
+
+    // The reclaim that triggered the redispatch must have bumped the counter.
+    // This is what guarantees that chronic failures still hit maxStalledCount.
+    const stalledCount = await cleanupClient.hget(k.job(job!.id), 'stalledCount');
+    expect(Number(stalledCount)).toBe(1);
+
+    await queue.close();
+  }, 30000);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/compat-bee-queue.test.ts
+++ b/tests/compat-bee-queue.test.ts
@@ -816,58 +816,45 @@ describeEachMode('node-resque: Stalled worker heartbeat', (CONNECTION) => {
     const Q = `bee-heartbeat-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     localQueues.push(Q);
     const queue = new Queue(Q, { connection: CONNECTION });
-    const _k = buildKeys(Q);
 
     const job = await queue.add('heartbeat-task', { v: 1 });
 
-    // Worker 1: picks up the job but "dies" without completing.
-    const stalledWorker = new Worker(
-      Q,
-      async () => {
-        await new Promise(() => {}); // Never completes
-      },
-      {
-        connection: CONNECTION,
-        concurrency: 1,
-        blockTimeout: 500,
-        lockDuration: 500,
-        stalledInterval: 500,
-        maxStalledCount: 1,
-      },
-    );
-    stalledWorker.on('error', () => {});
+    // Spawn a chain of crashing workers. Each picks up the redispatched
+    // entry, hangs, then dies (force-close stops the heartbeat). Each cycle
+    // adds a stall; once stalledCount > maxStalledCount the reclaim path
+    // moves the job to failed instead of redispatching again. This is the
+    // no-infinite-loop guard for chronically broken processors.
+    let cycles = 0;
+    let finalState: string | null = null;
+    while (cycles < 6 && finalState !== 'failed') {
+      const w = new Worker(
+        Q,
+        async () => {
+          await new Promise(() => {}); // hang
+        },
+        {
+          connection: CONNECTION,
+          concurrency: 1,
+          blockTimeout: 500,
+          lockDuration: 500,
+          stalledInterval: 500,
+          maxStalledCount: 1,
+        },
+      );
+      w.on('error', () => {});
+      await w.waitUntilReady();
+      await new Promise((r) => setTimeout(r, 700));
+      await w.close(true);
+      await new Promise((r) => setTimeout(r, 800));
 
-    await stalledWorker.waitUntilReady();
-    // Let it pick up the job so it enters the PEL
-    await new Promise((r) => setTimeout(r, 1500));
-    // Force-close without waiting for active jobs
-    await stalledWorker.close(true);
+      const fetched = await queue.getJob(job!.id);
+      finalState = fetched ? await fetched.getState() : null;
+      cycles++;
+    }
 
-    // Wait for the PEL entry to become idle long enough for XAUTOCLAIM
-    await new Promise((r) => setTimeout(r, 1000));
-
-    // Worker 2: its scheduler will detect the stalled entry via XAUTOCLAIM.
-    const recoveryWorker = new Worker(Q, async () => 'ok', {
-      connection: CONNECTION,
-      concurrency: 1,
-      blockTimeout: 500,
-      lockDuration: 500,
-      stalledInterval: 500,
-      maxStalledCount: 1,
-    });
-    recoveryWorker.on('error', () => {});
-
-    // Wait for enough stall detection cycles to run
-    await new Promise((r) => setTimeout(r, 3000));
-
-    await recoveryWorker.close();
-
-    // The stalled job should have been failed after exceeding maxStalledCount
     const fetched = await queue.getJob(job!.id);
     expect(fetched).not.toBeNull();
-    const state = await fetched!.getState();
-    // Job should be in failed state (stalled more than maxStalledCount)
-    expect(state).toBe('failed');
+    expect(await fetched!.getState()).toBe('failed');
     expect(fetched!.failedReason).toBe('job stalled more than maxStalledCount');
 
     await queue.close();

--- a/tests/compat-bull.test.ts
+++ b/tests/compat-bull.test.ts
@@ -12,7 +12,7 @@ const { Queue } = require('../dist/queue') as typeof import('../src/queue');
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
 const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
 
-import { describeEachMode, createCleanupClient, flushQueue } from './helpers/fixture';
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
 
 const TS = Date.now();
 
@@ -431,29 +431,37 @@ describeEachMode('Bull compat: Stalled job recovery', (CONNECTION) => {
     }
     await worker1.close(true);
 
-    // Worker 2: with short stalled interval to detect and recover the job
+    // Worker 2: healthy worker, picks up the redispatched job and finishes it.
+    // The reclaim path now redispatches under-threshold stalled jobs back to
+    // the stream (the test name "re-enqueued" describes exactly this contract).
+    let recovered = false;
     const stalledIds: string[] = [];
-    const worker2 = new Worker(Q, async () => 'recovered', {
-      connection: CONNECTION,
-      concurrency: 1,
-      blockTimeout: 500,
-      lockDuration: 1000,
-      stalledInterval: 1000,
-      maxStalledCount: 1,
-    });
+    const worker2 = new Worker(
+      Q,
+      async () => {
+        recovered = true;
+        return 'recovered';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 500,
+        lockDuration: 1000,
+        stalledInterval: 1000,
+        maxStalledCount: 1,
+      },
+    );
     worker2.on('error', () => {});
     worker2.on('stalled', (jobId: string) => stalledIds.push(jobId));
     await worker2.waitUntilReady();
 
-    // Wait for stalled recovery cycle to detect and move to failed
-    await new Promise((r) => setTimeout(r, 3500));
+    // Wait for the reclaim cycle to redispatch the job and worker2 to process it.
+    await waitFor(() => recovered, 15000);
     await worker2.close(true);
 
-    // Verify the job was handled by stalled recovery (moved to failed after maxStalledCount=1)
+    // Verify the job was re-enqueued by stalled recovery and ran to completion.
     const state = String(await cleanupClient.hget(k.job(job!.id), 'state'));
-    expect(state).toBe('failed');
-    const failedReason = String(await cleanupClient.hget(k.job(job!.id), 'failedReason'));
-    expect(failedReason).toContain('stalled');
+    expect(state).toBe('completed');
 
     await queue.close();
   }, 20000);

--- a/tests/compat-reliability.test.ts
+++ b/tests/compat-reliability.test.ts
@@ -104,52 +104,39 @@ describeEachMode('Stalled job recovery', (CONNECTION) => {
 
     const job = await queue.add('stall-fail', { value: 'doomed' });
 
-    // Worker that stalls - picks up job then crashes
-    const worker1 = new Worker(
-      Q,
-      async () => {
-        await new Promise((r) => setTimeout(r, 60000));
-        return 'never';
-      },
-      {
-        connection: CONNECTION,
-        concurrency: 1,
-        blockTimeout: 500,
-        stalledInterval: 60000,
-      },
-    );
-    worker1.on('error', () => {});
-    await new Promise((r) => setTimeout(r, 2000));
-    await worker1.close(true);
-
-    // Recovery worker with maxStalledCount=1
-    const worker2 = new Worker(
-      Q,
-      async () => {
-        await new Promise((r) => setTimeout(r, 60000));
-        return 'never';
-      },
-      {
-        connection: CONNECTION,
-        concurrency: 1,
-        blockTimeout: 500,
-        lockDuration: 1000,
-        stalledInterval: 1000,
-        maxStalledCount: 1,
-        promotionInterval: 500,
-      },
-    );
-    worker2.on('error', () => {});
-
-    // Wait for 2+ stall detection cycles
-    await new Promise((r) => setTimeout(r, 5000));
-
-    await worker2.close(true);
+    // Simulate a chronically broken pipeline: every worker that picks up
+    // the job crashes (force-close stops the heartbeat). Each cycle bumps
+    // stalledCount; once it exceeds maxStalledCount, the reclaim path
+    // moves the job to failed instead of redispatching again.
+    let cycles = 0;
+    let finalState: string | null = null;
+    while (cycles < 6 && finalState !== 'failed') {
+      const w = new Worker(
+        Q,
+        async () => {
+          await new Promise(() => {}); // hang
+          return 'never';
+        },
+        {
+          connection: CONNECTION,
+          concurrency: 1,
+          blockTimeout: 500,
+          lockDuration: 500,
+          stalledInterval: 500,
+          maxStalledCount: 1,
+          promotionInterval: 500,
+        },
+      );
+      w.on('error', () => {});
+      await new Promise((r) => setTimeout(r, 700));
+      await w.close(true);
+      await new Promise((r) => setTimeout(r, 800));
+      finalState = (await cleanupClient.hget(k.job(job.id), 'state'))?.toString() ?? null;
+      cycles++;
+    }
     await queue.close();
 
-    // After exceeding maxStalledCount, job should be in failed state
-    const state = await cleanupClient.hget(k.job(job.id), 'state');
-    expect(String(state)).toBe('failed');
+    expect(finalState).toBe('failed');
 
     const failedReason = await cleanupClient.hget(k.job(job.id), 'failedReason');
     expect(String(failedReason)).toContain('stalled');
@@ -157,7 +144,7 @@ describeEachMode('Stalled job recovery', (CONNECTION) => {
     // Should be in the failed ZSet
     const failedScore = await cleanupClient.zscore(k.failed, job.id);
     expect(failedScore).not.toBeNull();
-  }, 15000);
+  }, 25000);
 
   it('stalled job detection interval is configurable', async () => {
     const Q = uniqueQueue('stall-interval');
@@ -184,17 +171,26 @@ describeEachMode('Stalled job recovery', (CONNECTION) => {
     await new Promise((r) => setTimeout(r, 2000));
     await worker1.close(true);
 
-    // Worker with 500ms stalled interval - should detect quickly
+    // Worker 2 ALSO hangs - we want to observe the stalled-count
+    // increment from the reclaim cycle, not have the redispatched job
+    // immediately complete and clear the counter.
     const stalledAt: number[] = [];
-    const worker2 = new Worker(Q, async () => 'recovered', {
-      connection: CONNECTION,
-      concurrency: 1,
-      blockTimeout: 500,
-      lockDuration: 500,
-      stalledInterval: 500,
-      maxStalledCount: 3,
-      promotionInterval: 500,
-    });
+    const worker2 = new Worker(
+      Q,
+      async () => {
+        await new Promise(() => {}); // hang too
+        return 'never';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 500,
+        lockDuration: 500,
+        stalledInterval: 500,
+        maxStalledCount: 5,
+        promotionInterval: 500,
+      },
+    );
     worker2.on('error', () => {});
     worker2.on('stalled', () => stalledAt.push(Date.now()));
 

--- a/tests/deep-heartbeat.test.ts
+++ b/tests/deep-heartbeat.test.ts
@@ -103,7 +103,13 @@ describeEachMode('Deep heartbeat / lock renewal', (CONNECTION) => {
     expect(stalled.length).toBe(0);
   }, 15000);
 
-  // 2. Job without heartbeat gets stalledCount incremented and eventually fails
+  // 2. Job without heartbeat gets stalledCount incremented and eventually fails.
+  // Each direct reclaimStalled() call either redispatches (under threshold,
+  // ACK+DEL old PEL entry, XADD a fresh stream entry) or fails the job once
+  // stalledCount > maxStalledCount. To exercise both states without a live
+  // worker loop, we manually re-claim the freshly-XADDed entry into the test
+  // consumer's PEL between cycles so the next reclaim call has something to
+  // age past minIdleMs.
   it('job without heartbeat gets stalledCount incremented by reclaimStalled', async () => {
     const Q = uniqueName('no-hb');
     const queue = new Queue(Q, { connection: CONNECTION });
@@ -139,16 +145,31 @@ describeEachMode('Deep heartbeat / lock renewal', (CONNECTION) => {
 
     const reclaimClient = await createCleanupClient(CONNECTION);
     try {
+      // Helper: claim the redispatched stream entry into the test consumer's
+      // PEL so the next reclaimStalled() call can find + age it.
+      const claimToTest = async () => {
+        await reclaimClient.xreadgroup(CONSUMER_GROUP, 'test-consumer', { [k.stream]: '>' }, { count: 10 });
+      };
+
+      // Cycle 1: stalledCount 0 -> 1, redispatched.
       await reclaimStalled(reclaimClient, k, 'test-consumer', 500, 2, Date.now(), CONSUMER_GROUP);
       const sc1 = await cleanupClient.hget(k.job(jobId), 'stalledCount');
       expect(Number(sc1)).toBe(1);
 
+      await claimToTest();
+      await cleanupClient.hdel(k.job(jobId), ['lastActive']);
       await new Promise((r) => setTimeout(r, 600));
+
+      // Cycle 2: stalledCount 1 -> 2, redispatched.
       await reclaimStalled(reclaimClient, k, 'test-consumer', 500, 2, Date.now(), CONSUMER_GROUP);
       const sc2 = await cleanupClient.hget(k.job(jobId), 'stalledCount');
       expect(Number(sc2)).toBe(2);
 
+      await claimToTest();
+      await cleanupClient.hdel(k.job(jobId), ['lastActive']);
       await new Promise((r) => setTimeout(r, 600));
+
+      // Cycle 3: stalledCount 3 > maxStalledCount(2) -> fail.
       await reclaimStalled(reclaimClient, k, 'test-consumer', 500, 2, Date.now(), CONSUMER_GROUP);
 
       const state = await cleanupClient.hget(k.job(jobId), 'state');

--- a/tests/edge-worker.test.ts
+++ b/tests/edge-worker.test.ts
@@ -452,53 +452,39 @@ describeEachMode('Edge: Worker', (CONNECTION) => {
       const queue = new Queue(Q, { connection: CONNECTION });
       const k = buildKeys(Q);
 
-      let w1Started = false;
-      const worker1 = new Worker(
-        Q,
-        async () => {
-          w1Started = true;
-          await new Promise((r) => setTimeout(r, 60000));
-          return 'w1-done';
-        },
-        { connection: CONNECTION, concurrency: 1, blockTimeout: 500, stalledInterval: 60000 },
-      );
-      worker1.on('error', () => {});
-      await worker1.waitUntilReady();
-
       const job = await queue.add('stall-test', { recover: true });
-      while (!w1Started) {
-        await new Promise((r) => setTimeout(r, 50));
+
+      // Simulate a chronically broken job: every worker that picks it up
+      // crashes (force-close stops the heartbeat). Each crash + reclaim
+      // cycle bumps stalledCount; once it exceeds maxStalledCount, the
+      // reclaim path fails the job instead of redispatching.
+      let cycles = 0;
+      let finalState: string | null = null;
+      while (cycles < 6 && finalState !== 'failed') {
+        const w = new Worker(
+          Q,
+          async () => {
+            await new Promise(() => {}); // hang
+            return 'never';
+          },
+          {
+            connection: CONNECTION,
+            concurrency: 1,
+            blockTimeout: 500,
+            lockDuration: 500,
+            stalledInterval: 500,
+            maxStalledCount: 1,
+          },
+        );
+        w.on('error', () => {});
+        await new Promise((r) => setTimeout(r, 700));
+        await w.close(true);
+        await new Promise((r) => setTimeout(r, 800));
+        finalState = (await cleanupClient.hget(k.job(job.id), 'state'))?.toString() ?? null;
+        cycles++;
       }
 
-      await worker1.close(true);
-
-      const pending = (await cleanupClient.customCommand(['XPENDING', k.stream, CONSUMER_GROUP])) as any[];
-      expect(Number(pending[0])).toBeGreaterThanOrEqual(1);
-
-      const worker2 = new Worker(
-        Q,
-        async () => {
-          return 'w2-done';
-        },
-        {
-          connection: CONNECTION,
-          concurrency: 1,
-          blockTimeout: 500,
-          lockDuration: 1000,
-          stalledInterval: 1000,
-          maxStalledCount: 1,
-        },
-      );
-      worker2.on('error', () => {});
-      worker2.on('stalled', (_jobId: string) => {});
-      await worker2.waitUntilReady();
-
-      await new Promise((r) => setTimeout(r, 3500));
-
-      await worker2.close(true);
-
-      const state = String(await cleanupClient.hget(k.job(job.id), 'state'));
-      expect(state).toBe('failed');
+      expect(finalState).toBe('failed');
       const failedReason = String(await cleanupClient.hget(k.job(job.id), 'failedReason'));
       expect(failedReason).toContain('stalled');
 
@@ -506,7 +492,7 @@ describeEachMode('Edge: Worker', (CONNECTION) => {
       expect(failedScore).not.toBeNull();
 
       await queue.close();
-    }, 20000);
+    }, 25000);
 
     it('increments stalledCount on the job hash during reclaim', async () => {
       const Q2 = `ew-stalled-count-${TS}`;
@@ -532,10 +518,14 @@ describeEachMode('Edge: Worker', (CONNECTION) => {
       }
       await worker1.close(true);
 
+      // Worker 2 also hangs - we want to observe the stalledCount increment
+      // from the reclaim cycle. A healthy worker would complete the
+      // redispatched job and the test would race against the assertion.
       const worker2 = new Worker(
         Q2,
         async () => {
-          return 'w2';
+          await new Promise(() => {}); // hang
+          return 'never';
         },
         {
           connection: CONNECTION,
@@ -556,6 +546,8 @@ describeEachMode('Edge: Worker', (CONNECTION) => {
       const stalledCount = await cleanupClient.hget(k.job(job.id), 'stalledCount');
       expect(Number(stalledCount)).toBeGreaterThanOrEqual(1);
 
+      // After the reclaim + redispatch cycle, worker2 picked up and is
+      // hanging on the redispatched stream entry, so the job is active again.
       const state = String(await cleanupClient.hget(k.job(job.id), 'state'));
       expect(state).toBe('active');
 

--- a/tests/lifo.test.ts
+++ b/tests/lifo.test.ts
@@ -738,7 +738,7 @@ describeEachMode('LIFO: Stalled list-sourced job recovery', (CONNECTION) => {
     cleanupClient.close();
   });
 
-  it('reclaimStalledListJobs detects stalled LIFO job and moves to failed with list-active DECR', async () => {
+  it('reclaimStalledListJobs detects stalled LIFO job, redispatches under threshold, fails past threshold', async () => {
     const Q = `stall-lifo-reclaim-${Date.now()}`;
     const k = buildKeys(Q);
 
@@ -760,8 +760,8 @@ describeEachMode('LIFO: Stalled list-sourced job recovery', (CONNECTION) => {
     // Set list-active to 1 (simulating the INCR from rpopAndReserve)
     await cleanupClient.set(k.listActive, '1');
 
-    // Call reclaimStalledListJobs directly via FCALL
-    // minIdleMs=5000, maxStalledCount=1, timestamp=now
+    // Call reclaimStalledListJobs directly via FCALL.
+    // minIdleMs=5000, maxStalledCount=1, timestamp=now.
     const now = Date.now();
     const count = await cleanupClient.fcall(
       'glidemq_reclaimStalledListJobs',
@@ -769,19 +769,30 @@ describeEachMode('LIFO: Stalled list-sourced job recovery', (CONNECTION) => {
       ['5000', '1', now.toString(), k.failed],
     );
 
-    // First call: stalledCount goes from 0 to 1 (== maxStalledCount), job stays active (stalled event)
+    // First call: stalledCount 0 -> 1 (== maxStalledCount, under threshold).
+    // Reclaim path redispatches by RPUSHing the job back onto the lifo list,
+    // so state transitions to 'waiting' and list-active DECRs (job is no
+    // longer checked out). The lifo list now contains the redispatched id.
     expect(Number(count)).toBe(1);
     const state1 = await cleanupClient.hget(k.job(jobId), 'state');
-    expect(state1).toBe('active');
+    expect(state1).toBe('waiting');
     const sc1 = await cleanupClient.hget(k.job(jobId), 'stalledCount');
     expect(sc1).toBe('1');
-    // list-active should NOT be decremented yet (job is re-activated, not failed)
     const la1 = await cleanupClient.get(k.listActive);
-    expect(la1).toBe('1');
+    expect(Number(la1)).toBe(0);
+    const lifoLen = await cleanupClient.llen(k.lifo);
+    expect(Number(lifoLen)).toBe(1);
 
-    // Second call: stalledCount goes from 1 to 2 (> maxStalledCount), job moves to failed.
-    // Advance timestamp past minIdleMs (5000) so the dedup refresh from the first call no
-    // longer suppresses detection in this fresh recovery window.
+    // Simulate the next worker re-claiming the job: HSET state=active and
+    // INCR list-active, mimicking rpopAndReserve. Then drive a stale
+    // lastActive again so the second reclaim cycle fires.
+    await cleanupClient.hset(k.job(jobId), {
+      state: 'active',
+      lastActive: staleTime.toString(),
+    });
+    await cleanupClient.set(k.listActive, '1');
+
+    // Second call: stalledCount 1 -> 2 (> maxStalledCount), job moves to failed.
     const count2 = await cleanupClient.fcall(
       'glidemq_reclaimStalledListJobs',
       [k.stream, k.events],
@@ -804,7 +815,7 @@ describeEachMode('LIFO: Stalled list-sourced job recovery', (CONNECTION) => {
     await flushQueue(cleanupClient, Q);
   });
 
-  it('reclaimStalledListJobs detects stalled priority-sourced job and moves to failed with list-active DECR', async () => {
+  it('reclaimStalledListJobs detects stalled priority-sourced job, redispatches under threshold, fails past threshold', async () => {
     const Q = `stall-priority-reclaim-${Date.now()}`;
     const k = buildKeys(Q);
 
@@ -828,7 +839,9 @@ describeEachMode('LIFO: Stalled list-sourced job recovery', (CONNECTION) => {
 
     const now = Date.now();
 
-    // First call: stalledCount 0 -> 1 (== maxStalledCount), job stays active (stalled event)
+    // First call: stalledCount 0 -> 1 (== maxStalledCount, under threshold).
+    // Reclaim path redispatches by LPUSHing the job onto the priority list,
+    // so state transitions to 'waiting' and list-active DECRs.
     const count1 = await cleanupClient.fcall(
       'glidemq_reclaimStalledListJobs',
       [k.stream, k.events],
@@ -836,16 +849,23 @@ describeEachMode('LIFO: Stalled list-sourced job recovery', (CONNECTION) => {
     );
     expect(Number(count1)).toBe(1);
     const state1 = await cleanupClient.hget(k.job(jobId), 'state');
-    expect(state1).toBe('active');
+    expect(state1).toBe('waiting');
     const sc1 = await cleanupClient.hget(k.job(jobId), 'stalledCount');
     expect(sc1).toBe('1');
-    // list-active should NOT be decremented yet
     const la1 = await cleanupClient.get(k.listActive);
-    expect(la1).toBe('1');
+    expect(Number(la1)).toBe(0);
+    // priority list should now contain the redispatched job
+    const priLen = await cleanupClient.llen(k.priority);
+    expect(Number(priLen)).toBe(1);
+
+    // Simulate the next worker re-claiming via rpopAndReserve.
+    await cleanupClient.hset(k.job(jobId), {
+      state: 'active',
+      lastActive: staleTime.toString(),
+    });
+    await cleanupClient.set(k.listActive, '1');
 
     // Second call: stalledCount 1 -> 2 (> maxStalledCount), job moves to failed.
-    // Advance timestamp past minIdleMs (5000) so the dedup refresh from the first call no
-    // longer suppresses detection in this fresh recovery window.
     const count2 = await cleanupClient.fcall(
       'glidemq_reclaimStalledListJobs',
       [k.stream, k.events],
@@ -899,11 +919,16 @@ describeEachMode('LIFO: Stalled list-sourced job recovery', (CONNECTION) => {
       ['5000', '1', now.toString(), k.failed],
     );
 
+    // First call: detected and redispatched (count=1, state=waiting,
+    // list-active decremented). Second call at the same timestamp: the
+    // dedup refresh from call 1 means lastActive is fresh, so the entry
+    // is no longer "idle past minIdleMs" and the loop's outer guard skips
+    // it (count=0). stalledCount stays 1 - no double-counting.
     expect(Number(count1)).toBe(1);
     expect(Number(count2)).toBe(0);
-    expect(await cleanupClient.hget(k.job(jobId), 'state')).toBe('active');
+    expect(await cleanupClient.hget(k.job(jobId), 'state')).toBe('waiting');
     expect(await cleanupClient.hget(k.job(jobId), 'stalledCount')).toBe('1');
-    expect(await cleanupClient.get(k.listActive)).toBe('1');
+    expect(Number(await cleanupClient.get(k.listActive))).toBe(0);
 
     await flushQueue(cleanupClient, Q);
   });

--- a/tests/per-job-lock.test.ts
+++ b/tests/per-job-lock.test.ts
@@ -112,32 +112,41 @@ describeEachMode('Per-job lockDuration', (CONNECTION) => {
     // Force-close worker1 to simulate crash (no heartbeat)
     await worker1.close(true);
 
-    // Worker 2: with short stalledInterval to run reclaim cycles
+    // Worker 2: healthy, will pick up the redispatched job and complete it.
+    // The reclaim path detects the stale entry (using the per-job 2s
+    // lockDuration as the threshold) and redispatches it to the stream.
+    let recovered = false;
     const stalledIds: string[] = [];
-    const worker2 = new Worker(Q, async () => 'recovered', {
-      connection: CONNECTION,
-      concurrency: 1,
-      blockTimeout: 500,
-      stalledInterval: 1000, // frequent reclaim checks
-      maxStalledCount: 1,
-    });
+    const worker2 = new Worker(
+      Q,
+      async () => {
+        recovered = true;
+        return 'recovered';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 500,
+        stalledInterval: 1000, // frequent reclaim checks
+        maxStalledCount: 1,
+      },
+    );
     worker2.on('error', () => {});
     worker2.on('stalled', (jobId: string) => stalledIds.push(jobId));
     await worker2.waitUntilReady();
 
-    // Wait for stalled recovery to detect the job (per-job lockDuration: 2s)
-    await waitFor(async () => {
-      const state = await cleanupClient.hget(k.job(job!.id), 'state');
-      return String(state) === 'failed';
-    }, 8000);
-
+    // Wait for the reclaim cycle to fire and worker2 to pick up the
+    // redispatched job. The per-job 2s lockDuration is the threshold;
+    // the entry must idle past it before reclaim triggers.
+    await waitFor(() => recovered, 12000);
     await worker2.close(true);
 
-    // Job should be failed via stalled recovery
     const state = String(await cleanupClient.hget(k.job(job!.id), 'state'));
-    expect(state).toBe('failed');
-    const failedReason = String(await cleanupClient.hget(k.job(job!.id), 'failedReason'));
-    expect(failedReason).toContain('stalled');
+    expect(state).toBe('completed');
+    // The reclaim cycle that triggered the redispatch should have bumped
+    // the counter, proving per-job lockDuration was honored as the threshold.
+    const stalledCount = await cleanupClient.hget(k.job(job!.id), 'stalledCount');
+    expect(Number(stalledCount)).toBeGreaterThanOrEqual(1);
 
     await queue.close();
   }, 20000);


### PR DESCRIPTION
## Summary

Replaces #239 with a clean redesign. Stalled-recovery now matches the at-least-once-with-redelivery contract documented in `docs/DURABILITY.md`: a single worker crash gets the job redispatched to a healthy worker, while chronic crashing still hits `maxStalledCount` and fails (no infinite loop).

## Why

Before this fix, when `glidemq_reclaimStalled` encountered an under-threshold stalled entry it just set `state=active` and left the entry sitting in the scheduler's PEL. Workers' `XREADGROUP > ` never returns PEL entries, so the only path forward was the next reclaim cycle bumping `stalledCount` past the threshold and failing the job. A single worker crash always cost the whole job, even when another worker could finish it.

This is a hard problem for AI/LLM workloads where a job can take minutes-to-hours: a transient worker death (OOM, k8s eviction, redeploy) shouldn't be lethal. The library is positioned as AI-primitives-included; the reclaim semantics should match that intent.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Single crash, healthy recovery | reclaim → stalledCount++ → next cycle fails | reclaim → stalledCount++ → redispatch → recovery worker completes |
| Chronic crashing (every worker dies) | fails after `maxStalledCount + 1` cycles | fails after `maxStalledCount + 1` cycles (unchanged) |
| Broadcast mode | unchanged (entry must stay visible to all subscribers) | unchanged |
| List-sourced (LIFO/priority) | reclaim → stalledCount++ → eventual fail | redispatch via RPUSH lifo / LPUSH priority |

## Implementation

- `glidemq_reclaimStalled` (Lua): when `applyStalledLogic` returns false (under threshold), ACK+DEL the original PEL entry and XADD a fresh stream entry. Clear `processedOn` and `lastActive` so the new run records its own metrics. Broadcast mode still leaves the entry parked.
- `glidemq_reclaimStalledListJobs` (Lua): list-sourced jobs are pushed back to their source list (RPUSH lifo, LPUSH priority, or stream as fallback) under threshold. List-active counter is decremented since the job is no longer active.
- `LIBRARY_VERSION` 90 → 91.
- `docs/DURABILITY.md` updated under "Worker Crash Behavior".

## Tests

- Updated:
  - `bulletproof.test.ts` "Sidekiq BRPOP loss / immunity" — assert redispatch-and-complete path (these tests' `state == 'failed'` was load-bearing on the old broken behavior).
  - `bulletproof.test.ts` "Bee-Queue #106 / #120" + `compat-bee-queue.test.ts` "node-resque heartbeat" — setup rewritten to a worker-crash loop, assertions kept (`failed` after chronic stalls). Single hanging worker no longer triggers chronic stall under PR #238's always-on heartbeat.
  - `deep-heartbeat.test.ts` direct-API test — drains the redispatched entry back into the test consumer between cycles.
- New:
  - `bulletproof.test.ts` "Reclaim contract: redispatch increments stalledCount" — pins the contract that a single recovery still bumps the counter, ensuring chronic failures still hit `maxStalledCount`.

## Verification

- `tests/bulletproof.test.ts`: 62/62
- `tests/compat-bee-queue.test.ts`: 52/52
- `tests/deep-heartbeat.test.ts`: 40/40
- Wide sweep across 16 integration test files: 473/474 (1 unrelated DAG flake; passed on rerun)

## Notes

- This is the redesign promised in https://github.com/avifenesh/glide-mq/pull/239#issuecomment-4470703066. Once this lands, #239 can be closed.
- Follow-up: `DEL` → `UNLINK` sweep for big-collection deletes (obliterate, retention) is filed as a separate task.

## Test plan

- [ ] CI green