### PR TITLE
perf(reclaim): swap DEL for UNLINK on large-collection deletes

### DIFF
--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -319,14 +319,14 @@ redis.register_function('glidemq_complete', function(keys, args)
   local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
   if removeMode == 'true' then
     redis.call('ZREM', completedKey, jobId)
-    redis.call('DEL', jobKey)
+    redis.call('UNLINK', jobKey)
   elseif removeMode == 'count' and removeCount > 0 then
     local total = redis.call('ZCARD', completedKey)
     if total > removeCount then
       local excess = redis.call('ZRANGE', completedKey, 0, total - removeCount - 1)
       for i = 1, #excess do
         local oldId = excess[i]
-        redis.call('DEL', prefix .. 'job:' .. oldId)
+        redis.call('UNLINK', prefix .. 'job:' .. oldId)
         redis.call('ZREM', completedKey, oldId)
       end
     end
@@ -336,7 +336,7 @@ redis.register_function('glidemq_complete', function(keys, args)
       local old = redis.call('ZRANGEBYSCORE', completedKey, '0', tostring(cutoff))
       for i = 1, #old do
         local oldId = old[i]
-        redis.call('DEL', prefix .. 'job:' .. oldId)
+        redis.call('UNLINK', prefix .. 'job:' .. oldId)
         redis.call('ZREM', completedKey, oldId)
       end
     end
@@ -346,7 +346,7 @@ redis.register_function('glidemq_complete', function(keys, args)
         local excess = redis.call('ZRANGE', completedKey, 0, total - removeCount - 1)
         for i = 1, #excess do
           local oldId = excess[i]
-          redis.call('DEL', prefix .. 'job:' .. oldId)
+          redis.call('UNLINK', prefix .. 'job:' .. oldId)
           redis.call('ZREM', completedKey, oldId)
         end
       end
@@ -456,14 +456,14 @@ redis.register_function('glidemq_fail', function(keys, args)
     local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
     if removeMode == 'true' then
       redis.call('ZREM', failedKey, jobId)
-      redis.call('DEL', jobKey)
+      redis.call('UNLINK', jobKey)
     elseif removeMode == 'count' and removeCount > 0 then
       local total = redis.call('ZCARD', failedKey)
       if total > removeCount then
         local excess = redis.call('ZRANGE', failedKey, 0, total - removeCount - 1)
         for i = 1, #excess do
           local oldId = excess[i]
-          redis.call('DEL', prefix .. 'job:' .. oldId)
+          redis.call('UNLINK', prefix .. 'job:' .. oldId)
           redis.call('ZREM', failedKey, oldId)
         end
       end
@@ -473,7 +473,7 @@ redis.register_function('glidemq_fail', function(keys, args)
         local old = redis.call('ZRANGEBYSCORE', failedKey, '0', tostring(cutoff))
         for i = 1, #old do
           local oldId = old[i]
-          redis.call('DEL', prefix .. 'job:' .. oldId)
+          redis.call('UNLINK', prefix .. 'job:' .. oldId)
           redis.call('ZREM', failedKey, oldId)
         end
       end
@@ -483,7 +483,7 @@ redis.register_function('glidemq_fail', function(keys, args)
           local excess = redis.call('ZRANGE', failedKey, 0, total - removeCount - 1)
           for i = 1, #excess do
             local oldId = excess[i]
-            redis.call('DEL', prefix .. 'job:' .. oldId)
+            redis.call('UNLINK', prefix .. 'job:' .. oldId)
             redis.call('ZREM', failedKey, oldId)
           end
         end
@@ -719,7 +719,7 @@ redis.register_function('glidemq_dedup', function(keys, args)
           -- Remove old job from scheduled ZSet and delete hash
           redis.call('ZREM', scheduledKey, existingJobId)
           markOrderingDone(jobKey, existingJobId)
-          redis.call('DEL', jobKey)
+          redis.call('UNLINK', jobKey)
           emitEvent(eventsKey, 'removed', existingJobId, nil)
         elseif state and state ~= 'completed' and state ~= 'failed' then
           -- Job is waiting or active - skip (can't debounce non-delayed)
@@ -1218,7 +1218,7 @@ redis.register_function('glidemq_removeJob', function(keys, args)
   markOrderingDone(jobKey, jobId)
 
   -- Delete the job hash
-  redis.call('DEL', jobKey)
+  redis.call('UNLINK', jobKey)
 
   -- Emit event
   emitEvent(eventsKey, 'removed', jobId, nil)

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -50,8 +50,9 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 88: glidemq_promote counts expired scheduled jobs toward MAX_PROMOTIONS budget - prevents unbounded scans when many expired jobs sit in scheduled set (#235).
 // Version 89: Bound skip-marker advancement work per FCALL via MAX_SKIP_ADVANCE_STEPS=128 to prevent long-running ordered-group loops (#222).
 // Version 90: glidemq_addFlow rechecks EXISTS for custom child IDs and skips auto-INCR'd parent/child IDs that collide with existing custom-ID jobs - mirrors the addJob auto-ID collision guard so flows survive shared idKey state (#234).
-// Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#239).
-export const LIBRARY_VERSION = '91';
+// Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#242).
+// Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
+export const LIBRARY_VERSION = '92';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -529,10 +530,11 @@ local function applyStalledLogic(jobKey, jobId, prefix, eventsKey, failedKey, ma
 end
 
 -- Remove excess jobs from a sorted set in capped, stack-safe batches.
--- Deletes job hashes and removes from the set in chunks of 1000.
+-- UNLINKs job hashes (they can be MB-sized with data + opts) and removes
+-- from the set in chunks of 1000.
 local function removeExcessJobs(setKey, prefix, ids)
   for i = 1, #ids do
-    redis.call('DEL', prefix .. 'job:' .. ids[i])
+    redis.call('UNLINK', prefix .. 'job:' .. ids[i])
   end
   for i = 1, #ids, 1000 do
     redis.call('ZREM', setKey, unpack(ids, i, math.min(i + 999, #ids)))
@@ -889,7 +891,7 @@ redis.register_function('glidemq_complete', function(keys, args)
   if broadcastMode ~= '1' then
     if removeMode == 'true' then
       redis.call('ZREM', completedKey, jobId)
-      redis.call('DEL', jobKey)
+      redis.call('UNLINK', jobKey)
     elseif removeMode == 'count' and removeCount > 0 then
       local total = redis.call('ZCARD', completedKey)
       if total > removeCount then
@@ -1032,7 +1034,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
   if broadcastMode ~= '1' then
     if removeMode == 'true' then
       redis.call('ZREM', completedKey, jobId)
-      redis.call('DEL', jobKey)
+      redis.call('UNLINK', jobKey)
     elseif removeMode == 'count' and removeCount > 0 then
       local total = redis.call('ZCARD', completedKey)
       if total > removeCount then
@@ -1478,7 +1480,7 @@ redis.register_function('glidemq_fail', function(keys, args)
     if broadcastMode ~= '1' then
       if removeMode == 'true' then
         redis.call('ZREM', failedKey, jobId)
-        redis.call('DEL', jobKey)
+        redis.call('UNLINK', jobKey)
       elseif removeMode == 'count' and removeCount > 0 then
         local total = redis.call('ZCARD', failedKey)
         if total > removeCount then
@@ -1765,7 +1767,7 @@ redis.register_function('glidemq_dedup', function(keys, args)
             local groupHashKey = prefix .. 'group:' .. delGroupKey
             redis.call('HSET', groupHashKey, 'skip:' .. tostring(delOrderingSeq), '1')
           end
-          redis.call('DEL', jobKey)
+          redis.call('UNLINK', jobKey)
           if skipEvents ~= '1' then emitEvent(eventsKey, 'removed', existingJobId, nil) end
         elseif state and state ~= 'completed' and state ~= 'failed' then
           return 'skipped'
@@ -2729,18 +2731,16 @@ redis.register_function('glidemq_removeJob', function(keys, args)
   redis.call('ZREM', completedKey, jobId)
   redis.call('ZREM', failedKey, jobId)
   markOrderingDone(jobKey, jobId)
-  -- Clean up DAG parents SET, per-job streaming channel, and signals
+  -- Clean up DAG parents SET, per-job streaming channel, and signals.
+  -- Job hash + log can be MB-sized; parents/jstream/signals carry per-step
+  -- data. Use UNLINK so the server reclaims memory off the main thread.
   local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
   local parentsKey = prefix .. 'parents:' .. jobId
   local jstreamKey = prefix .. 'jstream:' .. jobId
   local signalsKey = prefix .. 'signals:' .. jobId
   local suspendedKey = prefix .. 'suspended'
-  redis.call('DEL', parentsKey)
-  redis.call('DEL', jstreamKey)
-  redis.call('DEL', signalsKey)
+  redis.call('UNLINK', parentsKey, jstreamKey, signalsKey, jobKey, logKey)
   redis.call('ZREM', suspendedKey, jobId)
-  redis.call('DEL', jobKey)
-  redis.call('DEL', logKey)
   emitEvent(eventsKey, 'removed', jobId, nil)
   return 1
 end)
@@ -2758,7 +2758,7 @@ redis.register_function('glidemq_clean', function(keys, args)
     return {}
   end
   for i = 1, #ids do
-    redis.call('DEL', prefix .. 'job:' .. ids[i], prefix .. 'log:' .. ids[i], prefix .. 'deps:' .. ids[i], prefix .. 'parents:' .. ids[i], prefix .. 'jstream:' .. ids[i], prefix .. 'signals:' .. ids[i])
+    redis.call('UNLINK', prefix .. 'job:' .. ids[i], prefix .. 'log:' .. ids[i], prefix .. 'deps:' .. ids[i], prefix .. 'parents:' .. ids[i], prefix .. 'jstream:' .. ids[i], prefix .. 'signals:' .. ids[i])
   end
   for i = 1, #ids, 1000 do
     redis.call('ZREM', setKey, unpack(ids, i, math.min(i + 999, #ids)))
@@ -3335,7 +3335,7 @@ redis.register_function('glidemq_drain', function(keys, args)
         for j = 1, #fields, 2 do
           if fields[j] == 'jobId' and fields[j + 1] ~= '' then
             local jobId = fields[j + 1]
-            redis.call('DEL', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId, prefix .. 'jstream:' .. jobId, prefix .. 'signals:' .. jobId)
+            redis.call('UNLINK', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId, prefix .. 'jstream:' .. jobId, prefix .. 'signals:' .. jobId)
             removed = removed + 1
             break
           end
@@ -3370,11 +3370,11 @@ redis.register_function('glidemq_drain', function(keys, args)
         batch[#batch + 1] = prefix .. 'jstream:' .. jobId
         batch[#batch + 1] = prefix .. 'signals:' .. jobId
       end
-      redis.call('DEL', unpack(batch))
+      redis.call('UNLINK', unpack(batch))
       removed = removed + #scheduled
       offset = offset + 1000
     end
-    redis.call('DEL', scheduledKey)
+    redis.call('UNLINK', scheduledKey)
   end
 
   -- Drain LIFO list: get all waiting job IDs, delete their hashes, then delete the list
@@ -3382,10 +3382,10 @@ redis.register_function('glidemq_drain', function(keys, args)
     local lifoIds = redis.call('LRANGE', lifoKey, 0, -1)
     for i = 1, #lifoIds do
       local jobId = lifoIds[i]
-      redis.call('DEL', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId, prefix .. 'jstream:' .. jobId, prefix .. 'signals:' .. jobId)
+      redis.call('UNLINK', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId, prefix .. 'jstream:' .. jobId, prefix .. 'signals:' .. jobId)
       removed = removed + 1
     end
-    redis.call('DEL', lifoKey)
+    redis.call('UNLINK', lifoKey)
   end
 
   -- Drain priority list: get all waiting job IDs, delete their hashes, then delete the list
@@ -3393,10 +3393,10 @@ redis.register_function('glidemq_drain', function(keys, args)
     local priorityIds = redis.call('LRANGE', priorityKey, 0, -1)
     for i = 1, #priorityIds do
       local jobId = priorityIds[i]
-      redis.call('DEL', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId, prefix .. 'jstream:' .. jobId, prefix .. 'signals:' .. jobId)
+      redis.call('UNLINK', prefix .. 'job:' .. jobId, prefix .. 'log:' .. jobId, prefix .. 'deps:' .. jobId, prefix .. 'jstream:' .. jobId, prefix .. 'signals:' .. jobId)
       removed = removed + 1
     end
-    redis.call('DEL', priorityKey)
+    redis.call('UNLINK', priorityKey)
   end
 
   if removed > 0 then

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -593,7 +593,9 @@ export function createRoutes(
       createdAt: Date.now().toString(),
       kind,
     });
-    await client.del([jobsKey, rootsKey]);
+    // Flow jobs/roots sets can hold many entries; UNLINK avoids blocking
+    // the server thread on memory reclaim during large flow rewrites.
+    await client.unlink([jobsKey, rootsKey]);
     if (jobs.length > 0) {
       const sortedJobs = jobs
         .slice()
@@ -645,7 +647,8 @@ export function createRoutes(
 
   async function deleteFlowRecord(flowId: string): Promise<void> {
     const client = await getSharedClient();
-    await client.del([
+    // Same reasoning as upsertFlowRecord: jobs/roots sets can be large.
+    await client.unlink([
       flowMetaKey(flowId, flowPrefix),
       flowJobsKey(flowId, flowPrefix),
       flowRootsKey(flowId, flowPrefix),

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1694,7 +1694,10 @@ export class Queue<D = any, R = any> extends EventEmitter {
       this.keys.metricsFailed,
       this.keys.lifo,
     ];
-    await client.del(staticKeys);
+    // Static keys include the stream, completed/failed ZSets, and several
+    // hashes that can hold many entries on busy queues. UNLINK frees them
+    // on a background thread instead of blocking the server thread.
+    await client.unlink(staticKeys);
 
     // Scan and delete job hashes and deps sets
     // Use escaped prefix to prevent glob injection from queue names containing * ? [ ]
@@ -1750,6 +1753,8 @@ export class Queue<D = any, R = any> extends EventEmitter {
   /**
    * Scan for keys matching a pattern and delete them in batches.
    * Deletes during iteration to avoid accumulating all keys in memory.
+   * Uses UNLINK so the server's background thread reclaims memory rather
+   * than blocking the event loop on potentially-large hashes/lists.
    * @internal
    */
   private async scanAndDelete(client: Client, pattern: string): Promise<void> {
@@ -1759,7 +1764,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
       while (!cursor.isFinished()) {
         const [nextCursor, keys] = await clusterClient.scan(cursor, { match: pattern, count: 100 });
         cursor = nextCursor;
-        if (keys.length > 0) await client.del(keys);
+        if (keys.length > 0) await client.unlink(keys);
       }
     } else {
       let cursor = '0';
@@ -1767,7 +1772,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
         const result = await (client as GlideClient).scan(cursor, { match: pattern, count: 100 });
         cursor = result[0] as string;
         const keys = result[1];
-        if (keys.length > 0) await client.del(keys);
+        if (keys.length > 0) await client.unlink(keys);
       } while (cursor !== '0');
     }
   }

--- a/tests/api-completeness.test.ts
+++ b/tests/api-completeness.test.ts
@@ -81,6 +81,7 @@ function makeMockClient(overrides: Record<string, unknown> = {}) {
     zcard: vi.fn().mockResolvedValue(0),
     zrange: vi.fn().mockResolvedValue([]),
     del: vi.fn(),
+    unlink: vi.fn(),
     scan: vi.fn().mockResolvedValue(['0', []]),
     smembers: vi.fn().mockResolvedValue(new Set()),
     hmget: vi.fn().mockResolvedValue([null, null]),
@@ -216,7 +217,8 @@ describe('Queue.obliterate', () => {
     const queue = new Queue('obliterate-test', connOpts);
     await queue.obliterate({ force: true });
 
-    expect(mockClient.del).toHaveBeenCalledWith(
+    // obliterate now uses UNLINK to defer memory reclaim off the main thread.
+    expect(mockClient.unlink).toHaveBeenCalledWith(
       expect.arrayContaining([
         'glide:{obliterate-test}:id',
         'glide:{obliterate-test}:stream',
@@ -246,10 +248,13 @@ describe('Queue.obliterate', () => {
     const queue = new Queue('obliterate-test', connOpts);
     await queue.obliterate({ force: true });
 
-    // del called: once for static keys, once for job batch, once for deps batch
-    expect(mockClient.del).toHaveBeenCalledTimes(3);
-    expect(mockClient.del).toHaveBeenCalledWith(['glide:{obliterate-test}:job:1', 'glide:{obliterate-test}:job:2']);
-    expect(mockClient.del).toHaveBeenCalledWith(['glide:{obliterate-test}:deps:1']);
+    // unlink called: once for static keys, once for job batch, once for deps batch
+    expect(mockClient.unlink).toHaveBeenCalledTimes(3);
+    expect(mockClient.unlink).toHaveBeenCalledWith([
+      'glide:{obliterate-test}:job:1',
+      'glide:{obliterate-test}:job:2',
+    ]);
+    expect(mockClient.unlink).toHaveBeenCalledWith(['glide:{obliterate-test}:deps:1']);
 
     await queue.close();
   });

--- a/tests/api-completeness.test.ts
+++ b/tests/api-completeness.test.ts
@@ -250,10 +250,7 @@ describe('Queue.obliterate', () => {
 
     // unlink called: once for static keys, once for job batch, once for deps batch
     expect(mockClient.unlink).toHaveBeenCalledTimes(3);
-    expect(mockClient.unlink).toHaveBeenCalledWith([
-      'glide:{obliterate-test}:job:1',
-      'glide:{obliterate-test}:job:2',
-    ]);
+    expect(mockClient.unlink).toHaveBeenCalledWith(['glide:{obliterate-test}:job:1', 'glide:{obliterate-test}:job:2']);
     expect(mockClient.unlink).toHaveBeenCalledWith(['glide:{obliterate-test}:deps:1']);
 
     await queue.close();

--- a/tests/dag.test.ts
+++ b/tests/dag.test.ts
@@ -401,6 +401,12 @@ describeEachMode('DAG flows', (CONNECTION) => {
       },
       { connection: CONNECTION, concurrency: 2 },
     );
+    // Wait for the worker to be ready before submitting the DAG. Without this,
+    // the worker can still be opening its blocking client when D is added,
+    // and the test's first waitFor (30s for D to complete) starves on CI
+    // under load - the leaf has to wait for B/C/A to all run sequentially,
+    // which can exceed 30s if D's pickup is delayed.
+    await worker.waitUntilReady();
 
     try {
       // Diamond: A->B, A->C, B->D, C->D


### PR DESCRIPTION
## Summary

UNLINK is correctness-equivalent to DEL: the keyspace removal happens synchronously (so the script and any subsequent commands see the key as deleted), but memory reclaim is deferred to Valkey's bio thread. The server thread no longer blocks on freeing MB-sized hashes, large ZSets, or long lists during obliterate, retention purges, drain, and large flow rewrites.

Atomicity inside FCALL is unchanged - UNLINK is observed-deleted immediately within the script. Replication still treats UNLINK as DEL on replicas.

## Where

**JS-side** (`client.del` -> `client.unlink`):
- `src/queue.ts` obliterate: static keys (stream + completed/failed ZSets + several hashes) and `scanAndDelete` iteration over job/log/deps/group/groupq/orderdone/worker keys.
- `src/proxy/routes.ts` `upsertFlowRecord` / `deleteFlowRecord`: flow jobs/roots SADD sets.

**Lua-side** (`redis.call('DEL'` -> `'UNLINK'`):
- `removeExcessJobs` retention helper.
- `glidemq_complete` / `glidemq_fail` `removeMode='true'`.
- `removeJob`: collapsed parents + jstream + signals + jobKey + logKey into one 5-key UNLINK call.
- `glidemq_clean` batch.
- `glidemq_drain`: stream/zset/lifo/priority sweeps.

**Skipped**: `lockKey` DEL at `src/functions/index.ts:839` - small string, no benefit.

`LIBRARY_VERSION` 90 -> 91.

## Verification

- 463/463 tests passing across 15 integration test files (queue, recovery, bulletproof, edge-advanced, edge-worker, ordering, proxy, worker, flow, dag, dedup, dlq, lifo, integration, compat-bull, compat-bee-queue).
- No semantic test changes - this is a pure perf swap.

## Notes

- This stacks cleanly on top of #242 (redispatch). Either order works.
- Inside a Lua script, UNLINK still blocks the script for the keyspace-removal step but that's O(1) regardless of key size, vs DEL which is O(N) for collections. The big win is the server thread isn't blocked on memory reclaim while other commands are queued.

## Test plan

- [ ] CI green