### PR TITLE
docs: sync WORKFLOWS / CHANGELOG / HANDOVER with 0.15.x state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,62 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **DAG `deps` direction inverted** (#244): `DAGNode.deps` was documented as "nodes that must complete before me" but the implementation submitted in deps-first topo order with each dep using its first downstream node as the BullMQ `parentId`, which inverted the semantics. The fix submits in reverse-topological order, treats nodes with `deps` as `waiting-children` parents, and wires every dependent through the parents SET so `deps` now matches the documented direction. `LIBRARY_VERSION` bumped to `88`.
+
+- **Proxy `/flows/:id/tree` rendered DAG flows upside down** (#245): the tree builder used flow-tree semantics (children listed under their parent) for both `tree` and `dag` flow kinds. For DAGs that produces an inverted graph - leaves appear as roots. `buildFlowTreeNodes` now branches on `FlowKind`: for `dag` it uses each node's `parentIds` directly so prerequisites render under the dependent that waits for them.
+
+- **DAG multi-dependent leaf race in `addDAG`** (#246): when a leaf had >1 dependent, the previous wiring piggybacked the first dependent on `addJob`'s atomic `parentId`/`parentDepsKey` and wired the rest via `registerParent`. Workers fetching the leaf between Phase A and Phase B saw `parentIds=undefined` and `completeAndFetchNext` skipped `SMEMBERS A.parents`, leaving subsequent dependents stuck in `waiting-children`. Multi-dependent leaves now submit with no parent fields and wire every dependent through Phase B. Additionally, the `hasParents` arg to `glidemq_completeAndFetchNext` (which gated the `SMEMBERS` on a stale worker snapshot) was dropped - the SET is now always read at completion time. `LIBRARY_VERSION` bumped to `93`.
+
+- **Stalled-job redispatch under threshold** (#242): when a job stalled but its `stalledCount` was still under `maxStalledCount`, `glidemq_reclaimStalled` left the entry parked in the scheduler PEL instead of redispatching to a healthy worker. The redelivery contract in `DURABILITY.md` now holds: stalled entries are ACK+DEL'd and re-XADD'd back to the stream under threshold, only failing once `stalledCount > maxStalledCount`. Aligns with BullMQ semantics.
+
+- **`addFlow` ID-collision races** (#234): `glidemq_addFlow` re-checks `EXISTS` for custom child IDs and skips auto-`INCR`'d parent/child IDs that collide with existing custom-ID jobs - mirrors the same guard the `addJob` path already had, so flows survive shared `idKey` state.
+
+- **Ordering skip-marker advancement unbounded** (#222): debounce-induced skip markers were walked unboundedly per FCALL, which could OOM-trip Lua on large gaps. Skip-marker advancement is now bounded per call; the remaining markers are picked up on the next gate evaluation.
+
+- **Serverless pool credential cache key collisions** (#229, #241): the pool's cache previously bypassed the cache when credentials were present (#229), and then hashed credentials into the cache key so distinct credential sets get distinct entries instead of leaking across tenants (#241).
+
+- **Expired jobs not counted against promote budget** (#235): `glidemq_promoteGroupQ`'s loop budget was decremented only for promotions, so a queue full of expired entries would saturate the budget on expires without ever promoting real jobs. Expired jobs now consume budget too.
+
+- **Group promote loop could iterate unbounded under `maxConcurrency`** (#236): when a group was already at `maxConcurrency`, the promote loop kept popping the waitlist without making progress. Cap added so the loop terminates after one full pass.
+
+- **Long-running jobs marked stalled** (#238): workers now emit periodic heartbeats during job execution so `lockDuration` is honored against actual wall-clock activity, not the time since the worker last polled.
+
+- **Broadcast retries fanned out to healthy subscribers** (#231): a failing subscription's retry attempts re-delivered the message to every other subscriber. Retries are now isolated to the failing subscription via per-subscription PEL tracking.
+
+- **`list-active` counter leaks** (#230): non-processing outcomes of `moveToActive` (revoked, expired, ordering-deferred) failed to `DECR` the `list-active` counter they incremented on the way in.
+
+- **Batch-mode worker over-fetched stream entries** (#233): `XREADGROUP count` was uncapped, so `concurrency * batch.size` was claimed even when only `batch.size` could be processed. Count is now clamped.
+
+- **Heartbeat started after token-limiter wait** (#224): if the token bucket forced a wait before processing, the worker had no heartbeat during the wait and could trigger its own reclaim. Heartbeat now starts before the wait.
+
+- **Proxy accepted unsupported opts keys** (#232): job-add requests with unknown `opts` keys (typos, future fields) were silently accepted and ignored. The proxy now rejects them so client/server schema drift fails loud.
+
+- **Suspended-job cleanup on timeout** (#226): timed-out suspended jobs were missing some cleanup paths (groupq waitlist entry, ordering meta), leaving stale state. Cleanup is now exhaustive.
+
+- **Per-job `lockDuration` validation** (#225): `opts.lockDuration` was not validated; non-finite, negative, or extreme values would corrupt the stall threshold. Now validated and clamped.
+
+- **`Queue.getClient` initialization race** (#227): concurrent first-time access could initialize two clients. Now guarded by a single-flight promise.
+
+- **Cross-queue DLQ shared entries** (#223): DLQ entries were scoped only by job ID, so two queues using the same ID would see each other's DLQ rows. Now scoped to the owning queue.
+
+- **Duplicate stalled-list recovery across schedulers** (#228): with multiple schedulers running, list-backed stalled recovery could run concurrently and double-recover. Now deduped via a coordination key.
+
+### Performance
+
+- **`addDAG` round trips collapsed from O(N) to O(levels)** (#246): submissions are now grouped by topological level and pipelined within each level via non-atomic batch. Bench (5-run median, wide diamond, local Valkey/cluster): N=4 went from ~25 ms to ~0.5 ms (~50x); N=50 went from ~12-16 ms to ~3-4 ms (~4x). Each FCALL stays atomic individually; the race semantics are preserved by `registerParent`'s `already_completed` path.
+
+- **Large-collection deletes use UNLINK** (#243): job hashes, retention purge, `glidemq_clean` batches, and `glidemq_drain` stream/zset/lifo/priority sweeps now use `UNLINK` instead of `DEL`. UNLINK keeps in-script atomicity (the keyspace removal is still synchronous from the script's view) but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL.
+
+### Security / dependencies
+
+- **CVE fixes via `npm audit fix`** (#240): resolved CVEs in transitive deps `langsmith` and `protobufjs`.
+
+---
+
 ## [0.15.2] - 2026-05-08
 
 ### Fixed

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -3,75 +3,42 @@
 ## Current State
 
 - **Branch**: main
-- **Version**: 0.14.0 - released and published to npm
-- **All packages published**: glide-mq 0.14.0, speedkey 0.3.0, dashboard 0.3.0, fastify 0.2.0, hapi 0.3.0, hono 0.3.0, nestjs 0.2.0
-- **CI**: All green across all repos
-- **Tests**: 2312/2312 pass (94/94 files), all plugin tests pass
-- **Website**: Updated and deployed (dual MQ + AI positioning)
+- **Version**: 0.15.2 released on npm; an `[Unreleased]` series of fixes and perf work has landed on main and awaits a 0.15.3 cut.
+- **CI**: green on main
+- **Local branches**: `perf/addDAG-batched-fcall` merged to main as #246; safe to delete.
 
-## What Was Done (2026-03-28)
+## What Was Done (0.15.x series since 0.14.0)
 
-### glide-mq 0.14.0 (PR #183 merged, then direct push for JSDoc review)
-- JobUsage redesigned: Record-based tokens/costs replacing flat fields
-- BudgetOptions: per-category caps, weighted totals, currency-agnostic costs
-- job.streamChunk(type, content?) convenience method
-- Extracted shared helpers: parseJsonRecord, computeWeightedTotal, validateAndResolveUsage
-- 9 new examples (agent-budget-loop, multi-model-cost, fallback-usage, streaming-sse, batch-embed-tpm, thinking-model, cost-breakdown, budget-weighted, reasoning-stream)
-- ConnectionOptions.requestTimeout added
-- valkey-search 1.2 in compose.yaml and CI
-- Full JSDoc on all public API (22 interfaces, 8 error classes, 3 main classes)
-- All docs/skills/website updated for dual MQ+AI positioning
-- WIRE_PROTOCOL, ARCHITECTURE, MIGRATION docs corrected
+### Released
 
-### speedkey 0.3.0
-- Published stable (was rc1)
-- Bloom Filter, JSON.MSET, search 1.1/1.2 options
-- All 6 platform targets
+- **0.15.0** (#192, #205): HTTP proxy parity expansion (queue events SSE, per-job lifecycle SSE, `jobs/wait`, workers, metrics, scheduler CRUD, rolling usage summary, broadcast publish/SSE, DLQ inspection/replay, suspended-job inspection, revoke, queue global rate-limit HTTP management). Flow HTTP API: `POST /flows`, `GET /flows/:id`, `GET /flows/:id/tree`, `DELETE /flows/:id` for tree flows and DAGs. `queue.getUsageSummary()` plus `/usage/summary`.
+- **0.15.1** (#206): debounce + ordering.key deadlock fix via lightweight skip markers. `LIBRARY_VERSION` 81.
+- **0.15.2** (#212, #213, #216-219): priority/LIFO in batch-mode workers, `list-active` underflow guards (12 sites through one `decrListActive` helper), priority/LIFO active visibility via `glidemq_getActiveListJobIds`, lockDuration-aware stall reclaim (`stalledInterval` no longer conflated with threshold). `LIBRARY_VERSION` 84. **Behavior change**: workers that relied on short `stalledInterval` without setting `lockDuration` now see slower stall recovery; set `lockDuration` explicitly to match if needed.
 
-### All 5 plugins updated
-- Dashboard 0.3.0: 3 AI endpoints, AI fields in serialization, 14 new tests
-- Fastify 0.2.0: 3 AI endpoints (24 total), AI types, AI SSE events
-- Hapi 0.3.0: 3 AI endpoints, fixed stream route API pattern
-- Hono 0.3.0: 3 AI endpoints, streamSSE, AI SSE events
-- NestJS 0.2.0: AI usage examples in README
+### Unreleased (on main, awaiting 0.15.3 cut)
 
-### Website (glide-mq.dev)
-- Dual positioning: "Fast, Reliable, AI-Ready"
-- All integration docs updated: versions, endpoint counts (24), AI endpoint tables
-- All old API refs removed
+See CHANGELOG.md `[Unreleased]` for the full list. Highlights:
 
-## What Was Done (2026-03-28, continued)
+- **DAG correctness pass** (#244, #245, #246): `DAGNode.deps` direction now matches the documented "must complete before me" semantic; the proxy `/flows/:id/tree` renders DAGs in the user-facing direction (prerequisites under their dependents); `addDAG` pipelines submissions by topological level for ~4-50x speedup on local Valkey (cluster gains depend on RTT). Hidden race in multi-dependent leaf wiring fixed - completion now always SMEMBERS the parents SET instead of trusting a worker snapshot of `parentIds`. `LIBRARY_VERSION` bumped 88 -> 93.
+- **Reclaim semantics** (#242): under-threshold stalled jobs are now redispatched back to the stream/lifo/priority list so a healthy worker can pick them up; jobs only fail once `stalledCount > maxStalledCount`. Aligns with at-least-once redelivery promise.
+- **Perf: UNLINK for large deletes** (#243): job hashes, retention purge, `glidemq_clean` batches, drain sweeps now use `UNLINK` instead of `DEL`. Atomicity preserved (UNLINK is synchronous from script's view); memory reclamation deferred to bio thread.
+- **Other fixes** (#222, #223, #224, #225, #226, #227, #228, #229, #230, #231, #232, #233, #234, #235, #236, #238, #241): `addFlow` ID-collision races, ordering skip-marker bounded advancement, serverless pool credential cache key collisions, expired-jobs promote budget, group promote cap, long-running job heartbeat, broadcast retry isolation, list-active leak on non-processing moveToActive outcomes, batch XREADGROUP count cap, heartbeat-before-token-wait, proxy strict opts validation, suspended-job cleanup on timeout, per-job lockDuration clamp, getClient single-flight, cross-queue DLQ scoping, dedup of list stalled recovery across schedulers.
+- **Deps** (#240): npm audit fix for langsmith / protobufjs CVEs.
 
-### Validation suite (C:\Users\avife\glidemq\glide-mq-validation)
-- All 7 packages installed from npm and validated
-- **In-memory suite** (`npm run validate`): 178 checks across 6 apps
-  - Rich main package app: lifecycle, reportUsage, streamChunk, readStream, flows, budget, suspend/resume, fallbacks, bulk, metrics, serializer
-  - Hono, Fastify, Hapi: createTestApp, HTTP CRUD, AI endpoints (usage, budget, stream SSE)
-  - Dashboard: import validation, Express mount, HTML + API
-  - NestJS: DI injection, @Processor, WorkerHost, testing mode
-- **Live suite** (`npm run validate:live`): 134 checks against real Valkey
-  - Standalone (:6379): core 45/45, search 10/10, plugins 12/12
-  - Cluster (:7000): core 45/45, search 10/10, plugins 12/12
-  - Tests: Queue/Worker, FlowProducer with budget, getFlowUsage/getFlowBudget, createJobIndex, searchJobs, vectorSearch (COSINE), Hono plugin with real connection
+## Open Threads
 
-### Cluster now uses valkey-bundle with search
-- compose.yaml: cluster image changed from valkey:8.0 to valkey-bundle:9.1.0-rc1
-- Cluster nodes load search/json/bloom modules via loadmodule in config
-- CI: standalone service + cluster binary extraction both use valkey-bundle:9.1.0-rc1
-- start-cluster.sh: auto-loads modules if /usr/lib/valkey/*.so exists
-
-## Next Steps
-
-- Bun/Deno NAPI compatibility testing
-- Fix the 2 flaky CI tests (broadcast dedup fanout, TPM timing - both timing-sensitive)
-- Consider valkey-bundle stable when 9.1.0 releases (currently on rc1)
+- **0.15.3 release**: ~21 PRs sit in `[Unreleased]`. Worth a release when the next user-visible change lands or when the DAG fixes need to ship.
+- **Bun/Deno NAPI compatibility testing**: still pending from 0.14.0 handover.
+- **valkey-bundle stable**: cluster CI is on `valkey-bundle:9.1.0-rc1`; switch to GA when 9.1.0 releases.
 
 ## API Design Decisions (locked)
 
-- JobUsage.tokens: Record<string, number> not flat fields
-- Budget tokenWeights: computed in TS, not Lua
-- TPM uses raw (unweighted) totalTokens
-- costs/costUnit: currency-agnostic
-- streamChunk: thin wrapper over stream(), not new infrastructure
-- Search 1.1+ options: forward-compatible types, graceful skip on older servers
-- Plugins: AI endpoints under /flows/:id/usage, /flows/:id/budget, /jobs/:id/stream
+- `DAGNode.deps` = "nodes that must complete before this node runs" (as documented; corrected in #244).
+- `dag(nodes, connection, prefix?)` - `queueName` is per-node on each `DAGNode`, not a top-level arg.
+- JobUsage.tokens: `Record<string, number>` not flat fields.
+- Budget tokenWeights: computed in TS, not Lua.
+- TPM uses raw (unweighted) totalTokens.
+- costs/costUnit: currency-agnostic.
+- streamChunk: thin wrapper over stream(), not new infrastructure.
+- Search 1.1+ options: forward-compatible types, graceful skip on older servers.
+- Plugins: AI endpoints under `/flows/:id/usage`, `/flows/:id/budget`, `/jobs/:id/stream`.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -195,7 +195,7 @@ const jobs = await dag(
 **Implementation notes:**
 
 - DAG validation runs automatically - cycles are detected and rejected with `CycleError`.
-- Jobs are submitted level by level in topological order; all jobs within a level are pipelined in a single batch, so submission cost is O(levels) round trips rather than O(N).
+- Jobs are submitted level by level in reverse-topological order (dependents first, prerequisites last) so each node's BullMQ-parents already exist by the time we wire it; all jobs within a level are pipelined in a single batch, so submission cost is O(levels) round trips rather than O(N).
 - If any parent fails or is dead-lettered, dependent jobs remain blocked indefinitely (manual cleanup required).
 - Cross-queue dependencies are supported - each node can specify its own `queueName`.
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -113,12 +113,11 @@ const flow = new FlowProducer({ connection });
 
 // Submit a DAG using the helper function
 const jobs = await dag(
-  'queueName',
   [
-    { name: 'A', data: { step: 1 } },
-    { name: 'B', data: { step: 2 }, deps: ['A'] },
-    { name: 'C', data: { step: 3 }, deps: ['A'] },
-    { name: 'D', data: { step: 4 }, deps: ['B', 'C'] },
+    { name: 'A', queueName: 'tasks', data: { step: 1 } },
+    { name: 'B', queueName: 'tasks', data: { step: 2 }, deps: ['A'] },
+    { name: 'C', queueName: 'tasks', data: { step: 3 }, deps: ['A'] },
+    { name: 'D', queueName: 'tasks', data: { step: 4 }, deps: ['B', 'C'] },
   ],
   connection,
 );
@@ -150,13 +149,13 @@ import { dag } from 'glide-mq';
 
 // Three parallel data fetches, then one merge job
 const jobs = await dag(
-  'data',
   [
-    { name: 'fetch-sales', data: { source: 'sales-db' } },
-    { name: 'fetch-inventory', data: { source: 'warehouse-db' } },
-    { name: 'fetch-returns', data: { source: 'returns-db' } },
+    { name: 'fetch-sales', queueName: 'data', data: { source: 'sales-db' } },
+    { name: 'fetch-inventory', queueName: 'data', data: { source: 'warehouse-db' } },
+    { name: 'fetch-returns', queueName: 'data', data: { source: 'returns-db' } },
     {
       name: 'merge-reports',
+      queueName: 'data',
       data: { reportId: 'Q1-2025' },
       deps: ['fetch-sales', 'fetch-inventory', 'fetch-returns'],
     },
@@ -181,12 +180,11 @@ import { dag } from 'glide-mq';
 //       D
 
 const jobs = await dag(
-  'tasks',
   [
-    { name: 'A', data: { step: 'root' } },
-    { name: 'B', data: { step: 'left' }, deps: ['A'] },
-    { name: 'C', data: { step: 'right' }, deps: ['A'] },
-    { name: 'D', data: { step: 'converge' }, deps: ['B', 'C'] },
+    { name: 'A', queueName: 'tasks', data: { step: 'root' } },
+    { name: 'B', queueName: 'tasks', data: { step: 'left' }, deps: ['A'] },
+    { name: 'C', queueName: 'tasks', data: { step: 'right' }, deps: ['A'] },
+    { name: 'D', queueName: 'tasks', data: { step: 'converge' }, deps: ['B', 'C'] },
   ],
   connection,
 );
@@ -197,7 +195,7 @@ const jobs = await dag(
 **Implementation notes:**
 
 - DAG validation runs automatically - cycles are detected and rejected with `CycleError`.
-- Jobs are submitted in topological order (leaves first, roots last).
+- Jobs are submitted level by level in topological order; all jobs within a level are pipelined in a single batch, so submission cost is O(levels) round trips rather than O(N).
 - If any parent fails or is dead-lettered, dependent jobs remain blocked indefinitely (manual cleanup required).
 - Cross-queue dependencies are supported - each node can specify its own `queueName`.
 


### PR DESCRIPTION
## Summary

- Three logically separate docs fixes from `/sync-docs apply`:
  1. `docs/WORKFLOWS.md` - fix `dag()` helper signature in 3 examples (used `dag(queueName, nodes, connection)`; actual is `dag(nodes, connection, prefix?)` with `queueName` per-node) and update the topological-order note to reflect #246's level-pipelining.
  2. `CHANGELOG.md` - add `[Unreleased]` section covering the 21 PRs that landed after the `[0.15.2]` release entry (DAG correctness, reclaim semantics, list-active hardening, broadcast retry isolation, UNLINK perf, etc.).
  3. `HANDOVER.md` - refresh from 0.14.0 (2026-03-28) to current state; documents the 0.15.x series and the corrected DAG deps direction.

## Test plan

- [x] `npm run build` clean
- [x] No code changes; docs-only PR
- [ ] Spot-read `docs/WORKFLOWS.md` `dag()` examples render in markdown preview correctly