### PR TITLE
[codex] Update Valkey CI images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
     services:
       valkey:
-        image: valkey/valkey-bundle:9.1.0-rc1
+        image: valkey/valkey:9.1.0
         options: >-
           --health-cmd "valkey-cli ping"
           --health-interval 10s
@@ -113,7 +113,7 @@ jobs:
 
       - name: Install Valkey binaries for cluster
         run: |
-          id=$(docker create valkey/valkey:8.0)
+          id=$(docker create valkey/valkey:9.1.0)
           sudo docker cp "$id:/usr/local/bin/valkey-server" /usr/local/bin/valkey-server
           sudo docker cp "$id:/usr/local/bin/valkey-cli" /usr/local/bin/valkey-cli
           docker rm "$id"
@@ -145,7 +145,7 @@ jobs:
     timeout-minutes: 15
     services:
       valkey:
-        image: valkey/valkey-bundle:9.1.0-rc1
+        image: valkey/valkey-bundle:9.1.0
         options: >-
           --health-cmd "valkey-cli ping"
           --health-interval 10s

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -29,7 +29,7 @@ See CHANGELOG.md `[Unreleased]` for the full list. Highlights:
 
 - **0.15.3 release**: ~21 PRs sit in `[Unreleased]`. Worth a release when the next user-visible change lands or when the DAG fixes need to ship.
 - **Bun/Deno NAPI compatibility testing**: still pending from 0.14.0 handover.
-- **valkey-bundle stable**: cluster CI is on `valkey-bundle:9.1.0-rc1`; switch to GA when 9.1.0 releases.
+- **Valkey CI images**: CI is off release candidates. Standalone and cluster coverage use stable `valkey/valkey:9.1.0`; search coverage uses stable `valkey/valkey-bundle:9.1.0`, which carries Valkey Search 1.2.x and keeps the Search 1.1+ option tests active.
 
 ## API Design Decisions (locked)
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   valkey:
-    image: valkey/valkey-bundle:9.1.0-rc1
+    image: valkey/valkey-bundle:9.1.0
     ports:
       - '6379:6379'
     command: valkey-server --save "" --appendonly no --maxmemory-policy noeviction
@@ -11,7 +11,7 @@ services:
       retries: 5
 
   valkey-cluster:
-    image: valkey/valkey-bundle:9.1.0-rc1
+    image: valkey/valkey-bundle:9.1.0
     ports:
       - '7000-7005:7000-7005'
       - '17000-17005:17000-17005'


### PR DESCRIPTION
## What changed

- Move CI standalone integration service from `valkey/valkey-bundle:9.1.0-rc1` to stable core `valkey/valkey:9.1.0`.
- Move CI cluster binary install from `valkey/valkey:8.0` to stable core `valkey/valkey:9.1.0`.
- Move CI search service and local compose services from `valkey/valkey-bundle:9.1.0-rc1` to stable `valkey/valkey-bundle:9.1.0`.
- Update `HANDOVER.md` with the current Valkey compatibility note.

## Why

Valkey `9.1.0` is now GA for both the core and bundle images, so CI no longer needs the old RC bundle or the `8.0` cluster binary source. The bundle image carries Valkey Search 1.2.x, so the Search 1.1+ option tests should stay active in CI.

## Validation

- `npm run build`
- `npx prettier --check .github/workflows/ci.yml HANDOVER.md`
- `/deslop` scoped to `.github/workflows/ci.yml`, `compose.yaml`, `HANDOVER.md` - 0 findings
- Docker manifests: `valkey/valkey:9.1.0`, `valkey/valkey-bundle:9.1.0`
- Booted `valkey/valkey:9.1.0` locally - GA reported
- Booted `valkey/valkey-bundle:9.1.0` locally - Search module loaded as version `66048`
- Recreated local `valkey-cluster` compose service on `valkey/valkey-bundle:9.1.0`
- `npx vitest run tests/search.test.ts`
- `npx vitest run tests/search-index.test.ts`

Local note: the system Valkey service owns `6379`, so I did not stop it to bind the bundle there. Search module availability was validated via an alternate local port and the compose cluster container.