### PR TITLE
chore: release 0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Unreleased]
+## [0.15.3] - 2026-05-18
 
 ### Fixed
 
@@ -59,6 +59,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Security / dependencies
 
 - **CVE fixes via `npm audit fix`** (#240): resolved CVEs in transitive deps `langsmith` and `protobufjs`.
+
+### Examples
+
+- Added `ai-research-dag` to the [examples catalog](https://github.com/avifenesh/glidemq-examples/tree/main/examples/ai-research-dag) - a 6-stage AI research pipeline (`plan -> 3x search -> synthesize -> review`) that uses `flow.addDAG()`, `job.reportUsage()`, and per-stage cost aggregation. Mocked LLM calls, no API keys required.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glide-mq",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glide-mq",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@glidemq/speedkey": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glide-mq",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "High-performance message queue for Node.js with AI-native primitives - built on Valkey/Redis with Rust NAPI bindings",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Cuts glide-mq 0.15.3. Highlights (full list in [CHANGELOG.md](CHANGELOG.md)):

- **DAG correctness pass** ([#244](https://github.com/avifenesh/glide-mq/pull/244), [#245](https://github.com/avifenesh/glide-mq/pull/245), [#246](https://github.com/avifenesh/glide-mq/pull/246)) - `DAGNode.deps` now matches the documented "must complete before me" semantic; proxy tree rendering for DAG flows fixed; `addDAG` is pipelined by topological level for ~4-50x faster submission. Fixed a race in multi-dependent leaf wiring (worker's snapshot of `parentIds` could be stale). `LIBRARY_VERSION` 88 -> 93.
- **Stalled-job redispatch** ([#242](https://github.com/avifenesh/glide-mq/pull/242)) - under-threshold stalled jobs are redispatched back to stream/list so a healthy worker picks them up. Aligns with the at-least-once redelivery promise in DURABILITY.md.
- **Perf: UNLINK for large deletes** ([#243](https://github.com/avifenesh/glide-mq/pull/243)) - obliterate / retention / drain stop blocking on MB-sized job hashes.
- **+15 smaller fixes** - addFlow ID collisions, broadcast retry isolation, list-active leaks, proxy strict opts, heartbeat-before-token-wait, scheduler stall recovery dedup, etc.
- **New example** - [`ai-research-dag`](https://github.com/avifenesh/glidemq-examples/pull/50) showcases the new DAG pipelining with a 6-stage AI research workflow.

## Test plan

- [x] `npm run build` clean
- [x] Local test suite green throughout the cycle (188 tests across dag/stress/flow/edge-flow/deep-workflows/integration/api-completeness)
- [x] `ai-research-dag` example runs end-to-end against local Valkey (1.2s wall clock)

## Release notes

After merge, tag `v0.15.3` to trigger the npm publish workflow.

After publish, bump `examples/ai-research-dag/package.json` and the dependent example dag-workflows to `^0.15.3`.