### PR TITLE
fix: reserve list-active atomically when popping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Atomic list reservation**: priority/LIFO workers now increment `list-active` in the same server function that pops job IDs, so a worker failure cannot lose a list job between the pop and counter update. `LIBRARY_VERSION` is now `95`.
+
 ## [0.15.4] - 2026-06-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Atomic list reservation**: priority/LIFO workers now increment `list-active` in the same server function that pops job IDs, so a worker failure cannot lose a list job between the pop and counter update. `LIBRARY_VERSION` is now `95`.
+- **Atomic list reservation**: priority/LIFO workers now increment `list-active` in `glidemq_popListsReserve`, while legacy `glidemq_popLists` remains non-reserving for rolling compatibility. New workers fall back to the legacy pop plus typed `INCRBY` when the reservation function is unavailable. `LIBRARY_VERSION` is now `98`.
 
 ## [0.15.4] - 2026-06-04
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,10 +2,9 @@
 
 ## Current State
 
-- **Branch**: `ci/lua-coverage`, top of the coverage stack.
-- **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
-- **CI**: green across all six fork/upstream stack PRs after the 2026-08-22 packaging update.
-- **Local branches**: `refactor/extract-lua-library` -> `ci/ts-coverage` -> `ci/lua-coverage`.
+- **Branch**: `fix/atomic-list-pop`, based directly on `upstream/main`.
+- **Version**: package `0.15.4`; this branch bumps the server-function library identity to `94`.
+- **Validation**: regression coverage is green on standalone Valkey; full validation is pending.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 
@@ -18,6 +17,7 @@
 - **0.15.2** (#212, #213, #216-219): priority/LIFO in batch-mode workers, `list-active` underflow guards (12 sites through one `decrListActive` helper), priority/LIFO active visibility via `glidemq_getActiveListJobIds`, lockDuration-aware stall reclaim (`stalledInterval` no longer conflated with threshold). `LIBRARY_VERSION` 84. **Behavior change**: workers that relied on short `stalledInterval` without setting `lockDuration` now see slower stall recovery; set `lockDuration` explicitly to match if needed.
 - **0.15.3** (#222-#246): DAG dependency direction/tree rendering/multi-dependent leaf fixes, `addDAG` level batching, stalled-job redispatch semantics, large-key `UNLINK` cleanup, bounded ordering skip-marker advancement, serverless credential cache scoping, flow ID-collision guards, proxy strict opts validation, long-running job heartbeats, broadcast retry isolation, queue client single-flight, and dependency CVE fixes. `LIBRARY_VERSION` 93.
 - **0.15.4**: interval scheduler anchoring prevents late worker ticks from accumulating drift, `npm test` now runs the intended non-fuzzer suite, and CI/local compose coverage use stable Valkey 9.1.0 images.
+- **Unreleased**: list-backed workers now reserve `list-active` in the same FCALL as priority/LIFO popping, closing the crash window between removing a job from its list and incrementing the active counter. `LIBRARY_VERSION` 95 follows stalled-cursor 94.
 
 ### 0.15.4 Release Notes
 
@@ -31,7 +31,7 @@ See CHANGELOG.md `0.15.4` for the full list. Highlights:
 
 - **Bun/Deno NAPI compatibility testing**: still pending from 0.14.0 handover.
 - **Valkey CI images**: CI is off release candidates. Standalone and cluster coverage use stable `valkey/valkey:9.1.0`; search coverage uses stable `valkey/valkey-bundle:9.1.0`, which carries Valkey Search 1.2.x and keeps the Search 1.1+ option tests active.
-- **Coverage**: stacked fork PRs. Extract Lua (`refactor/extract-lua-library`) -> TS V8 coverage (`ci/ts-coverage`) -> Lua line probes (`ci/lua-coverage`). Codecov project status is informational; patch target 80%. Integration and lua are separate flags. `npm run build:lua-cov` instruments dist Lua and stamps dist `LIBRARY_VERSION` as `93-cov`; Vitest aliases `src/functions` to `dist/functions` so src-imported clients cannot REPLACE the probed library. CI dumps LCOV with `node scripts/dump-lua-coverage.cjs` after the suite. The build now copies both `glidemq.lua` and `glidemq.embedded.json` to `dist/functions`, and npm CD smoke-loads `dist` before publishing.
+- **Coverage**: Codecov project status is informational; patch target 80%. Integration and Lua coverage remain separate CI flags.
 
 ## API Design Decisions (locked)
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -3,7 +3,7 @@
 ## Current State
 
 - **Branch**: `fix/atomic-list-pop`, based directly on `upstream/main`.
-- **Version**: package `0.15.4`; this branch bumps the server-function library identity to `94`.
+- **Version**: package `0.15.4`; this branch bumps the server-function library identity to `98`.
 - **Validation**: regression coverage is green on standalone Valkey; full validation is pending.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
@@ -17,7 +17,7 @@
 - **0.15.2** (#212, #213, #216-219): priority/LIFO in batch-mode workers, `list-active` underflow guards (12 sites through one `decrListActive` helper), priority/LIFO active visibility via `glidemq_getActiveListJobIds`, lockDuration-aware stall reclaim (`stalledInterval` no longer conflated with threshold). `LIBRARY_VERSION` 84. **Behavior change**: workers that relied on short `stalledInterval` without setting `lockDuration` now see slower stall recovery; set `lockDuration` explicitly to match if needed.
 - **0.15.3** (#222-#246): DAG dependency direction/tree rendering/multi-dependent leaf fixes, `addDAG` level batching, stalled-job redispatch semantics, large-key `UNLINK` cleanup, bounded ordering skip-marker advancement, serverless credential cache scoping, flow ID-collision guards, proxy strict opts validation, long-running job heartbeats, broadcast retry isolation, queue client single-flight, and dependency CVE fixes. `LIBRARY_VERSION` 93.
 - **0.15.4**: interval scheduler anchoring prevents late worker ticks from accumulating drift, `npm test` now runs the intended non-fuzzer suite, and CI/local compose coverage use stable Valkey 9.1.0 images.
-- **Unreleased**: list-backed workers now reserve `list-active` in the same FCALL as priority/LIFO popping, closing the crash window between removing a job from its list and incrementing the active counter. `LIBRARY_VERSION` 95 follows stalled-cursor 94.
+- **Unreleased**: list-backed workers now reserve `list-active` in `glidemq_popListsReserve`; legacy `glidemq_popLists` remains non-reserving and new workers fall back to it plus typed `INCRBY` during rolling upgrades. `LIBRARY_VERSION` 98 follows stalled-cursor 94.
 
 ### 0.15.4 Release Notes
 

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -3489,7 +3489,6 @@ end)
 redis.register_function('glidemq_popLists', function(keys, args)
   local priorityKey = keys[1]
   local lifoKey = keys[2]
-  local listActiveKey = keys[3]
   local count = tonumber(args[1]) or 1
   local results = {}
   for i = 1, count do
@@ -3498,15 +3497,36 @@ redis.register_function('glidemq_popLists', function(keys, args)
     results[#results + 1] = id
   end
   if #results > 0 then
-    if listActiveKey and listActiveKey ~= '' then
-      redis.call('INCRBY', listActiveKey, #results)
-    end
     return results
   end
   for i = 1, count do
     local id = redis.call('RPOP', lifoKey)
     if not id then break end
     results[#results + 1] = id
+  end
+  return results
+end)
+
+-- Reservation-aware list pop added after glidemq_popLists was deployed.
+-- Keep the legacy function's no-reservation behavior for old workers and old
+-- libraries; new workers call this function and fall back when unavailable.
+redis.register_function('glidemq_popListsReserve', function(keys, args)
+  local priorityKey = keys[1]
+  local lifoKey = keys[2]
+  local listActiveKey = keys[3]
+  local count = tonumber(args[1]) or 1
+  local results = {}
+  for i = 1, count do
+    local id = redis.call('RPOP', priorityKey)
+    if not id then break end
+    results[#results + 1] = id
+  end
+  if #results == 0 then
+    for i = 1, count do
+      local id = redis.call('RPOP', lifoKey)
+      if not id then break end
+      results[#results + 1] = id
+    end
   end
   if #results > 0 and listActiveKey and listActiveKey ~= '' then
     redis.call('INCRBY', listActiveKey, #results)

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -3489,6 +3489,7 @@ end)
 redis.register_function('glidemq_popLists', function(keys, args)
   local priorityKey = keys[1]
   local lifoKey = keys[2]
+  local listActiveKey = keys[3]
   local count = tonumber(args[1]) or 1
   local results = {}
   for i = 1, count do
@@ -3496,11 +3497,19 @@ redis.register_function('glidemq_popLists', function(keys, args)
     if not id then break end
     results[#results + 1] = id
   end
-  if #results > 0 then return results end
+  if #results > 0 then
+    if listActiveKey and listActiveKey ~= '' then
+      redis.call('INCRBY', listActiveKey, #results)
+    end
+    return results
+  end
   for i = 1, count do
     local id = redis.call('RPOP', lifoKey)
     if not id then break end
     results[#results + 1] = id
+  end
+  if #results > 0 and listActiveKey and listActiveKey ~= '' then
+    redis.call('INCRBY', listActiveKey, #results)
   end
   return results
 end)

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -54,7 +54,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#242).
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
-export const LIBRARY_VERSION = '93';
+// Version 95: glidemq_popLists reserves list-active in the same FCALL as the list pop, closing the worker crash window between pop and INCRBY.
+export const LIBRARY_VERSION = '95';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -649,11 +650,13 @@ export async function rpopAndReserve(
 }
 
 /**
- * Pop from priority and LIFO lists in a single FCALL (1 RTT instead of 2).
+ * Pop from priority and LIFO lists in a single FCALL (1 RTT instead of 2),
+ * reserving list-active atomically with the pop.
  * Returns job IDs popped, or empty array if both lists are empty.
  */
 export async function popLists(client: Client, k: QueueKeys, count: number): Promise<string[]> {
-  const result = await client.fcall('glidemq_popLists', [k.priority, k.lifo], [count.toString()]);
+  const safeCount = Math.max(1, Math.min(Math.floor(count) || 1, 1000));
+  const result = await client.fcall('glidemq_popLists', [k.priority, k.lifo, k.listActive], [safeCount.toString()]);
   if (!Array.isArray(result) || result.length === 0) return [];
   return result.map((v) => String(v));
 }

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -55,8 +55,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#242).
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
-// Version 95: glidemq_popListsReserve reserves list-active in the same FCALL as the list pop, closing the worker crash window between pop and INCRBY.
-export const LIBRARY_VERSION = '95';
+// Version 98: glidemq_popListsReserve reserves list-active in the same FCALL as the list pop, closing the worker crash window between pop and INCRBY; legacy glidemq_popLists remains non-reserving for rolling compatibility.
+export const LIBRARY_VERSION = '98';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,3 +1,4 @@
+import { RequestError } from '@glidemq/speedkey';
 import type { GlideReturnType } from '@glidemq/speedkey';
 import type { Client } from '../types';
 import { librarySourceFrom, loadLibraryFile } from './load-library-source';
@@ -54,7 +55,7 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#242).
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
-// Version 95: glidemq_popLists reserves list-active in the same FCALL as the list pop, closing the worker crash window between pop and INCRBY.
+// Version 95: glidemq_popListsReserve reserves list-active in the same FCALL as the list pop, closing the worker crash window between pop and INCRBY.
 export const LIBRARY_VERSION = '95';
 
 // Consumer group name used by workers
@@ -650,13 +651,21 @@ export async function rpopAndReserve(
 }
 
 /**
- * Pop from priority and LIFO lists in a single FCALL (1 RTT instead of 2),
- * reserving list-active atomically with the pop.
+ * Pop from priority and LIFO lists, reserving list-active atomically when the
+ * reservation-aware function is available. During rolling upgrades, fall back
+ * to the legacy pop and typed counter increment if that function is missing.
  * Returns job IDs popped, or empty array if both lists are empty.
  */
 export async function popLists(client: Client, k: QueueKeys, count: number): Promise<string[]> {
   const safeCount = Math.max(1, Math.min(Math.floor(count) || 1, 1000));
-  const result = await client.fcall('glidemq_popLists', [k.priority, k.lifo, k.listActive], [safeCount.toString()]);
+  let result: GlideReturnType;
+  try {
+    result = await client.fcall('glidemq_popListsReserve', [k.priority, k.lifo, k.listActive], [safeCount.toString()]);
+  } catch (error) {
+    if (!(error instanceof RequestError) || !/function\s+not\s+found/i.test(error.message)) throw error;
+    result = await client.fcall('glidemq_popLists', [k.priority, k.lifo, k.listActive], [safeCount.toString()]);
+    if (Array.isArray(result) && result.length > 0) await client.incrBy(k.listActive, result.length);
+  }
   if (!Array.isArray(result) || result.length === 0) return [];
   return result.map((v) => String(v));
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -141,11 +141,9 @@ export class Worker<D = any, R = any> extends BaseWorker<D, R> {
       }
 
       if (jobIds.length > 0) {
-        // INCR list-active so complete/fail Lua DECRs stay balanced.
-        // rpopAndReserve already did the INCR atomically; for non-gc paths do it here.
-        if (!this.globalConcurrencyEnabled) {
-          await this.commandClient.incrBy(this.queueKeys.listActive, jobIds.length);
-        }
+        // Both list-pop functions reserve list-active atomically with the pop.
+        // rpopAndReserve does so while enforcing global concurrency; popLists
+        // does so for the non-global path.
         // Batch mode: route list-popped jobs through the batch processor.
         // Single-job processor is a throwing sentinel in batch mode (#212).
         // Chunk by batchSize so one pop (up to concurrency * batchSize jobs

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -141,9 +141,9 @@ export class Worker<D = any, R = any> extends BaseWorker<D, R> {
       }
 
       if (jobIds.length > 0) {
-        // Both list-pop functions reserve list-active atomically with the pop.
-        // rpopAndReserve does so while enforcing global concurrency; popLists
-        // does so for the non-global path.
+        // rpopAndReserve reserves while enforcing global concurrency. popLists
+        // reserves atomically when the new server function is available and
+        // uses a typed legacy pop plus INCRBY during rolling upgrades.
         // Batch mode: route list-popped jobs through the batch processor.
         // Single-job processor is a throwing sentinel in batch mode (#212).
         // Chunk by batchSize so one pop (up to concurrency * batchSize jobs

--- a/tests/list-active-counter.test.ts
+++ b/tests/list-active-counter.test.ts
@@ -12,10 +12,12 @@
  *
  * Run: npx vitest run tests/list-active-counter.test.ts
  */
-import { it, expect, beforeAll, afterAll } from 'vitest';
+import { it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { describeEachMode, createCleanupClient, flushQueue } from './helpers/fixture';
+import { RequestError } from '@glidemq/speedkey';
 
 const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+const { popLists } = require('../dist/functions/index') as typeof import('../src/functions/index');
 
 const CONSUMER_GROUP = 'workers';
 
@@ -56,6 +58,47 @@ describeEachMode('list-active counter underflow (issue #217)', (CONNECTION) => {
 
   afterAll(async () => {
     cleanupClient.close();
+  });
+
+  it('keeps legacy popLists non-reserving and reserves in the new function', async () => {
+    const Q = `la-pop-reserve-${Date.now()}`;
+    const k = buildKeys(Q);
+    const jobId = 'lifo-job';
+
+    await cleanupClient.rpush(k.lifo, jobId);
+    const result = await cleanupClient.fcall('glidemq_popLists', [k.priority, k.lifo, k.listActive], ['1']);
+
+    expect(result.map((value: unknown) => String(value))).toEqual([jobId]);
+    expect(Number(await cleanupClient.get(k.listActive))).toBe(0);
+
+    const priorityJobId = 'priority-job';
+    await cleanupClient.lpush(k.priority, priorityJobId);
+    const priorityResult = await cleanupClient.fcall(
+      'glidemq_popListsReserve',
+      [k.priority, k.lifo, k.listActive],
+      ['1'],
+    );
+
+    expect(priorityResult.map((value: unknown) => String(value))).toEqual([priorityJobId]);
+    expect(Number(await cleanupClient.get(k.listActive))).toBe(1);
+
+    await flushQueue(cleanupClient, Q);
+  });
+
+  it('falls back to legacy popLists and increments list-active when reservation function is missing', async () => {
+    const client = {
+      fcall: vi
+        .fn()
+        .mockRejectedValueOnce(new RequestError('ERR Function not found'))
+        .mockResolvedValueOnce(['legacy-job']),
+      incrBy: vi.fn().mockResolvedValue(1),
+    };
+    const result = await popLists(client, buildKeys('wrapper-fallback'), 1);
+
+    expect(result).toEqual(['legacy-job']);
+    expect(client.fcall).toHaveBeenNthCalledWith(1, 'glidemq_popListsReserve', expect.any(Array), ['1']);
+    expect(client.fcall).toHaveBeenNthCalledWith(2, 'glidemq_popLists', expect.any(Array), ['1']);
+    expect(client.incrBy).toHaveBeenCalledWith(buildKeys('wrapper-fallback').listActive, 1);
   });
 
   it('complete-twice on list-sourced job does not underflow', async () => {


### PR DESCRIPTION
## Summary
- increment list-active inside the same FCALL that pops priority and LIFO jobs
- remove the worker-side increment race
- retain the already-atomic global-concurrency path

## Red-first proof
The first commit is test-only. Against its parent, the injected post-pop failure left list-active at 0 after a job had been removed.

## Validation
- targeted list-active, LIFO, and batch coverage
- build, typecheck, lint, format, diff check

Local cluster port 7000 is unavailable; cluster coverage will run in CI.