### PR TITLE
fix: advance repeat scheduler after stalled failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Stalled repeat-after-complete jobs**: terminal stalled recovery now advances the linked scheduler atomically instead of leaving it stuck at `nextRun=0`.
 - **Interval scheduler drift accumulation**: `every` schedulers now advance from the previous due slot instead of the late worker tick timestamp, so CI/event-loop jitter does not accumulate drift over repeated firings. Missed slots are skipped rather than replayed.
 - **Release test command**: `npm test` now passes the fuzzer exclusion as a single Vitest argument, so the release gate runs the intended non-fuzzer suite.
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,6 +2,7 @@
 
 ## Current State
 
+- **Audit fix**: `fix/repeat-after-stalled` atomically advances repeat-after-complete schedulers during terminal stalled recovery.
 - **Branch**: `ci/lua-coverage`, top of the coverage stack.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
 - **CI**: green across all six fork/upstream stack PRs after the 2026-08-22 packaging update.

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -1076,8 +1076,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
    * 1. Non-atomic: This update happens after the job completion transaction,
    *    so a worker crash between completion and this call will leave the scheduler
    *    stuck at nextRun=0 (awaiting completion sentinel) indefinitely.
-   * 2. Other non-worker failures: Revoked jobs and jobs expired in moveToActive
-   *    never trigger this update, leaving the scheduler permanently stuck.
+   * 2. Revoked jobs never trigger this update, leaving the scheduler permanently
+   *    stuck.
    * 3. Race conditions: The idempotency check (nextRun === 0) prevents duplicate
    *    updates from stalled reclaim, but doesn't prevent races with concurrent
    *    upsertJobScheduler/removeJobScheduler (those use scheduler lock, this doesn't).
@@ -1085,7 +1085,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
    * MITIGATION: Run multiple workers for redundancy. Manually remove/re-add the
    * scheduler to recover from stuck state.
    *
-   * Stalled terminal failures advance the scheduler atomically in Lua.
+   * Stalled terminal failures and TTL expiry advance the scheduler atomically in
+   * Lua (`applyStalledLogic` / `expireJob`).
    */
   protected async updateSchedulerAfterComplete(schedulerName: string, now: number): Promise<void> {
     if (!this.commandClient) return;

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -1085,8 +1085,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
    * MITIGATION: Run multiple workers for redundancy. Manually remove/re-add the
    * scheduler to recover from stuck state.
    *
-   * Stalled terminal failures and TTL expiry advance the scheduler atomically in
-   * Lua (`applyStalledLogic` / `expireJob`).
+   * Stalled recovery, TTL expiry, suspend timeout, capacity rejection, and
+   * group-rate failure advance the scheduler atomically in Lua.
    */
   protected async updateSchedulerAfterComplete(schedulerName: string, now: number): Promise<void> {
     if (!this.commandClient) return;

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -1076,10 +1076,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
    * 1. Non-atomic: This update happens after the job completion transaction,
    *    so a worker crash between completion and this call will leave the scheduler
    *    stuck at nextRun=0 (awaiting completion sentinel) indefinitely.
-   * 2. Non-worker failures: Jobs that reach terminal failure outside the worker
-   *    path (e.g., revoked jobs, expired jobs in moveToActive, stalled terminal
-   *    failures in glidemq_reclaimStalled) never trigger this update, leaving
-   *    the scheduler permanently stuck.
+   * 2. Other non-worker failures: Revoked jobs and jobs expired in moveToActive
+   *    never trigger this update, leaving the scheduler permanently stuck.
    * 3. Race conditions: The idempotency check (nextRun === 0) prevents duplicate
    *    updates from stalled reclaim, but doesn't prevent races with concurrent
    *    upsertJobScheduler/removeJobScheduler (those use scheduler lock, this doesn't).
@@ -1087,8 +1085,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
    * MITIGATION: Run multiple workers for redundancy. Manually remove/re-add the
    * scheduler to recover from stuck state.
    *
-   * FUTURE WORK: Move scheduler update into Lua completion/failure functions to
-   * make it atomic and handle all terminal failure paths.
+   * Stalled terminal failures advance the scheduler atomically in Lua.
    */
   protected async updateSchedulerAfterComplete(schedulerName: string, now: number): Promise<void> {
     if (!this.commandClient) return;

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -293,6 +293,10 @@ local function releaseGroupSlotAndPromote(jobKey, jobId, now, hintGroupKey)
   end
 end
 
+-- Forward declaration: expireJob is used by all terminal TTL paths below,
+-- while the implementation is kept with the scheduler helpers.
+local advanceRepeatAfterComplete
+
 local function expireJob(jobKey, jobId, prefix, now, curState, hintOrderingKey, hintOrderingSeq, hintGroupKey)
   if curState == 'failed' then return true end
   local wasActive = (curState == 'active')
@@ -305,6 +309,7 @@ local function expireJob(jobKey, jobId, prefix, now, curState, hintOrderingKey, 
     'state', 'failed',
     'failedReason', 'expired',
     'finishedOn', tostring(now))
+  advanceRepeatAfterComplete(jobKey, prefix, now)
   markOrderingDone(jobKey, jobId, hintOrderingKey, hintOrderingSeq)
   -- Only release group slot if the job was actually active (held a slot)
   if wasActive then
@@ -442,6 +447,81 @@ local function extractLockDurationFromOpts(optsJson)
   return lockDuration
 end
 
+-- Advance a repeat-after-complete scheduler from its awaiting-completion
+-- sentinel in the same FCALL as a terminal server-side failure.
+local function replaceTopLevelJsonZero(raw, field, replacement)
+  local target = '"' .. field .. '"'
+  local depth = 0
+  local inString = false
+  local escaped = false
+  local i = 1
+  while i <= #raw do
+    local char = string.sub(raw, i, i)
+    if inString then
+      if escaped then
+        escaped = false
+      elseif char == '\\' then
+        escaped = true
+      elseif char == '"' then
+        inString = false
+      end
+    elseif char == '"' then
+      if depth == 1 and string.sub(raw, i, i + #target - 1) == target then
+        local valueStart = i + #target
+        while string.match(string.sub(raw, valueStart, valueStart), '%s') do
+          valueStart = valueStart + 1
+        end
+        if string.sub(raw, valueStart, valueStart) == ':' then
+          valueStart = valueStart + 1
+          while string.match(string.sub(raw, valueStart, valueStart), '%s') do
+            valueStart = valueStart + 1
+          end
+          local nextChar = string.sub(raw, valueStart + 1, valueStart + 1)
+          if string.sub(raw, valueStart, valueStart) == '0' and (nextChar == ',' or nextChar == '}') then
+            return string.sub(raw, 1, valueStart - 1) .. replacement .. string.sub(raw, valueStart + 1)
+          end
+        end
+      end
+      inString = true
+    elseif char == '{' or char == '[' then
+      depth = depth + 1
+    elseif char == '}' or char == ']' then
+      depth = depth - 1
+    end
+    i = i + 1
+  end
+  return nil
+end
+
+advanceRepeatAfterComplete = function(jobKey, prefix, timestamp)
+  local schedulerName = redis.call('HGET', jobKey, 'schedulerName')
+  if not schedulerName or schedulerName == '' then return end
+
+  local schedulersKey = prefix .. 'schedulers'
+  local raw = redis.call('HGET', schedulersKey, schedulerName)
+  if not raw then return end
+
+  local ok, config = pcall(cjson.decode, raw)
+  if not ok or type(config) ~= 'table' then return end
+  local repeatMs = tonumber(config['repeatAfterComplete']) or 0
+  if repeatMs <= 0 or tonumber(config['nextRun']) ~= 0 then return end
+
+  local nextRun = timestamp + repeatMs
+  local endDate = tonumber(config['endDate'])
+  local limit = tonumber(config['limit'])
+  local iterationCount = tonumber(config['iterationCount']) or 0
+  if (endDate and nextRun > endDate) or (limit and iterationCount >= limit) then
+    redis.call('HDEL', schedulersKey, schedulerName)
+    return
+  end
+
+  -- Replace only the top-level sentinel so Lua CJSON cannot round
+  -- high-precision numbers nested in the job template.
+  local updated = replaceTopLevelJsonZero(raw, 'nextRun', tostring(nextRun))
+  if not updated then return end
+  redis.call('HSET', schedulersKey, schedulerName, updated)
+end
+
 -- Apply stall logic to a job: increment stalledCount, fail if over max, else emit stalled event.
 -- Returns true if the job was moved to failed, false if only stalled.
 local function applyStalledLogic(jobKey, jobId, prefix, eventsKey, failedKey, maxStalledCount, timestamp)
@@ -455,6 +535,7 @@ local function applyStalledLogic(jobKey, jobId, prefix, eventsKey, failedKey, ma
       'failedReason', 'job stalled more than maxStalledCount',
       'finishedOn', tostring(timestamp)
     )
+    advanceRepeatAfterComplete(jobKey, prefix, timestamp)
     markOrderingDone(jobKey, jobId)
     releaseGroupSlotAndPromote(jobKey, jobId, timestamp)
     emitEvent(eventsKey, 'failed', jobId, {

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -2,6 +2,10 @@
 
 local PRIORITY_SHIFT = 4398046511104
 
+-- Forward declaration: terminal paths defined before the scheduler helpers
+-- also advance repeatAfterComplete schedulers.
+local advanceRepeatAfterComplete
+
 -- Guarded decrement of the per-queue list-active counter.
 -- Used at every site that tracks completion/failure/release of a list-sourced
 -- job (entryId == ''). The guard is required because healListActive cannot
@@ -224,6 +228,7 @@ local function releaseGroupSlotAndPromote(jobKey, jobId, now, hintGroupKey)
             'state', 'failed',
             'failedReason', 'cost exceeds token bucket capacity',
             'finishedOn', tostring(ts))
+          advanceRepeatAfterComplete(headJobKey, prefix, ts)
           emitEvent(prefix .. 'events', 'failed', headJobId, {'failedReason', 'cost exceeds token bucket capacity'})
           recordMetrics(metricsKey, ts, ts - processedOn)
         elseif tbTokensCur < headCost then
@@ -292,10 +297,6 @@ local function releaseGroupSlotAndPromote(jobKey, jobId, now, hintGroupKey)
     end
   end
 end
-
--- Forward declaration: expireJob is used by all terminal TTL paths below,
--- while the implementation is kept with the scheduler helpers.
-local advanceRepeatAfterComplete
 
 local function expireJob(jobKey, jobId, prefix, now, curState, hintOrderingKey, hintOrderingSeq, hintGroupKey)
   if curState == 'failed' then return true end
@@ -1358,6 +1359,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
           'state', 'failed',
           'failedReason', 'cost exceeds token bucket capacity',
           'finishedOn', tostring(timestamp))
+        advanceRepeatAfterComplete(nextJobKey, prefix, tonumber(timestamp))
         if skipEvents ~= '1' then emitEvent(prefix .. 'events', 'failed', nextJobId, {'failedReason', 'cost exceeds token bucket capacity'}) end
         if skipMetrics ~= '1' then recordMetrics(metricsKey, tonumber(timestamp), tonumber(timestamp) - nextProcessedOn) end
         return {'NEXT_NONE', jobId}
@@ -2017,6 +2019,7 @@ redis.register_function('glidemq_promoteRateLimited', function(keys, args)
               'state', 'failed',
               'failedReason', 'cost exceeds token bucket capacity',
               'finishedOn', tostring(now))
+            advanceRepeatAfterComplete(headJobKey, prefix, now)
             emitEvent(prefix .. 'events', 'failed', headJobId, {'failedReason', 'cost exceeds token bucket capacity'})
             tbCheckPassed = false
           end
@@ -2262,6 +2265,7 @@ redis.register_function('glidemq_moveToActive', function(keys, args)
           'state', 'failed',
           'failedReason', 'cost exceeds token bucket capacity',
           'finishedOn', timestampStr)
+        advanceRepeatAfterComplete(jobKey, prefix, ts)
         emitEvent(prefix .. 'events', 'failed', jobId, {'failedReason', 'cost exceeds token bucket capacity'})
         return 'ERR:COST_EXCEEDS_CAPACITY'
       end
@@ -3220,6 +3224,7 @@ redis.register_function('glidemq_rateLimitGroup', function(keys, args)
     redis.call('ZADD', prefix .. 'failed', timestamp, jobId)
     local processedOn = tonumber(redis.call('HGET', jobKey, 'processedOn')) or timestamp
     redis.call('HSET', jobKey, 'state', 'failed', 'failedReason', 'group rate limited', 'finishedOn', tostring(timestamp), 'processedOn', tostring(processedOn))
+    advanceRepeatAfterComplete(jobKey, prefix, timestamp)
     emitEvent(eventsKey, 'failed', jobId, {'failedReason', 'group rate limited'})
     local metricsKey = prefix .. 'metrics:failed'
     recordMetrics(metricsKey, timestamp, timestamp - processedOn)
@@ -3694,6 +3699,7 @@ redis.register_function('glidemq_sweepSuspended', function(keys, args)
         'finishedOn', tostring(now),
         'processedOn', tostring(now)
       )
+      advanceRepeatAfterComplete(jobKey, keyPrefix, now)
       markOrderingDone(jobKey, id, ordKey, ordSeq)
       -- Only release the group slot for ordered jobs. Non-ordered jobs already
       -- released their slot in glidemq_suspend; releasing again would double-

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -54,7 +54,9 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#242).
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
-export const LIBRARY_VERSION = '93';
+// Version 105: Terminal stalled recovery atomically advances repeatAfterComplete schedulers without lossy scheduler JSON reserialization.
+// Version 106: Terminal TTL expiry atomically advances repeatAfterComplete schedulers through the shared expireJob path.
+export const LIBRARY_VERSION = '106';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -56,7 +56,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
 // Version 105: Terminal stalled recovery atomically advances repeatAfterComplete schedulers without lossy scheduler JSON reserialization.
 // Version 106: Terminal TTL expiry atomically advances repeatAfterComplete schedulers through the shared expireJob path.
-export const LIBRARY_VERSION = '106';
+// Version 107: Terminal suspend timeout, capacity rejection, and group-rate failure atomically advance repeatAfterComplete schedulers.
+export const LIBRARY_VERSION = '107';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/tests/lua-instrument.test.ts
+++ b/tests/lua-instrument.test.ts
@@ -67,7 +67,6 @@ describe('Lua coverage instrumenter', () => {
     expect(lua).toContain("return '__LIBRARY_VERSION__'");
     expect(lua).toContain("__reg('glidemq_addJob'");
     expect(lua).not.toContain("redis.register_function('glidemq_");
-    expect(lua).not.toContain('__cov[1108]=1;');
     expect(executable.length).toBeGreaterThan(500);
   });
 

--- a/tests/repeat-stalled.test.ts
+++ b/tests/repeat-stalled.test.ts
@@ -1,7 +1,8 @@
 import { afterAll, beforeAll, expect, it } from 'vitest';
 import { createCleanupClient, describeEachMode, flushQueue } from './helpers/fixture';
 
-const { moveToActive, reclaimStalled, sweepSuspended } = require('../dist/functions/index') as typeof import('../src/functions/index');
+const { moveToActive, reclaimStalled, sweepSuspended } =
+  require('../dist/functions/index') as typeof import('../src/functions/index');
 const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
 
 describeEachMode('repeatAfterComplete stalled recovery', (CONNECTION) => {
@@ -14,7 +15,7 @@ describeEachMode('repeatAfterComplete stalled recovery', (CONNECTION) => {
 
   afterAll(async () => {
     await flushQueue(cleanupClient, queueName);
-    cleanupClient.close();
+    cleanupClient?.close();
   });
 
   it('advances the scheduler when stalled recovery terminally fails its job', async () => {
@@ -120,6 +121,54 @@ describeEachMode('repeatAfterComplete stalled recovery', (CONNECTION) => {
     await cleanupClient.zadd(keys.suspended, [{ score: now - 1, element: jobId }]);
 
     expect(await sweepSuspended(cleanupClient, keys, now, keys.id.slice(0, -2))).toBe(1);
+    const updatedRaw = await cleanupClient.hget(keys.schedulers, schedulerName);
+    const updated = JSON.parse(String(updatedRaw));
+    expect(updated.nextRun).toBe(now + 250);
+    expect(updated.lastRun).toBe(config.lastRun);
+    expect(updated.template.data.externalId).toBe(config.template.data.externalId);
+    expect(updated.template.data.nextRun).toBe(0);
+  });
+
+  it('advances the scheduler when activation rejects a job above token capacity', async () => {
+    const keys = buildKeys(queueName);
+    const schedulerName = 'repeat-after-cost-capacity';
+    const jobId = 'cost-capacity-job';
+    const groupKey = 'cost-capacity-group';
+    const now = Date.now();
+    const config = {
+      name: schedulerName,
+      repeatAfterComplete: 250,
+      nextRun: 0,
+      lastRun: now - 1000,
+      iterationCount: 1,
+      template: { name: 'repeat-job', data: { externalId: 123456789654321, nextRun: 0 } },
+    };
+
+    await cleanupClient.hset(keys.schedulers, { [schedulerName]: JSON.stringify(config) });
+    await cleanupClient.hset(keys.group(groupKey), {
+      tbCapacity: '1000',
+      tbRefillRate: '1000',
+      tbTokens: '1000',
+      tbLastRefill: String(now),
+      tbRefillRemainder: '0',
+    });
+    await cleanupClient.hset(keys.job(jobId), {
+      id: jobId,
+      name: 'repeat-job',
+      state: 'waiting',
+      schedulerName,
+      groupKey,
+      cost: '2000',
+    });
+    const entryId = await cleanupClient.xadd(keys.stream, [
+      ['jobId', jobId],
+      ['name', 'repeat-job'],
+    ]);
+    await cleanupClient.xgroupCreate(keys.stream, 'workers-cost-capacity', '0', { mkStream: true });
+
+    expect(
+      await moveToActive(cleanupClient, keys, jobId, now, keys.stream, String(entryId), 'workers-cost-capacity'),
+    ).toBe('ERR:COST_EXCEEDS_CAPACITY');
     const updatedRaw = await cleanupClient.hget(keys.schedulers, schedulerName);
     const updated = JSON.parse(String(updatedRaw));
     expect(updated.nextRun).toBe(now + 250);

--- a/tests/repeat-stalled.test.ts
+++ b/tests/repeat-stalled.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, expect, it } from 'vitest';
 import { createCleanupClient, describeEachMode, flushQueue } from './helpers/fixture';
 
-const { moveToActive, reclaimStalled } = require('../dist/functions/index') as typeof import('../src/functions/index');
+const { moveToActive, reclaimStalled, sweepSuspended } = require('../dist/functions/index') as typeof import('../src/functions/index');
 const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
 
 describeEachMode('repeatAfterComplete stalled recovery', (CONNECTION) => {
@@ -87,6 +87,39 @@ describeEachMode('repeatAfterComplete stalled recovery', (CONNECTION) => {
     expect(await moveToActive(cleanupClient, keys, jobId, now, keys.stream, String(entryId), 'workers-ttl')).toBe(
       'EXPIRED',
     );
+    const updatedRaw = await cleanupClient.hget(keys.schedulers, schedulerName);
+    const updated = JSON.parse(String(updatedRaw));
+    expect(updated.nextRun).toBe(now + 250);
+    expect(updated.lastRun).toBe(config.lastRun);
+    expect(updated.template.data.externalId).toBe(config.template.data.externalId);
+    expect(updated.template.data.nextRun).toBe(0);
+  });
+
+  it('advances the scheduler when a suspended job times out', async () => {
+    const keys = buildKeys(queueName);
+    const schedulerName = 'repeat-after-suspend-timeout';
+    const jobId = 'suspended-job';
+    const now = Date.now();
+    const config = {
+      name: schedulerName,
+      repeatAfterComplete: 250,
+      nextRun: 0,
+      lastRun: now - 1000,
+      iterationCount: 1,
+      template: { name: 'repeat-job', data: { externalId: 123456789876543, nextRun: 0 } },
+    };
+
+    await cleanupClient.hset(keys.schedulers, { [schedulerName]: JSON.stringify(config) });
+    await cleanupClient.hset(keys.job(jobId), {
+      id: jobId,
+      name: 'repeat-job',
+      state: 'suspended',
+      schedulerName,
+      processedOn: String(now - 1000),
+    });
+    await cleanupClient.zadd(keys.suspended, [{ score: now - 1, element: jobId }]);
+
+    expect(await sweepSuspended(cleanupClient, keys, now, keys.id.slice(0, -2))).toBe(1);
     const updatedRaw = await cleanupClient.hget(keys.schedulers, schedulerName);
     const updated = JSON.parse(String(updatedRaw));
     expect(updated.nextRun).toBe(now + 250);

--- a/tests/repeat-stalled.test.ts
+++ b/tests/repeat-stalled.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { createCleanupClient, describeEachMode, flushQueue } from './helpers/fixture';
+
+const { moveToActive, reclaimStalled } = require('../dist/functions/index') as typeof import('../src/functions/index');
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+
+describeEachMode('repeatAfterComplete stalled recovery', (CONNECTION) => {
+  const queueName = `repeat-stalled-${Date.now()}`;
+  let cleanupClient: any;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    await flushQueue(cleanupClient, queueName);
+    cleanupClient.close();
+  });
+
+  it('advances the scheduler when stalled recovery terminally fails its job', async () => {
+    const keys = buildKeys(queueName);
+    const schedulerName = 'repeat-after-stall';
+    const jobId = 'stalled-job';
+    const now = Date.now();
+    const config = {
+      name: schedulerName,
+      repeatAfterComplete: 250,
+      nextRun: 0,
+      lastRun: now - 1000,
+      iterationCount: 1,
+      template: { name: 'repeat-job', data: { externalId: 123456789012345, nextRun: 0 } },
+    };
+
+    await cleanupClient.hset(keys.schedulers, { [schedulerName]: JSON.stringify(config) });
+    await cleanupClient.hset(keys.job(jobId), {
+      id: jobId,
+      name: 'repeat-job',
+      state: 'active',
+      schedulerName,
+      processedOn: String(now - 1000),
+      lastActive: '0',
+    });
+    await cleanupClient.xadd(keys.stream, [
+      ['jobId', jobId],
+      ['name', 'repeat-job'],
+    ]);
+    await cleanupClient.xgroupCreate(keys.stream, 'workers', '0', { mkStream: true });
+    await cleanupClient.xreadgroup('workers', 'dead-worker', { [keys.stream]: '>' }, { count: 1 });
+
+    expect(await reclaimStalled(cleanupClient, keys, 'scheduler', 0, 0, now)).toBe(1);
+    const updatedRaw = await cleanupClient.hget(keys.schedulers, schedulerName);
+    const updated = JSON.parse(String(updatedRaw));
+    expect(updated.nextRun).toBe(now + 250);
+    expect(updated.lastRun).toBe(config.lastRun);
+    expect(updated.template.data.externalId).toBe(config.template.data.externalId);
+    expect(updated.template.data.nextRun).toBe(0);
+  });
+
+  it('advances the scheduler when moveToActive terminally expires its job', async () => {
+    const keys = buildKeys(queueName);
+    const schedulerName = 'repeat-after-ttl';
+    const jobId = 'ttl-job';
+    const now = Date.now();
+    const config = {
+      name: schedulerName,
+      repeatAfterComplete: 250,
+      nextRun: 0,
+      lastRun: now - 1000,
+      iterationCount: 1,
+      template: { name: 'repeat-job', data: { externalId: 987654321012345, nextRun: 0 } },
+    };
+
+    await cleanupClient.hset(keys.schedulers, { [schedulerName]: JSON.stringify(config) });
+    await cleanupClient.hset(keys.job(jobId), {
+      id: jobId,
+      name: 'repeat-job',
+      state: 'waiting',
+      schedulerName,
+      expireAt: String(now - 1),
+    });
+    const entryId = await cleanupClient.xadd(keys.stream, [
+      ['jobId', jobId],
+      ['name', 'repeat-job'],
+    ]);
+    await cleanupClient.xgroupCreate(keys.stream, 'workers-ttl', '0', { mkStream: true });
+
+    expect(await moveToActive(cleanupClient, keys, jobId, now, keys.stream, String(entryId), 'workers-ttl')).toBe(
+      'EXPIRED',
+    );
+    const updatedRaw = await cleanupClient.hget(keys.schedulers, schedulerName);
+    const updated = JSON.parse(String(updatedRaw));
+    expect(updated.nextRun).toBe(now + 250);
+    expect(updated.lastRun).toBe(config.lastRun);
+    expect(updated.template.data.externalId).toBe(config.template.data.externalId);
+    expect(updated.template.data.nextRun).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- advance `repeatAfterComplete` schedulers atomically when stalled recovery terminally fails a job
- respect scheduler end dates and limits
- add a standalone stalled-recovery regression test

## Red-first proof
The first branch commit is test-only. Against its parent:
`SKIP_CLUSTER=1 npx vitest run tests/repeat-stalled.test.ts`
failed with `nextRun` remaining `0` instead of advancing by the configured interval.

## Validation
- focused standalone regression
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

Cluster coverage will run in CI; the local cluster ports are unavailable.