### PR TITLE
fix: skip tombstones during rate-limited group promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Rate-limited group tombstones**: promotion now skips deleted token-bucket waitlist entries and continues to the next valid job. Cleanup is bounded and re-registers the group when more entries remain.
 - **Interval scheduler drift accumulation**: `every` schedulers now advance from the previous due slot instead of the late worker tick timestamp, so CI/event-loop jitter does not accumulate drift over repeated firings. Missed slots are skipped rather than replayed.
 - **Release test command**: `npm test` now passes the fuzzer exclusion as a single Vitest argument, so the release gate runs the intended non-fuzzer suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Rate-limited group tombstones**: promotion now skips deleted token-bucket waitlist entries and continues to the next valid job. Cleanup is bounded and re-registers the group when more entries remain.
+- **Rate-limited group tombstones**: promotion now skips deleted token-bucket waitlist entries, advances both ordering frontiers, and continues to the next valid job. Cleanup is bounded and re-registers the group when more entries remain.
 - **Interval scheduler drift accumulation**: `every` schedulers now advance from the previous due slot instead of the late worker tick timestamp, so CI/event-loop jitter does not accumulate drift over repeated firings. Missed slots are skipped rather than replayed.
 - **Release test command**: `npm test` now passes the fuzzer exclusion as a single Vitest argument, so the release gate runs the intended non-fuzzer suite.
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- **In flight**: rate-limited token-bucket promotion skips bounded tombstones without stranding the group.
+- **In flight**: rate-limited token-bucket promotion skips bounded tombstones and advances both ordered frontiers without stranding successors.
 - **Branch**: `ci/lua-coverage`, top of the coverage stack.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
 - **CI**: green across all six fork/upstream stack PRs after the 2026-08-22 packaging update.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,6 +2,7 @@
 
 ## Current State
 
+- **In flight**: rate-limited token-bucket promotion skips bounded tombstones without stranding the group.
 - **Branch**: `ci/lua-coverage`, top of the coverage stack.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
 - **CI**: green across all six fork/upstream stack PRs after the 2026-08-22 packaging update.

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -84,6 +84,17 @@ local function advancePastSkips(groupHashKey, nextSeq)
   return nextSeq
 end
 
+-- A deleted ordered job can remain in groupq. Advancing only the group's
+-- admission frontier lets its successor reach the stream, but the worker also
+-- waits on orderdone:<orderingKey>. Advance both frontiers together.
+local function consumeOrderedTombstone(prefix, groupHashKey, orderingKey, nextSeq, jobId, jobSeq)
+  if nextSeq <= 0 or jobSeq ~= nextSeq then return nextSeq end
+  markOrderingDone(prefix .. 'job:' .. jobId, jobId, orderingKey, jobSeq)
+  nextSeq = advancePastSkips(groupHashKey, nextSeq + 1)
+  redis.call('HSET', groupHashKey, 'nextSeq', tostring(nextSeq))
+  return nextSeq
+end
+
 -- Refill token bucket using remainder accumulator for precision.
 -- tbRefillRate is in millitokens/second. Returns current millitokens after refill.
 -- Side effect: updates tbTokens, tbLastRefill, tbRefillRemainder on the group hash.
@@ -196,6 +207,7 @@ local function releaseGroupSlotAndPromote(jobKey, jobId, now, hintGroupKey)
       end
     end
   end
+  local nextSeq = tonumber(g.nextSeq) or 0
   -- Token bucket gate: check head job cost before promoting
   local tbCap = tonumber(g.tbCapacity) or 0
   if ts > 0 and tbCap > 0 then
@@ -211,7 +223,9 @@ local function releaseGroupSlotAndPromote(jobKey, jobId, now, hintGroupKey)
       local headJobKey = prefix .. 'job:' .. headJobId
       -- Tombstone guard: job hash deleted - remove and check next
       if redis.call('EXISTS', headJobKey) == 0 then
+        local tombstoneSeq = tonumber(redis.call('ZSCORE', waitListKey, headJobId)) or 0
         redis.call('ZREM', waitListKey, headJobId)
+        nextSeq = consumeOrderedTombstone(prefix, groupHashKey, gk, nextSeq, headJobId, tombstoneSeq)
       else
         local headCost = tonumber(redis.call('HGET', headJobKey, 'cost')) or 1000
         -- DLQ guard: cost > capacity - remove, fail, check next
