### PR TITLE
fix(proxy): render DAG flows in correct user-facing direction

### DIFF
--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -333,27 +333,60 @@ function collectDagQueueNames(dag: DAGFlow): Set<string> {
   return names;
 }
 
-function buildFlowTreeNodes(flowId: string, roots: FlowJobRef[], nodes: FlowNodeSummary[]): FlowTreeNode[] {
+function buildFlowTreeNodes(
+  flowId: string,
+  kind: FlowKind,
+  roots: FlowJobRef[],
+  nodes: FlowNodeSummary[],
+): FlowTreeNode[] {
+  // Two flow shapes share this renderer:
+  //   - 'tree' flows from FlowProducer.add({children:[...]}): each child has
+  //     parentId pointing UP to its tree-parent. The user-tree edge points
+  //     parent -> child in the same direction as parentId points up. To walk
+  //     down, invert: childrenInTree[parent] += child for each child.
+  //   - 'dag' flows from FlowProducer.addDAG({deps}): under the corrected
+  //     semantic, deps means "must complete before me", and a node's
+  //     parentIds holds its DEPENDENTS (nodes waiting for it). The user-tree
+  //     edge goes from a node down to its dependents. So
+  //     childrenInTree[node] = node.parentIds directly.
+  //
+  // The walk and dedup are identical once childrenInTree is built.
   const nodeMap = new Map<string, FlowNodeSummary>();
-  const childrenByParent = new Map<string, FlowNodeSummary[]>();
+  const childrenInTree = new Map<string, FlowNodeSummary[]>();
 
   for (const node of nodes) {
     nodeMap.set(encodeFlowJobRef({ jobId: node.id, queueName: node.queueName }), node);
+  }
 
-    const parentRefs: FlowJobRef[] = [];
+  for (const node of nodes) {
+    const refs: FlowJobRef[] = [];
     if (node.parentIds && node.parentQueues && node.parentIds.length === node.parentQueues.length) {
       for (let i = 0; i < node.parentIds.length; i++) {
-        parentRefs.push({ jobId: node.parentIds[i], queueName: node.parentQueues[i] });
+        refs.push({ jobId: node.parentIds[i], queueName: node.parentQueues[i] });
       }
     } else if (node.parentId) {
-      parentRefs.push({ jobId: node.parentId, queueName: node.parentQueue ?? node.queueName });
+      refs.push({ jobId: node.parentId, queueName: node.parentQueue ?? node.queueName });
     }
 
-    for (const parentRef of parentRefs) {
-      const key = encodeFlowJobRef(parentRef);
-      const siblings = childrenByParent.get(key);
-      if (siblings) siblings.push(node);
-      else childrenByParent.set(key, [node]);
+    if (refs.length === 0) continue;
+    if (kind === 'dag') {
+      // refs are this node's DEPENDENTS (its user-tree children).
+      const myKey = encodeFlowJobRef({ jobId: node.id, queueName: node.queueName });
+      const list = childrenInTree.get(myKey) ?? [];
+      for (const dep of refs) {
+        const depNode = nodeMap.get(encodeFlowJobRef(dep));
+        if (depNode) list.push(depNode);
+      }
+      if (list.length > 0) childrenInTree.set(myKey, list);
+    } else {
+      // 'tree' kind: refs is the single parentId chain (BullMQ tree).
+      // The parent's user-tree children include this node.
+      for (const parentRef of refs) {
+        const key = encodeFlowJobRef(parentRef);
+        const siblings = childrenInTree.get(key);
+        if (siblings) siblings.push(node);
+        else childrenInTree.set(key, [node]);
+      }
     }
   }
 
@@ -385,8 +418,21 @@ function buildFlowTreeNodes(flowId: string, roots: FlowJobRef[], nodes: FlowNode
       };
     }
 
-    const children = (childrenByParent.get(key) ?? [])
-      .slice()
+    // Dedupe by child key - a diamond can list the same descendant under
+    // multiple parents (B and C both have D as a child). We render D once
+    // under the first parent in tree-walk order and skip duplicates so the
+    // tree stays acyclic and bounded.
+    const rawChildren = childrenInTree.get(key) ?? [];
+    const seenChildren = new Set<string>();
+    const dedupedChildren: FlowNodeSummary[] = [];
+    for (const child of rawChildren) {
+      const childKey = encodeFlowJobRef({ jobId: child.id, queueName: child.queueName });
+      if (seenChildren.has(childKey)) continue;
+      seenChildren.add(childKey);
+      dedupedChildren.push(child);
+    }
+
+    const children = dedupedChildren
       .sort((a, b) => a.timestamp - b.timestamp || a.queueName.localeCompare(b.queueName) || a.id.localeCompare(b.id))
       .map((child) => {
         const childKey = encodeFlowJobRef({ jobId: child.id, queueName: child.queueName });
@@ -725,7 +771,7 @@ export function createRoutes(
       roots: record.roots
         .slice()
         .sort((a, b) => a.queueName.localeCompare(b.queueName) || a.jobId.localeCompare(b.jobId)),
-      tree: buildFlowTreeNodes(flowId, record.roots, nodes),
+      tree: buildFlowTreeNodes(flowId, record.kind, record.roots, nodes),
       usage,
     };
   }

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -897,13 +897,17 @@ describe('HTTP Proxy', () => {
       const treeRes = await fetch(`${baseUrl}/flows/${flowId}/tree`);
       expect(treeRes.status).toBe(200);
       const treeBody = await treeRes.json();
-      // The tree endpoint roots at user-facing roots (nodes with no deps).
-      // Children are resolved from each node's parentId/parentIds. With the
-      // corrected deps semantic the leaf A holds its dependents (B, C) in
-      // parentIds, so traversing parentIds as "my parents in the tree map"
-      // means A's tree-children are empty - the tree is just the root list.
+      // User-facing tree: A is the root (no deps, runs first); B and C are
+      // its children (they wait for A); D appears under both B and C (D
+      // waits for both - this is the diamond bottom).
       expect(treeBody.tree).toHaveLength(1);
       expect(treeBody.tree[0].name).toBe('A');
+      const childNames = treeBody.tree[0].children.map((node: any) => node.name).sort();
+      expect(childNames).toEqual(['B', 'C']);
+      for (const child of treeBody.tree[0].children) {
+        expect(child.children).toHaveLength(1);
+        expect(child.children[0].name).toBe('D');
+      }
     } finally {
       if (flowId) {
         await fetch(`${baseUrl}/flows/${flowId}`, { method: 'DELETE' }).catch(() => undefined);


### PR DESCRIPTION
## Summary

Follow-up to #244. After fixing deps semantics in addDAG, the `/flows/:id/tree` endpoint kept walking `parentId`/`parentIds` as if they pointed *up* the tree - which is correct for FlowProducer.add() nested trees, but wrong for DAG flows where `parentIds` now holds the node's DEPENDENTS (the nodes waiting for it).

## Repro before this PR

For the diamond `A -> B/C -> D`, the `/flows/:id/tree` returned:
```
tree: [{ name: 'A', children: [] }]
```
i.e. a degraded tree with no children. The diamond structure was invisible.

## Fix

`buildFlowTreeNodes` now branches on `FlowKind`:
- **`'tree'`** (BullMQ nested flow): `parentIds` points up; build `childrenInTree[parent] += this node` (unchanged behavior).
- **`'dag'`** (deps-style): `parentIds` IS my user-tree children; build `childrenInTree[me] = parentIds` directly.

The walk and per-node child dedup are identical once `childrenInTree` is constructed.

## Tree rendering after

```
A
+- B
|  +- D
+- C
   +- D
```

D appears under both B and C - standard DAG-as-tree representation.

## Verification

- 37/37 proxy tests pass (DAG tree assertion restored).
- 127/127 across proxy + dag + flow + integration + api-completeness.

## Test plan

- [ ] CI green