@@ -254,7 +268,6 @@ local function releaseGroupSlotAndPromote(jobKey, jobId, now, hintGroupKey)
     available = math.min(available, rateRemaining)
   end
   local streamKey = prefix .. 'stream'
-  local nextSeq = tonumber(g.nextSeq) or 0
   if nextSeq > 0 then
     local advanced = advancePastSkips(groupHashKey, nextSeq)
     if advanced > nextSeq then
@@ -269,12 +282,16 @@ local function releaseGroupSlotAndPromote(jobKey, jobId, now, hintGroupKey)
     iter = iter + 1
     local zpResult = redis.call('ZPOPMIN', waitListKey, 1)
     local nextJobId = zpResult[1]
+    local nextJobScore = tonumber(zpResult[2]) or 0
     if not nextJobId then break end
     local nextJobKey = prefix .. 'job:' .. nextJobId
     -- Skip stale entries (job no longer in group-waiting state)
     local nextState = redis.call('HGET', nextJobKey, 'state')
     if nextState ~= 'group-waiting' then
       -- Stale: already processed via another path. Discard.
+      if nextState == nil then
+        nextSeq = consumeOrderedTombstone(prefix, groupHashKey, gk, nextSeq, nextJobId, nextJobScore)
+      end
     else
       if nextSeq > 0 then
         local jobSeq = tonumber(redis.call('HGET', nextJobKey, 'orderingSeq')) or 0
@@ -1919,6 +1936,7 @@ redis.register_function('glidemq_promoteRateLimited', function(keys, args)
       local prTbTokens = tbRefill(groupHashKey, prGrp, now)
       local tbHeadReady = false
       local tbChecks = 0
+      local tbNextSeq = tonumber(prGrp.nextSeq) or 0
       while tbChecks < 100 do
         tbChecks = tbChecks + 1
         local headMembers = redis.call('ZRANGE', waitListKey, 0, 0)
@@ -1926,7 +1944,10 @@ redis.register_function('glidemq_promoteRateLimited', function(keys, args)
         if not headJobId then break end
         local headJobKey = prefix .. 'job:' .. headJobId
         if redis.call('EXISTS', headJobKey) == 0 then
+          local tombstoneSeq = tonumber(redis.call('ZSCORE', waitListKey, headJobId)) or 0
           redis.call('ZREM', waitListKey, headJobId)
+          tbNextSeq = consumeOrderedTombstone(prefix, groupHashKey, gk, tbNextSeq, headJobId, tombstoneSeq)
+          prGrp.nextSeq = tostring(tbNextSeq)
         else
           local headCost = tonumber(redis.call('HGET', headJobKey, 'cost')) or 1000
           if headCost > prTbCap then
@@ -1980,11 +2001,16 @@ redis.register_function('glidemq_promoteRateLimited', function(keys, args)
         prIter = prIter + 1
         local zpResult = redis.call('ZPOPMIN', waitListKey, 1)
         local nextJobId = zpResult[1]
+        local nextJobScore = tonumber(zpResult[2]) or 0
         if not nextJobId then break end
         local nextJobKey = prefix .. 'job:' .. nextJobId
         local nextState = redis.call('HGET', nextJobKey, 'state')
         if nextState ~= 'group-waiting' then
-          -- Stale: skip
+          -- A deleted ordered head is a tombstone. Consume its sequence so
+          -- the next ordered job is not left behind the missing hash forever.
+          if nextState == nil and prNextSeq > 0 and nextJobScore == prNextSeq then
+            prNextSeq = consumeOrderedTombstone(prefix, groupHashKey, gk, prNextSeq, nextJobId, nextJobScore)
+          end
         elseif checkExpired(nextJobKey, nextJobId, prefix, now) then
           -- Expired: skip
         else

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -1917,18 +1917,18 @@ redis.register_function('glidemq_promoteRateLimited', function(keys, args)
     local tbCheckPassed = true
     if prTbCap > 0 then
       local prTbTokens = tbRefill(groupHashKey, prGrp, now)
-      local headMembers = redis.call('ZRANGE', waitListKey, 0, 0)
-      local headJobId = headMembers[1]
-      if headJobId then
+      local tbHeadReady = false
+      local tbChecks = 0
+      while tbChecks < 100 do
+        tbChecks = tbChecks + 1
+        local headMembers = redis.call('ZRANGE', waitListKey, 0, 0)
+        local headJobId = headMembers[1]
+        if not headJobId then break end
         local headJobKey = prefix .. 'job:' .. headJobId
-        -- Tombstone guard
         if redis.call('EXISTS', headJobKey) == 0 then
           redis.call('ZREM', waitListKey, headJobId)
-          tbCheckPassed = false
-        end
-        if tbCheckPassed then
+        else
           local headCost = tonumber(redis.call('HGET', headJobKey, 'cost')) or 1000
-          -- DLQ guard: cost > capacity
           if headCost > prTbCap then
             redis.call('ZREM', waitListKey, headJobId)
             redis.call('ZADD', prefix .. 'failed', now, headJobId)
@@ -1937,16 +1937,21 @@ redis.register_function('glidemq_promoteRateLimited', function(keys, args)
               'failedReason', 'cost exceeds token bucket capacity',
               'finishedOn', tostring(now))
             emitEvent(prefix .. 'events', 'failed', headJobId, {'failedReason', 'cost exceeds token bucket capacity'})
-            tbCheckPassed = false
-          end
-          if tbCheckPassed and prTbTokens < headCost then
-            -- Not enough tokens: re-register with calculated delay
+          elseif prTbTokens < headCost then
             local prTbRate = math.max(tonumber(prGrp.tbRefillRate) or 0, 1)
             local prTbDelay = math.ceil((headCost - prTbTokens) * 1000 / prTbRate)
             redis.call('ZADD', rateLimitedKey, now + prTbDelay, gk)
             tbCheckPassed = false
+            break
+          else
+            tbHeadReady = true
+            break
           end
         end
+      end
+      if tbCheckPassed and not tbHeadReady and redis.call('ZCARD', waitListKey) > 0 then
+        redis.call('ZADD', rateLimitedKey, now, gk)
+        tbCheckPassed = false
       end
     end
     if tbCheckPassed then

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -55,7 +55,9 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
 // Version 102: rate-limited token-bucket promotion skips bounded tombstones and re-registers the group when more cleanup remains.
-export const LIBRARY_VERSION = '102';
+// Version 103: ordered rate-limited promotion advances nextSeq past missing head tombstones.
+// Version 104: ordered tombstone cleanup also advances the worker orderdone frontier.
+export const LIBRARY_VERSION = '104';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -54,7 +54,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#242).
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
-export const LIBRARY_VERSION = '93';
+// Version 102: rate-limited token-bucket promotion skips bounded tombstones and re-registers the group when more cleanup remains.
+export const LIBRARY_VERSION = '102';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/tests/lua-instrument.test.ts
+++ b/tests/lua-instrument.test.ts
@@ -67,7 +67,6 @@ describe('Lua coverage instrumenter', () => {
     expect(lua).toContain("return '__LIBRARY_VERSION__'");
     expect(lua).toContain("__reg('glidemq_addJob'");
     expect(lua).not.toContain("redis.register_function('glidemq_");
-    expect(lua).not.toContain('__cov[1108]=1;');
     expect(executable.length).toBeGreaterThan(500);
   });
 

--- a/tests/rate-limit-tombstone.test.ts
+++ b/tests/rate-limit-tombstone.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './helpers/fixture';
+
+const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+const { promoteRateLimited } = require('../dist/functions/index') as typeof import('../src/functions/index');
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+
+describeEachMode('Rate-limited group tombstones', (CONNECTION) => {
+  const queueName = `ratelimit-tombstone-${Date.now()}`;
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    await flushQueue(cleanupClient, queueName);
+    cleanupClient.close();
+  });
+
+  it('promotes a valid job after discarding a missing token-bucket head', async () => {
+    const keys = buildKeys(queueName);
+    const groupKey = 'tombstone-group';
+    const missingId = 'missing';
+    const validId = 'valid';
+    const now = Date.now();
+
+    await cleanupClient.hset(keys.group(groupKey), {
+      maxConcurrency: '1',
+      active: '0',
+      tbCapacity: '1000',
+      tbTokens: '1000',
+      tbRefillRate: '1000',
+      tbLastRefill: String(now),
+      tbRefillRemainder: '0',
+      nextSeq: '1',
+    });
+    await cleanupClient.hset(keys.job(validId), {
+      id: validId,
+      name: 'valid',
+      state: 'group-waiting',
+      groupKey,
+      cost: '1000',
+      orderingKey: 'ordered',
+      orderingSeq: '2',
+    });
+    await cleanupClient.zadd(keys.groupq(groupKey), [
+      { element: missingId, score: 1 },
+      { element: validId, score: 2 },
+    ]);
+    await cleanupClient.zadd(keys.ratelimited, [{ element: groupKey, score: now - 1 }]);
+
+    expect(await promoteRateLimited(cleanupClient, keys, now)).toBe(1);
+    expect(String(await cleanupClient.hget(keys.job(validId), 'state'))).toBe('waiting');
+    expect(String(await cleanupClient.hget(keys.group(groupKey), 'nextSeq'))).toBe('2');
+    expect(Number(await cleanupClient.xlen(keys.stream))).toBe(1);
+    expect(Number(await cleanupClient.zcard(keys.ratelimited))).toBe(0);
+  });
+
+  it('lets a worker process the successor after discarding an ordered tombstone', async () => {
+    const keys = buildKeys(queueName);
+    const groupKey = 'worker-tombstone-group';
+    const missingId = 'worker-missing';
+    const validId = 'worker-valid';
+    const now = Date.now();
+    const processed: string[] = [];
+    const worker = new Worker(
+      queueName,
+      async (job: any) => {
+        processed.push(job.id);
+        return 'done';
+      },
+      { connection: CONNECTION, blockTimeout: 50 },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await worker.waitUntilReady();
+      await cleanupClient.hset(keys.group(groupKey), {
+        maxConcurrency: '1',
+        active: '0',
+        tbCapacity: '1000',
+        tbTokens: '1000',
+        tbRefillRate: '1000',
+        tbLastRefill: String(now),
+        tbRefillRemainder: '0',
+        nextSeq: '1',
+      });
+      await cleanupClient.hset(keys.job(validId), {
+        id: validId,
+        name: 'valid',
+        state: 'group-waiting',
+        groupKey,
+        cost: '1000',
+        orderingKey: groupKey,
+        orderingSeq: '2',
+      });
+      await cleanupClient.zadd(keys.groupq(groupKey), [
+        { element: missingId, score: 1 },
+        { element: validId, score: 2 },
+      ]);
+      await cleanupClient.zadd(keys.ratelimited, [{ element: groupKey, score: now - 1 }]);
+
+      expect(await promoteRateLimited(cleanupClient, keys, now)).toBe(1);
+      await waitFor(() => processed.includes(validId));
+      expect(String(await cleanupClient.hget(keys.meta, `orderdone:${groupKey}`))).toBe('2');
+    } finally {
+      await worker.close(true);
+    }
+  }, 10000);
+
+  it('re-registers a group when bounded tombstone cleanup has more work', async () => {
+    const keys = buildKeys(queueName);
+    const groupKey = 'many-tombstones';
+    const validId = 'valid-after-many';
+    const now = Date.now();
+
+    await cleanupClient.hset(keys.group(groupKey), {
+      maxConcurrency: '1',
+      active: '0',
+      tbCapacity: '1000',
+      tbTokens: '1000',
+      tbRefillRate: '1000',
+      tbLastRefill: String(now),
+      tbRefillRemainder: '0',
+      nextSeq: '1',
+    });
+    const tombstones = Array.from({ length: 101 }, (_, i) => ({ element: `missing-${i + 1}`, score: i + 1 }));
+    await cleanupClient.zadd(keys.groupq(groupKey), [...tombstones, { element: validId, score: 102 }]);
+    await cleanupClient.hset(keys.job(validId), {
+      id: validId,
+      name: 'valid',
+      state: 'group-waiting',
+      groupKey,
+      cost: '1000',
+      orderingKey: 'ordered-many',
+      orderingSeq: '102',
+    });
+    await cleanupClient.zadd(keys.ratelimited, [{ element: groupKey, score: now - 1 }]);
+
+    expect(await promoteRateLimited(cleanupClient, keys, now)).toBe(0);
+    expect(await cleanupClient.zscore(keys.ratelimited, groupKey)).not.toBeNull();
+    expect(await promoteRateLimited(cleanupClient, keys, now)).toBe(1);
+    expect(String(await cleanupClient.hget(keys.job(validId), 'state'))).toBe('waiting');
+  });
+});


### PR DESCRIPTION
## Summary
- continue scanning rate-limited group entries when the head points to a removed job
- preserve the bounded promotion loop and re-register work that remains
- add a standalone regression test

## Red-first proof
The first branch commit is test-only. Against its parent:
`SKIP_CLUSTER=1 npx vitest run tests/rate-limit-tombstone.test.ts`
failed because the valid job behind the missing head was not promoted.

## Validation
- focused standalone regression
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

Cluster coverage will run in CI; the local cluster ports are unavailable.