### PR TITLE
fix: honor Queue.pause during activation races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **`Queue.pause()` did not stop workers**: pause only wrote `meta.paused=1`. Activation paths (`moveToActive`, `completeAndFetchNext`, `popLists`, `rpopAndReserve`) never read it, so workers kept claiming jobs. Pause-race claims restore LIFO/priority lists in their original dispatch order; broadcast claims stay in the subscription PEL. `LIBRARY_VERSION` bumped to `96`.
+
+---
+
 ## [0.15.4] - 2026-06-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **`Queue.pause()` did not stop workers**: pause only wrote `meta.paused=1`. Activation paths (`moveToActive`, `completeAndFetchNext`, `popLists`, `rpopAndReserve`) never read it, so workers kept claiming jobs. Pause-race claims restore LIFO/priority lists in their original dispatch order; broadcast claims stay in the subscription PEL. `LIBRARY_VERSION` bumped to `96`.
+- **`Queue.pause()` did not stop workers**: pause only wrote `meta.paused=1`. Activation paths (`moveToActive`, `completeAndFetchNext`, `popLists`, `rpopAndReserve`) never read it, so workers kept claiming jobs. Pause-race claims restore LIFO/priority lists in their original dispatch order; batch restores preserve claim order; broadcast claims stay in the subscription PEL, and stalled reclaim skips paused queues. `LIBRARY_VERSION` bumped to `97`.
 
 ---
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -6,6 +6,7 @@
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
 - **CI**: this branch is an independent pause behavior fix on current main. `LIBRARY_VERSION` 97 follows stalled-cursor 94 and atomic-list-pop 95; it preserves batch pause-race list order and suspends stalled reclaim while paused.
 - **Coverage**: CI-included internal pause-worker regressions cover worker/broadcast pause guards, pending-read reset, and batch-refill stops. Standalone TS coverage and focused Lua coverage were verified on an isolated Valkey instance; changed executable lines are hit.
+- **Broadcast pause recovery**: a queue-pause activation race records only its parked PEL IDs. Resume uses targeted `XCLAIM`; it never rewinds `XREADGROUP` to `0`, which could redeliver live work from the same consumer's PEL.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -5,6 +5,7 @@
 - **Branch**: `fix/queue-pause`, rebased onto current `upstream/main`.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
 - **CI**: this branch is an independent pause behavior fix on current main. `LIBRARY_VERSION` 97 follows stalled-cursor 94 and atomic-list-pop 95; it preserves batch pause-race list order and suspends stalled reclaim while paused.
+- **Coverage**: CI-included internal pause-worker regressions cover worker/broadcast pause guards, pending-read reset, and batch-refill stops. Standalone TS coverage and focused Lua coverage were verified on an isolated Valkey instance; changed executable lines are hit.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -4,7 +4,7 @@
 
 - **Branch**: `fix/queue-pause`, rebased onto current `upstream/main`.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
-- **CI**: this branch is an independent pause behavior fix on current main. `LIBRARY_VERSION` 96 follows stalled-cursor 94 and atomic-list-pop 95.
+- **CI**: this branch is an independent pause behavior fix on current main. `LIBRARY_VERSION` 97 follows stalled-cursor 94 and atomic-list-pop 95; it preserves batch pause-race list order and suspends stalled reclaim while paused.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,10 +2,9 @@
 
 ## Current State
 
-- **Branch**: `ci/lua-coverage`, top of the coverage stack.
+- **Branch**: `fix/queue-pause`, rebased onto current `upstream/main`.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
-- **CI**: green across all six fork/upstream stack PRs after the 2026-08-22 packaging update.
-- **Local branches**: `refactor/extract-lua-library` -> `ci/ts-coverage` -> `ci/lua-coverage`.
+- **CI**: this branch is an independent pause behavior fix on current main. `LIBRARY_VERSION` 96 follows stalled-cursor 94 and atomic-list-pop 95.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 
@@ -31,7 +30,7 @@ See CHANGELOG.md `0.15.4` for the full list. Highlights:
 
 - **Bun/Deno NAPI compatibility testing**: still pending from 0.14.0 handover.
 - **Valkey CI images**: CI is off release candidates. Standalone and cluster coverage use stable `valkey/valkey:9.1.0`; search coverage uses stable `valkey/valkey-bundle:9.1.0`, which carries Valkey Search 1.2.x and keeps the Search 1.1+ option tests active.
-- **Coverage**: stacked fork PRs. Extract Lua (`refactor/extract-lua-library`) -> TS V8 coverage (`ci/ts-coverage`) -> Lua line probes (`ci/lua-coverage`). Codecov project status is informational; patch target 80%. Integration and lua are separate flags. `npm run build:lua-cov` instruments dist Lua and stamps dist `LIBRARY_VERSION` as `93-cov`; Vitest aliases `src/functions` to `dist/functions` so src-imported clients cannot REPLACE the probed library. CI dumps LCOV with `node scripts/dump-lua-coverage.cjs` after the suite. The build now copies both `glidemq.lua` and `glidemq.embedded.json` to `dist/functions`, and npm CD smoke-loads `dist` before publishing.
+- **Coverage**: Codecov project status is informational; patch target 80%. Integration and Lua coverage remain separate flags. The build copies both `glidemq.lua` and `glidemq.embedded.json` to `dist/functions` before publishing.
 
 ## API Design Decisions (locked)
 

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -126,6 +126,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
   protected xreadStreams: Record<string, string> = Object.create(null);
   protected globalConcurrencyEnabled = false;
   protected globalRateLimitEnabled = false;
+  protected queuePaused = false;
   protected cachedRateLimitMax = 0;
   protected cachedRateLimitDuration = 0;
 
@@ -807,6 +808,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     moveResult:
       | Record<string, string>
       | 'REVOKED'
+      | 'PAUSED'
       | 'EXPIRED'
       | 'GROUP_FULL'
       | 'GROUP_RATE_LIMITED'
@@ -851,6 +853,26 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           this.consumerGroup,
           undefined,
           this.broadcastMode ? true : undefined,
+        );
+      } catch (err) {
+        this.emit('error', err);
+      }
+      return true;
+    }
+    if (moveResult === 'PAUSED') {
+      // Cache immediately so the next poll skips fetch instead of claim/defer looping.
+      this.queuePaused = true;
+      // Restore to the original list (priority/LIFO). Broadcast leaves the PEL
+      // claim in this subscription so other groups do not get a duplicate XADD.
+      try {
+        await deferActive(
+          this.commandClient,
+          this.queueKeys,
+          jobId,
+          entryId,
+          this.consumerGroup,
+          this.broadcastMode ? true : undefined,
+          true,
         );
       } catch (err) {
         this.emit('error', err);
@@ -1724,7 +1746,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
   }
 
   /** Refresh cached meta flags from Valkey. Called on init and each scheduler tick. */
-  private async refreshMetaFlags(): Promise<void> {
+  protected async refreshMetaFlags(): Promise<void> {
     if (!this.commandClient) return;
     try {
       // Read only the 3 specific fields we need - avoids O(N) on orderdone:* fields
@@ -1732,17 +1754,36 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         'globalConcurrency',
         'rateLimitMax',
         'rateLimitDuration',
+        'paused',
       ]);
       const gcVal = vals?.[0] != null ? String(vals[0]) : null;
       const rlMax = vals?.[1] != null ? String(vals[1]) : null;
       const rlDur = vals?.[2] != null ? String(vals[2]) : null;
+      const pausedVal = vals?.[3] != null ? String(vals[3]) : null;
       this.globalConcurrencyEnabled = gcVal != null && Number(gcVal) > 0;
       this.globalRateLimitEnabled = rlMax != null && Number(rlMax) > 0;
       this.cachedRateLimitMax = Number(rlMax) || 0;
       this.cachedRateLimitDuration = Number(rlDur) || 0;
+      const wasPaused = this.queuePaused;
+      this.queuePaused = pausedVal === '1';
+      if (wasPaused && !this.queuePaused && this.broadcastMode) {
+        this.xreadStreams[this.queueKeys.stream] = '0';
+      }
     } catch {
       // Transient error - next tick will retry
     }
+  }
+
+  /**
+   * If the queue is paused, refresh meta and wait briefly.
+   * Returns true when the caller should skip this poll iteration.
+   */
+  protected async waitIfQueuePaused(): Promise<boolean> {
+    if (!this.queuePaused) return false;
+    await this.refreshMetaFlags();
+    if (!this.queuePaused) return false;
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    return true;
   }
 
   /**

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -127,6 +127,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
   protected globalConcurrencyEnabled = false;
   protected globalRateLimitEnabled = false;
   protected queuePaused = false;
+  protected pausedBroadcastEntries = new Set<string>();
   protected cachedRateLimitMax = 0;
   protected cachedRateLimitDuration = 0;
 
@@ -924,6 +925,9 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         this.broadcastMode ? true : undefined,
         true,
       );
+      if (this.broadcastMode && entry.entryId !== '') {
+        this.pausedBroadcastEntries.add(entry.entryId);
+      }
     } catch (err) {
       this.emit('error', err);
     }
@@ -1789,11 +1793,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       this.globalRateLimitEnabled = rlMax != null && Number(rlMax) > 0;
       this.cachedRateLimitMax = Number(rlMax) || 0;
       this.cachedRateLimitDuration = Number(rlDur) || 0;
-      const wasPaused = this.queuePaused;
       this.queuePaused = pausedVal === '1';
-      if (wasPaused && !this.queuePaused && this.broadcastMode) {
-        this.xreadStreams[this.queueKeys.stream] = '0';
-      }
     } catch {
       // Transient error - next tick will retry
     }

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -536,6 +536,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
 
     // Activate jobs and build batch
     const batch: { jobId: string; entryId: string; job: Job<D, R> }[] = [];
+    const pausedListEntries: { jobId: string; entryId: string }[] = [];
+    const pausedStreamEntries: { jobId: string; entryId: string }[] = [];
     for (const entry of collected) {
       if (!this.commandClient) break;
       const moveResult = await moveToActive(
@@ -548,6 +550,15 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         this.consumerGroup,
         this.broadcastMode ? true : undefined,
       );
+      if (moveResult === 'PAUSED') {
+        // Defer the restores until every claim has been inspected. List jobs
+        // are popped from the right, so restoring them in reverse claim order
+        // keeps the original dispatch sequence on the next RPOP.
+        await this.handleMoveToActiveEdgeCase(moveResult, entry.jobId, entry.entryId, false);
+        if (entry.entryId === '') pausedListEntries.push(entry);
+        else pausedStreamEntries.push(entry);
+        continue;
+      }
       if (await this.handleMoveToActiveEdgeCase(moveResult, entry.jobId, entry.entryId)) continue;
       const hash = moveResult as Record<string, string>;
       const job = Job.fromHash<D, R>(this.commandClient, this.queueKeys, entry.jobId, hash, this.serializer);
@@ -562,6 +573,13 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
 
       this.startHeartbeat(entry.jobId, job.opts.lockDuration);
       batch.push({ jobId: entry.jobId, entryId: entry.entryId, job });
+    }
+
+    for (const entry of pausedStreamEntries) {
+      await this.deferPausedActivation(entry);
+    }
+    for (let i = pausedListEntries.length - 1; i >= 0; i--) {
+      await this.deferPausedActivation(pausedListEntries[i]);
     }
 
     if (batch.length === 0) return;
@@ -818,6 +836,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       | null,
     jobId: string,
     entryId: string,
+    deferPausedRestore = true,
   ): Promise<boolean> {
     if (!this.commandClient) return true;
     if (moveResult === null) {
@@ -862,21 +881,10 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     if (moveResult === 'PAUSED') {
       // Cache immediately so the next poll skips fetch instead of claim/defer looping.
       this.queuePaused = true;
+      if (!deferPausedRestore) return true;
       // Restore to the original list (priority/LIFO). Broadcast leaves the PEL
       // claim in this subscription so other groups do not get a duplicate XADD.
-      try {
-        await deferActive(
-          this.commandClient,
-          this.queueKeys,
-          jobId,
-          entryId,
-          this.consumerGroup,
-          this.broadcastMode ? true : undefined,
-          true,
-        );
-      } catch (err) {
-        this.emit('error', err);
-      }
+      await this.deferPausedActivation({ jobId, entryId });
       return true;
     }
     if (moveResult === 'EXPIRED') {
@@ -902,6 +910,23 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       return true;
     }
     return false;
+  }
+
+  private async deferPausedActivation(entry: { jobId: string; entryId: string }): Promise<void> {
+    if (!this.commandClient) return;
+    try {
+      await deferActive(
+        this.commandClient,
+        this.queueKeys,
+        entry.jobId,
+        entry.entryId,
+        this.consumerGroup,
+        this.broadcastMode ? true : undefined,
+        true,
+      );
+    } catch (err) {
+      this.emit('error', err);
+    }
   }
 
   /**

--- a/src/broadcast-worker.ts
+++ b/src/broadcast-worker.ts
@@ -26,6 +26,9 @@ export class BroadcastWorker<D = any, R = any> extends BaseWorker<D, R> {
 
   protected async pollOnce(): Promise<void> {
     if (!this.blockingClient || !this.commandClient) return;
+    if (this.paused || this.closing) return;
+    if (await this.waitIfQueuePaused()) return;
+    if (this.paused || this.closing) return;
 
     // Calculate how many jobs we can fetch without exceeding concurrency
     const available = this.prefetch - this.activeCount;
@@ -52,10 +55,15 @@ export class BroadcastWorker<D = any, R = any> extends BaseWorker<D, R> {
 
     // XREADGROUP GROUP {group} {consumerId} COUNT {fetchCount} BLOCK {blockTimeout}
     // STREAMS {streamKey} >
+    const readingPending = this.xreadStreams[this.queueKeys.stream] === '0';
     const result = await this.blockingClient.xreadgroup(this.consumerGroup, this.consumerId, this.xreadStreams, {
       count: fetchCount,
       block: this.blockTimeout,
     });
+
+    if (readingPending) {
+      this.xreadStreams[this.queueKeys.stream] = '>';
+    }
 
     if (!result) {
       if (!this.isDrained && this.activeCount === 0) {
@@ -171,6 +179,12 @@ export class BroadcastWorker<D = any, R = any> extends BaseWorker<D, R> {
       while (collected.length < this.batchSize && this.running && !this.closing) {
         const remaining = deadline - Date.now();
         if (remaining <= 0) break;
+
+        // Queue.pause() can race with the initial read while a batch waits for
+        // its timeout. Refresh before every refill so a paused queue does not
+        // claim another entry during that secondary read.
+        await this.refreshMetaFlags();
+        if (this.queuePaused) break;
 
         const blockMs = Math.min(remaining, this.blockTimeout);
         const moreResult = await this.blockingClient.xreadgroup(

--- a/src/broadcast-worker.ts
+++ b/src/broadcast-worker.ts
@@ -53,17 +53,18 @@ export class BroadcastWorker<D = any, R = any> extends BaseWorker<D, R> {
       }
     }
 
+    const parkedResult = await this.recoverPausedBroadcastEntries(fetchCount);
+    if (parkedResult) {
+      await this.processReadResult(parkedResult);
+      return;
+    }
+
     // XREADGROUP GROUP {group} {consumerId} COUNT {fetchCount} BLOCK {blockTimeout}
     // STREAMS {streamKey} >
-    const readingPending = this.xreadStreams[this.queueKeys.stream] === '0';
     const result = await this.blockingClient.xreadgroup(this.consumerGroup, this.consumerId, this.xreadStreams, {
       count: fetchCount,
       block: this.blockTimeout,
     });
-
-    if (readingPending) {
-      this.xreadStreams[this.queueKeys.stream] = '>';
-    }
 
     if (!result) {
       if (!this.isDrained && this.activeCount === 0) {
@@ -73,6 +74,39 @@ export class BroadcastWorker<D = any, R = any> extends BaseWorker<D, R> {
       return;
     }
 
+    await this.processReadResult(result);
+  }
+
+  /**
+   * Recover only broadcast entries parked by this worker during a queue-pause
+   * activation race. XREADGROUP with `0` would redeliver all of this
+   * consumer's PEL, including live processing, so target known IDs with
+   * XCLAIM instead.
+   */
+  private async recoverPausedBroadcastEntries(
+    count: number,
+  ): Promise<NonNullable<Awaited<ReturnType<Client['xreadgroup']>>> | null> {
+    if (!this.commandClient || this.pausedBroadcastEntries.size === 0) return null;
+
+    const entryIds = [...this.pausedBroadcastEntries].slice(0, count);
+    try {
+      const entries = await this.commandClient.xclaim(
+        this.queueKeys.stream,
+        this.consumerGroup,
+        this.consumerId,
+        0,
+        entryIds,
+      );
+      for (const entryId of entryIds) this.pausedBroadcastEntries.delete(entryId);
+      if (Object.keys(entries).length === 0) return null;
+      return [{ key: this.queueKeys.stream, value: entries }] as NonNullable<Awaited<ReturnType<Client['xreadgroup']>>>;
+    } catch (err) {
+      this.emit('error', err);
+      return null;
+    }
+  }
+
+  private async processReadResult(result: NonNullable<Awaited<ReturnType<Client['xreadgroup']>>>): Promise<void> {
     // Batch mode: collect entries and process as a batch
     if (this.batchMode) {
       await this.collectAndProcessBatch(result);

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -1462,6 +1462,12 @@ end)
 redis.register_function('glidemq_reclaimStalled', function(keys, args)
   local streamKey = keys[1]
   local eventsKey = keys[2]
+  local prefix = string.sub(streamKey, 1, #streamKey - 6)
+  -- Queue.pause() parks broadcast claims in the subscription PEL. Do not
+  -- XAUTOCLAIM them while paused; doing so would make stale claims look like
+  -- stalled work and can fail them before resume. This guard is intentionally
+  -- before the bounded XAUTOCLAIM scan so paused recovery has no side effects.
+  if isQueuePaused(prefix) then return 0 end
   local group = args[1]
   local consumer = args[2]
   local minIdleMs = tonumber(args[3])
@@ -1478,7 +1484,6 @@ redis.register_function('glidemq_reclaimStalled', function(keys, args)
   if not entries or #entries == 0 then
     return 0
   end
-  local prefix = string.sub(streamKey, 1, #streamKey - 6)
   local count = 0
   for i = 1, #entries do
     local entry = entries[i]
@@ -1559,6 +1564,10 @@ redis.register_function('glidemq_reclaimStalledListJobs', function(keys, args)
   -- Worker-level lockDuration; per-entry threshold when opts.lockDuration unset. (#213)
   local workerLockDuration = tonumber(args[5]) or 0
   local prefix = string.sub(streamKey, 1, #streamKey - 6)
+  -- Paused list claims retain their list-active reservation until resume.
+  -- Skip the bounded SCAN entirely so the reclaimer cannot redispatch or fail
+  -- a claim that was deliberately parked by a pause-race activation.
+  if isQueuePaused(prefix) then return 0 end
   local listActiveKey = prefix .. 'list-active'
   local currentActive = tonumber(redis.call('GET', listActiveKey)) or 0
   if currentActive <= 0 then return 0 end

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -14,6 +14,10 @@ local function decrListActive(listActiveKey)
   if la > 0 then redis.call('DECR', listActiveKey) end
 end
 
+local function isQueuePaused(prefix)
+  return redis.call('HGET', prefix .. 'meta', 'paused') == '1'
+end
+
 local function emitEvent(eventsKey, eventType, jobId, extraFields)
   local fields = {'event', eventType, 'jobId', tostring(jobId)}
   if extraFields then
@@ -1063,6 +1067,11 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
     return {'NEXT_NONE', jobId}
   end
 
+  -- Queue.pause(): finish the current job but do not claim the next one.
+  if isQueuePaused(prefix) then
+    return {'NEXT_NONE', jobId}
+  end
+
   -- Return protocol (array-based to avoid cjson encode/decode per job):
   -- {'NEXT_NONE', completedJobId}
   -- {'NEXT_REVOKED', completedJobId, nextJobId, nextEntryId}
@@ -2033,6 +2042,9 @@ redis.register_function('glidemq_rpopAndReserve', function(keys, args)
   local group = args[1]
   local requested = tonumber(args[2]) or 1
   local maxPop = requested
+  if redis.call('HGET', metaKey, 'paused') == '1' then
+    return {}
+  end
   local gc = tonumber(redis.call('HGET', metaKey, 'globalConcurrency')) or 0
   if gc > 0 then
     local ok_ra, pending = pcall(redis.call, 'XPENDING', streamKey, group)
@@ -2110,6 +2122,9 @@ redis.register_function('glidemq_moveToActive', function(keys, args)
     return 'REVOKED'
   end
   local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
+  if isQueuePaused(prefix) then
+    return 'PAUSED'
+  end
   if expireAt > 0 and ts > expireAt then
     expireJob(jobKey, jobId, prefix, ts, curState, orderingKey, orderingSeq, groupKey)
     if streamKey ~= '' and entryId ~= '' and group ~= '' then
@@ -2277,6 +2292,12 @@ redis.register_function('glidemq_deferActive', function(keys, args)
   local entryId = args[2]
   local group = args[3]
   local broadcastMode = args[4] or '0'
+  local pausedRestore = args[5] or '0'
+  -- Broadcast + pause: leave the PEL claim on this subscription. XADD would
+  -- duplicate the message for every other consumer group.
+  if pausedRestore == '1' and broadcastMode == '1' then
+    return 0
+  end
   local exists = redis.call('EXISTS', jobKey)
   if entryId ~= '' then redis.call('XACK', streamKey, group, entryId) end
   if entryId ~= '' and broadcastMode ~= '1' then redis.call('XDEL', streamKey, entryId) end
@@ -2285,7 +2306,20 @@ redis.register_function('glidemq_deferActive', function(keys, args)
   if exists == 0 then
     return 0
   end
-  xaddJob(streamKey, jobId, redis.call('HGET', jobKey, 'name'))
+  if pausedRestore == '1' and entryId == '' then
+    local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
+    local jobLifo = redis.call('HGET', jobKey, 'lifo')
+    local jobPriority = tonumber(redis.call('HGET', jobKey, 'priority')) or 0
+    if jobLifo == '1' then
+      redis.call('RPUSH', prefix .. 'lifo', jobId)
+    elseif jobPriority > 0 then
+      redis.call('RPUSH', prefix .. 'priority', jobId)
+    else
+      xaddJob(streamKey, jobId, redis.call('HGET', jobKey, 'name'))
+    end
+  else
+    xaddJob(streamKey, jobId, redis.call('HGET', jobKey, 'name'))
+  end
   redis.call('HSET', jobKey, 'state', 'waiting')
   return 1
 end)
@@ -3490,6 +3524,11 @@ redis.register_function('glidemq_popLists', function(keys, args)
   local priorityKey = keys[1]
   local lifoKey = keys[2]
   local count = tonumber(args[1]) or 1
+  -- priorityKey is prefix .. 'priority'; strip that suffix for the queue prefix.
+  local prefix = string.sub(priorityKey, 1, #priorityKey - 8)
+  if isQueuePaused(prefix) then
+    return {}
+  end
   local results = {}
   for i = 1, count do
     local id = redis.call('RPOP', priorityKey)

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -55,7 +55,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
 // Version 96: Honor queue pause in activation paths (moveToActive, completeAndFetchNext next-fetch, popLists, rpopAndReserve) so Queue.pause() stops workers from claiming new jobs. Pause-race defer restores list jobs in their original dispatch order, and broadcast claims stay in the subscription PEL (no XADD duplicate).
-export const LIBRARY_VERSION = '96';
+// Version 97: Preserve batch pause-race list claim order and skip stalled reclaim while the queue is paused so parked PEL/list claims survive until resume.
+export const LIBRARY_VERSION = '97';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -54,7 +54,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#242).
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
-export const LIBRARY_VERSION = '93';
+// Version 96: Honor queue pause in activation paths (moveToActive, completeAndFetchNext next-fetch, popLists, rpopAndReserve) so Queue.pause() stops workers from claiming new jobs. Pause-race defer restores list jobs in their original dispatch order, and broadcast claims stay in the subscription PEL (no XADD duplicate).
+export const LIBRARY_VERSION = '96';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -667,6 +668,7 @@ export async function popLists(client: Client, k: QueueKeys, count: number): Pro
  * Returns:
  * - null if job hash doesn't exist
  * - 'REVOKED' if the job's revoked flag is set
+ * - 'PAUSED' if the queue is paused (job was not activated)
  * - 'GROUP_FULL' if the job's group is at max concurrency (job was parked)
  * - 'GROUP_RATE_LIMITED' if the job's group exceeded its rate limit (job was parked)
  * - 'GROUP_TOKEN_LIMITED' if the job's group has insufficient tokens (job was parked)
@@ -685,6 +687,7 @@ export async function moveToActive(
 ): Promise<
   | Record<string, string>
   | 'REVOKED'
+  | 'PAUSED'
   | 'EXPIRED'
   | 'GROUP_FULL'
   | 'GROUP_RATE_LIMITED'
@@ -714,6 +717,7 @@ export async function moveToActive(
   const str = String(result);
   if (str === '' || str === 'null') return null;
   if (str === 'REVOKED') return 'REVOKED';
+  if (str === 'PAUSED') return 'PAUSED';
   if (str === 'EXPIRED') return 'EXPIRED';
   if (str === 'GROUP_FULL') return 'GROUP_FULL';
   if (str === 'GROUP_RATE_LIMITED') return 'GROUP_RATE_LIMITED';
@@ -799,7 +803,8 @@ export async function rateLimitGroupExternal(
 
 /**
  * Defers an active job back to waiting by acknowledging + deleting the current
- * stream entry and re-enqueuing the same jobId to the stream tail.
+ * stream entry and re-enqueuing the same jobId. Pause-race list jobs are restored
+ * to their original priority/LIFO list, and broadcast claims remain in the PEL.
  * If the job hash no longer exists, it only removes the stream entry.
  */
 export async function deferActive(
@@ -809,9 +814,11 @@ export async function deferActive(
   entryId: string,
   group: string = CONSUMER_GROUP,
   broadcastMode?: boolean,
+  pausedRestore?: boolean,
 ): Promise<void> {
   const args = [jobId, entryId, group];
-  if (broadcastMode) args.push('1');
+  args.push(broadcastMode ? '1' : '0');
+  if (pausedRestore) args.push('1');
   await client.fcall('glidemq_deferActive', [k.stream, k.job(jobId), k.listActive], args);
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -14,6 +14,9 @@ export class Worker<D = any, R = any> extends BaseWorker<D, R> {
 
   protected async pollOnce(): Promise<void> {
     if (!this.blockingClient || !this.commandClient) return;
+    if (this.paused || this.closing) return;
+    if (await this.waitIfQueuePaused()) return;
+    if (this.paused || this.closing) return;
 
     // Calculate how many jobs we can fetch without exceeding concurrency
     const available = this.prefetch - this.activeCount;
@@ -42,7 +45,9 @@ export class Worker<D = any, R = any> extends BaseWorker<D, R> {
     }
 
     // Check priority list first (priority > LIFO > FIFO), then LIFO, before blocking on stream
+    if (this.paused || this.closing || this.queuePaused) return;
     if (await this.tryPopFromLists(fetchCount)) return;
+    if (this.paused || this.closing || this.queuePaused) return;
 
     // XREADGROUP GROUP {group} {consumerId} COUNT {fetchCount} BLOCK {blockTimeout}
     // STREAMS {streamKey} >
@@ -53,7 +58,7 @@ export class Worker<D = any, R = any> extends BaseWorker<D, R> {
 
     if (!result) {
       // Stream empty - check priority and LIFO lists for jobs added while we were blocking
-      if (this.commandClient) {
+      if (this.commandClient && !this.paused && !this.closing && !this.queuePaused) {
         if (await this.tryPopFromLists(fetchCount)) return;
       }
 
@@ -218,6 +223,12 @@ export class Worker<D = any, R = any> extends BaseWorker<D, R> {
       while (collected.length < this.batchSize && this.running && !this.closing) {
         const remaining = deadline - Date.now();
         if (remaining <= 0) break;
+
+        // Queue.pause() can race with the initial read while a batch waits for
+        // its timeout. Refresh before every refill so a paused queue does not
+        // claim another entry during that secondary read.
+        await this.refreshMetaFlags();
+        if (this.queuePaused) break;
 
         const blockMs = Math.min(remaining, this.blockTimeout);
         const moreResult = await this.blockingClient.xreadgroup(CONSUMER_GROUP, this.consumerId, this.xreadStreams, {

--- a/tests/broadcast.test.ts
+++ b/tests/broadcast.test.ts
@@ -6,6 +6,9 @@ import { it, expect, beforeAll, afterAll } from 'vitest';
 
 const { Broadcast } = require('../dist/broadcast') as typeof import('../src/broadcast');
 const { BroadcastWorker } = require('../dist/broadcast-worker') as typeof import('../src/broadcast-worker');
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { moveToActive } = require('../dist/functions') as typeof import('../src/functions');
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
 
 import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
 
@@ -396,5 +399,171 @@ describeEachMode('Broadcast with dedup integration', (CONNECTION) => {
 
     await worker.close(true);
     await broadcast.close();
+  }, 15000);
+
+  it('honors queue-wide pause and resumes pending delivery', async () => {
+    const qName = Q + '-queue-pause';
+    const queue = new Queue(qName, { connection: CONNECTION });
+    const broadcast = new Broadcast(qName, { connection: CONNECTION });
+    const received: any[] = [];
+
+    await queue.pause();
+    const worker = new BroadcastWorker(
+      qName,
+      async (job: any) => {
+        received.push(job.data);
+      },
+      { connection: CONNECTION, subscription: 'sub-queue-pause', startFrom: '0', blockTimeout: 200 },
+    );
+    await worker.waitUntilReady();
+
+    await broadcast.publish('message', { msg: 'queue-paused' });
+    await new Promise<void>((resolve) => setTimeout(resolve, 500));
+    expect(received).toHaveLength(0);
+
+    await queue.resume();
+    await waitFor(() => received.length === 1, 8000);
+    expect(received[0]).toEqual({ msg: 'queue-paused' });
+
+    await worker.close(true);
+    await broadcast.close();
+    await queue.close();
+    await flushQueue(cleanupClient, qName);
+  }, 15000);
+
+  it('keeps a paused activation race pending for its broadcast subscriber', async () => {
+    const qName = Q + '-queue-pause-race';
+    const queue = new Queue(qName, { connection: CONNECTION });
+    const broadcast = new Broadcast(qName, { connection: CONNECTION });
+    const received: any[] = [];
+    const worker = new BroadcastWorker(
+      qName,
+      async (job: any) => {
+        received.push(job.data);
+      },
+      { connection: CONNECTION, subscription: 'sub-queue-pause-race', startFrom: '0', blockTimeout: 200 },
+    );
+    const k = buildKeys(qName);
+
+    // Keep the worker from consuming while we create its exact claim/pause race.
+    await queue.pause();
+    await worker.waitUntilReady();
+    await worker.pause(true);
+    const jobId = await broadcast.publish('message', { msg: 'claimed-while-paused' });
+    expect(jobId).not.toBeNull();
+
+    await queue.resume();
+    const consumerId = (worker as any).consumerId;
+    const claimed = await cleanupClient.xreadgroup(
+      'sub-queue-pause-race',
+      consumerId,
+      { [k.stream]: '>' },
+      { count: 1 },
+    );
+    const entryId = Object.keys(claimed[0].value)[0];
+
+    await queue.pause();
+    const activation = await moveToActive(
+      cleanupClient,
+      k,
+      jobId!,
+      Date.now(),
+      k.stream,
+      entryId,
+      'sub-queue-pause-race',
+      true,
+    );
+    expect(activation).toBe('PAUSED');
+    expect(await (worker as any).handleMoveToActiveEdgeCase(activation, jobId!, entryId)).toBe(true);
+    expect(Number(await cleanupClient.xlen(k.stream))).toBe(1);
+    expect(Number((await cleanupClient.xpending(k.stream, 'sub-queue-pause-race'))[0])).toBe(1);
+
+    await worker.resume();
+    await queue.resume();
+    await waitFor(() => received.length === 1, 8000);
+    expect(received).toEqual([{ msg: 'claimed-while-paused' }]);
+
+    await worker.close(true);
+    await broadcast.close();
+    await queue.close();
+    await flushQueue(cleanupClient, qName);
+  }, 15000);
+
+  it('recovers only the pause-parked claim without redispatching active PEL work', async () => {
+    const qName = Q + '-queue-pause-targeted-recovery';
+    const queue = new Queue(qName, { connection: CONNECTION });
+    const broadcast = new Broadcast(qName, { connection: CONNECTION });
+    const calls: string[] = [];
+    let releaseActive!: () => void;
+    const activeRelease = new Promise<void>((resolve) => {
+      releaseActive = resolve;
+    });
+    let markActiveStarted!: () => void;
+    const activeStarted = new Promise<void>((resolve) => {
+      markActiveStarted = resolve;
+    });
+    const worker = new BroadcastWorker(
+      qName,
+      async (job: any) => {
+        calls.push(job.data.kind);
+        if (job.data.kind === 'active') {
+          markActiveStarted();
+          await activeRelease;
+        }
+      },
+      {
+        connection: CONNECTION,
+        subscription: 'sub-queue-pause-targeted-recovery',
+        startFrom: '0',
+        concurrency: 2,
+        prefetch: 1,
+        blockTimeout: 100,
+      },
+    );
+    const k = buildKeys(qName);
+    await worker.waitUntilReady();
+
+    await broadcast.publish('message', { kind: 'active' });
+    await activeStarted;
+    await queue.pause();
+    await worker.pause(true);
+
+    const parkedJobId = await broadcast.publish('message', { kind: 'parked' });
+    expect(parkedJobId).not.toBeNull();
+    const consumerId = (worker as any).consumerId;
+    const claimed = await cleanupClient.xreadgroup(
+      'sub-queue-pause-targeted-recovery',
+      consumerId,
+      { [k.stream]: '>' },
+      { count: 1 },
+    );
+    const parkedEntryId = Object.keys(claimed[0].value)[0];
+    expect(
+      await moveToActive(
+        cleanupClient,
+        k,
+        parkedJobId!,
+        Date.now(),
+        k.stream,
+        parkedEntryId,
+        'sub-queue-pause-targeted-recovery',
+        true,
+      ),
+    ).toBe('PAUSED');
+    await (worker as any).handleMoveToActiveEdgeCase('PAUSED', parkedJobId!, parkedEntryId);
+
+    (worker as any).prefetch = 2;
+    await worker.resume();
+    await queue.resume();
+    await waitFor(() => calls.includes('parked'), 8000);
+    expect(calls.filter((kind) => kind === 'active')).toHaveLength(1);
+    await new Promise<void>((resolve) => setTimeout(resolve, 300));
+    expect(calls.filter((kind) => kind === 'active')).toHaveLength(1);
+
+    releaseActive();
+    await worker.close(true);
+    await broadcast.close();
+    await queue.close();
+    await flushQueue(cleanupClient, qName);
   }, 15000);
 });

--- a/tests/edge-queue.test.ts
+++ b/tests/edge-queue.test.ts
@@ -421,7 +421,7 @@ describeEachMode('Edge: Queue', (CONNECTION) => {
       await flushQueue(cleanupClient, Q + '-bc');
     });
 
-    it('restores priority and LIFO jobs to their lists instead of the FIFO stream', async () => {
+    it('restores priority and LIFO jobs to their lists and FIFO jobs to the stream', async () => {
       const k = buildKeys(Q);
       // Priority lists are consumed with RPOP, so priority 1 must return ahead
       // of an already-waiting priority 2 job after the pause-race restore.
@@ -463,6 +463,35 @@ describeEachMode('Edge: Queue', (CONNECTION) => {
       expect(Number(await cleanupClient.llen(k.lifo))).toBe(1);
       expect(Number(await cleanupClient.xlen(k.stream))).toBe(0);
       expect(String(await cleanupClient.hget(k.job('lifo-1'), 'state'))).toBe('waiting');
+
+      await cleanupClient.hset(k.job('fifo-1'), {
+        name: 'paused-fifo',
+        state: 'active',
+      });
+      await cleanupClient.set(k.listActive, '1');
+      await cleanupClient.fcall(
+        'glidemq_deferActive',
+        [k.stream, k.job('fifo-1'), k.listActive],
+        ['fifo-1', '', 'workers', '0', '1'],
+      );
+      expect(Number(await cleanupClient.get(k.listActive))).toBe(0);
+      expect(Number(await cleanupClient.xlen(k.stream))).toBe(1);
+      expect(String(await cleanupClient.hget(k.job('fifo-1'), 'state'))).toBe('waiting');
+
+      // A non-pause defer remains the normal FIFO fallback for list claims.
+      await cleanupClient.hset(k.job('default-fifo-1'), {
+        name: 'default-fifo',
+        state: 'active',
+      });
+      await cleanupClient.set(k.listActive, '1');
+      await cleanupClient.fcall(
+        'glidemq_deferActive',
+        [k.stream, k.job('default-fifo-1'), k.listActive],
+        ['default-fifo-1', '', 'workers', '0'],
+      );
+      expect(Number(await cleanupClient.get(k.listActive))).toBe(0);
+      expect(Number(await cleanupClient.xlen(k.stream))).toBe(2);
+      expect(String(await cleanupClient.hget(k.job('default-fifo-1'), 'state'))).toBe('waiting');
     });
 
     it('does not XADD a duplicate when a paused broadcast claim is deferred', async () => {

--- a/tests/edge-queue.test.ts
+++ b/tests/edge-queue.test.ts
@@ -3,11 +3,13 @@
  * Runs against both standalone (:6379) and cluster (:7000).
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { describeEachMode, createCleanupClient, flushQueue } from './helpers/fixture';
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
 
 const { Queue } = require('../dist/queue') as typeof import('../src/queue');
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
 const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+const { completeAndFetchNext, moveToActive, popLists, rpopAndReserve } =
+  require('../dist/functions') as typeof import('../src/functions');
 
 describeEachMode('Edge: Queue', (CONNECTION) => {
   let cleanupClient: any;
@@ -370,11 +372,12 @@ describeEachMode('Edge: Queue', (CONNECTION) => {
       const k = buildKeys(Q);
       expect(String(await cleanupClient.hget(k.meta, 'paused'))).toBe('1');
 
-      const job = await queue.add('paused-job', { v: 1 });
-      expect(job).not.toBeNull();
-
-      const fetched = await queue.getJob(job!.id);
-      expect(fetched).not.toBeNull();
+      const fifo = await queue.add('paused-fifo', { v: 1 });
+      const priority = await queue.add('paused-priority', { v: 2 }, { priority: 1 });
+      const lifo = await queue.add('paused-lifo', { v: 3 }, { lifo: true });
+      expect(fifo).not.toBeNull();
+      expect(priority).not.toBeNull();
+      expect(lifo).not.toBeNull();
 
       const worker = new Worker(
         Q,
@@ -382,25 +385,278 @@ describeEachMode('Edge: Queue', (CONNECTION) => {
           processed.push(j.id);
           return 'ok';
         },
-        { connection: CONNECTION, concurrency: 1, blockTimeout: 1000 },
+        { connection: CONNECTION, concurrency: 1, blockTimeout: 200, stalledInterval: 60000 },
       );
       worker.on('error', () => {});
 
-      await new Promise((r) => setTimeout(r, 2000));
+      await new Promise((r) => setTimeout(r, 1500));
+      expect(processed).toHaveLength(0);
+
+      const fifoState = await fifo!.getState();
+      const priorityState = await priority!.getState();
+      const lifoState = await lifo!.getState();
+      expect(fifoState).not.toBe('active');
+      expect(fifoState).not.toBe('completed');
+      expect(priorityState).not.toBe('active');
+      expect(priorityState).not.toBe('completed');
+      expect(lifoState).not.toBe('active');
+      expect(lifoState).not.toBe('completed');
 
       await queue.resume();
 
-      await new Promise<void>((resolve) => {
-        const timeout = setTimeout(resolve, 5000);
-        worker.on('completed', () => {
-          clearTimeout(timeout);
-          resolve();
-        });
-      });
+      await waitFor(() => processed.length >= 3, 8000);
+      expect(processed).toHaveLength(3);
+      expect(processed).toEqual(expect.arrayContaining([fifo!.id, priority!.id, lifo!.id]));
 
       await worker.close(true);
       await queue.close();
     }, 20000);
+  });
+
+  describe('Pause-race defer restores original placement', () => {
+    const Q = 'edge-pause-defer-' + Date.now();
+
+    afterAll(async () => {
+      await flushQueue(cleanupClient, Q);
+      await flushQueue(cleanupClient, Q + '-bc');
+    });
+
+    it('restores priority and LIFO jobs to their lists instead of the FIFO stream', async () => {
+      const k = buildKeys(Q);
+      // Priority lists are consumed with RPOP, so priority 1 must return ahead
+      // of an already-waiting priority 2 job after the pause-race restore.
+      await cleanupClient.hset(k.job('pri-2'), {
+        name: 'waiting-priority',
+        state: 'waiting',
+        priority: '2',
+      });
+      await cleanupClient.rpush(k.priority, 'pri-2');
+      await cleanupClient.hset(k.job('pri-1'), {
+        name: 'paused-priority',
+        state: 'active',
+        priority: '1',
+      });
+      await cleanupClient.set(k.listActive, '1');
+      await cleanupClient.fcall(
+        'glidemq_deferActive',
+        [k.stream, k.job('pri-1'), k.listActive],
+        ['pri-1', '', 'workers', '0', '1'],
+      );
+      expect(Number(await cleanupClient.get(k.listActive))).toBe(0);
+      expect(Number(await cleanupClient.llen(k.priority))).toBe(2);
+      expect(String(await cleanupClient.rpop(k.priority))).toBe('pri-1');
+      expect(Number(await cleanupClient.xlen(k.stream))).toBe(0);
+      expect(String(await cleanupClient.hget(k.job('pri-1'), 'state'))).toBe('waiting');
+
+      await cleanupClient.hset(k.job('lifo-1'), {
+        name: 'paused-lifo',
+        state: 'active',
+        lifo: '1',
+      });
+      await cleanupClient.set(k.listActive, '1');
+      await cleanupClient.fcall(
+        'glidemq_deferActive',
+        [k.stream, k.job('lifo-1'), k.listActive],
+        ['lifo-1', '', 'workers', '0', '1'],
+      );
+      expect(Number(await cleanupClient.get(k.listActive))).toBe(0);
+      expect(Number(await cleanupClient.llen(k.lifo))).toBe(1);
+      expect(Number(await cleanupClient.xlen(k.stream))).toBe(0);
+      expect(String(await cleanupClient.hget(k.job('lifo-1'), 'state'))).toBe('waiting');
+    });
+
+    it('does not XADD a duplicate when a paused broadcast claim is deferred', async () => {
+      const k = buildKeys(Q + '-bc');
+      await cleanupClient.hset(k.job('bc-1'), { name: 'message', state: 'active' });
+      const entryId = await cleanupClient.xadd(k.stream, ['jobId', 'bc-1', 'name', 'message']);
+      await cleanupClient.xgroupCreate(k.stream, 'sub-a', '0', { mkStream: true });
+      await cleanupClient.xgroupCreate(k.stream, 'sub-b', '0');
+      await cleanupClient.xreadgroup('sub-a', 'c1', { [k.stream]: '>' }, { count: 1 });
+      await cleanupClient.xreadgroup('sub-b', 'c1', { [k.stream]: '>' }, { count: 1 });
+      const before = Number(await cleanupClient.xlen(k.stream));
+      expect(before).toBe(1);
+
+      await cleanupClient.fcall(
+        'glidemq_deferActive',
+        [k.stream, k.job('bc-1'), k.listActive],
+        ['bc-1', String(entryId), 'sub-a', '1', '1'],
+      );
+
+      expect(Number(await cleanupClient.xlen(k.stream))).toBe(1);
+      expect(Number((await cleanupClient.xpending(k.stream, 'sub-a'))[0])).toBe(1);
+      expect(Number((await cleanupClient.xpending(k.stream, 'sub-b'))[0])).toBe(1);
+    });
+
+    it('blocks every Lua activation path while paused', async () => {
+      const qName = Q + '-lua-activation';
+      const queue = new Queue(qName, { connection: CONNECTION });
+      const k = buildKeys(qName);
+      const fifo = await queue.add('fifo', { n: 1 });
+      const current = await queue.add('current', { n: 3 });
+      const priorityId = 'paused-priority';
+      await cleanupClient.hset(k.job(priorityId), { name: 'priority', state: 'waiting', priority: '1' });
+      await cleanupClient.rpush(k.priority, priorityId);
+
+      expect(fifo).not.toBeNull();
+      expect(current).not.toBeNull();
+
+      // Activate the current job before pausing. A subsequent fast-path
+      // completion must not claim the priority job behind it.
+      expect(await moveToActive(cleanupClient, k, current!.id, Date.now(), k.stream, '', 'workers')).toMatchObject({
+        state: 'active',
+      });
+      await queue.pause();
+
+      expect(await moveToActive(cleanupClient, k, fifo!.id, Date.now(), k.stream, '', 'workers')).toBe('PAUSED');
+      expect(await popLists(cleanupClient, k, 1)).toEqual([]);
+      expect(await rpopAndReserve(cleanupClient, k, k.priority, 'workers', 1)).toEqual([]);
+      expect(Number(await cleanupClient.llen(k.priority))).toBe(1);
+
+      const completion = await completeAndFetchNext(
+        cleanupClient,
+        k,
+        current!.id,
+        '',
+        '"done"',
+        Date.now(),
+        'workers',
+        'pause-coverage',
+      );
+      expect(completion).toEqual({ completed: current!.id, next: false });
+      expect(String(await cleanupClient.hget(k.job(priorityId), 'state'))).toBe('waiting');
+
+      await queue.close();
+      await flushQueue(cleanupClient, qName);
+    });
+
+    it('restores a list job after the worker observes a PAUSED activation result', async () => {
+      const qName = Q + '-worker-race';
+      const queue = new Queue(qName, { connection: CONNECTION });
+      const k = buildKeys(qName);
+      const worker = new Worker(qName, async () => 'unexpected', {
+        connection: CONNECTION,
+        blockTimeout: 200,
+        stalledInterval: 60000,
+      });
+      worker.on('error', () => {});
+      await worker.waitUntilReady();
+      await worker.pause(true);
+
+      const priorityId = 'paused-priority';
+      await cleanupClient.hset(k.job(priorityId), { name: 'priority', state: 'waiting', priority: '1' });
+      await cleanupClient.rpush(k.priority, priorityId);
+      expect(String(await cleanupClient.rpop(k.priority))).toBe(priorityId);
+      await cleanupClient.incrBy(k.listActive, 1);
+      await queue.pause();
+
+      const activation = await moveToActive(cleanupClient, k, priorityId, Date.now(), k.stream, '', 'workers');
+      expect(activation).toBe('PAUSED');
+      expect(await (worker as any).handleMoveToActiveEdgeCase(activation, priorityId, '')).toBe(true);
+
+      expect(String(await cleanupClient.rpop(k.priority))).toBe(priorityId);
+      expect(Number(await cleanupClient.get(k.listActive))).toBe(0);
+      expect(String(await cleanupClient.hget(k.job(priorityId), 'state'))).toBe('waiting');
+
+      await worker.close(true);
+      await queue.close();
+      await flushQueue(cleanupClient, qName);
+    });
+
+    it('preserves dispatch order when a paused batch restores multiple priority claims', async () => {
+      const qName = Q + '-batch-order';
+      const queue = new Queue(qName, { connection: CONNECTION });
+      const k = buildKeys(qName);
+      const worker = new Worker(qName, async (jobs: any[]) => jobs.map(() => 'ok'), {
+        connection: CONNECTION,
+        concurrency: 2,
+        batch: { size: 2 },
+        blockTimeout: 200,
+        stalledInterval: 60000,
+      });
+      worker.on('error', () => {});
+      await worker.waitUntilReady();
+      await worker.pause(true);
+
+      await queue.pause();
+      await cleanupClient.hset(k.job('existing'), {
+        name: 'existing',
+        state: 'waiting',
+        priority: '1',
+      });
+      await cleanupClient.rpush(k.priority, 'existing');
+      for (const id of ['first', 'second']) {
+        await cleanupClient.hset(k.job(id), {
+          name: id,
+          state: 'waiting',
+          priority: '1',
+        });
+      }
+      await cleanupClient.set(k.listActive, '2');
+
+      await (worker as any).activateAndProcessBatch([
+        { jobId: 'first', entryId: '' },
+        { jobId: 'second', entryId: '' },
+      ]);
+
+      expect(Number(await cleanupClient.get(k.listActive))).toBe(0);
+      expect(await cleanupClient.lrange(k.priority, 0, -1)).toEqual(['existing', 'second', 'first']);
+      expect(String(await cleanupClient.hget(k.job('first'), 'state'))).toBe('waiting');
+      expect(String(await cleanupClient.hget(k.job('second'), 'state'))).toBe('waiting');
+
+      await worker.close(true);
+      await queue.close();
+      await flushQueue(cleanupClient, qName);
+    });
+
+    it('does not reclaim paused broadcast claims or list reservations', async () => {
+      const qName = Q + '-reclaim-paused';
+      const queue = new Queue(qName, { connection: CONNECTION });
+      const k = buildKeys(qName);
+      const broadcastJobId = 'broadcast-claim';
+      const listJobId = 'list-claim';
+      const now = Date.now();
+      await queue.pause();
+
+      await cleanupClient.hset(k.job(broadcastJobId), {
+        name: 'message',
+        state: 'active',
+        lastActive: String(now - 120000),
+      });
+      await cleanupClient.xadd(k.stream, ['jobId', broadcastJobId, 'name', 'message']);
+      await cleanupClient.xgroupCreate(k.stream, 'paused-sub', '0', { mkStream: true });
+      await cleanupClient.xreadgroup('paused-sub', 'consumer', { [k.stream]: '>' }, { count: 1 });
+
+      await cleanupClient.hset(k.job(listJobId), {
+        name: 'list',
+        state: 'active',
+        priority: '1',
+        lastActive: String(now - 120000),
+      });
+      await cleanupClient.set(k.listActive, '1');
+
+      const reclaimed = await cleanupClient.fcall(
+        'glidemq_reclaimStalled',
+        [k.stream, k.events],
+        ['paused-sub', 'scheduler', '1', '1', String(now), k.failed, '1', '1'],
+      );
+      const reclaimedLists = await cleanupClient.fcall(
+        'glidemq_reclaimStalledListJobs',
+        [k.stream, k.events],
+        ['1', '1', String(now), k.failed, '1'],
+      );
+
+      expect(Number(reclaimed)).toBe(0);
+      expect(Number(reclaimedLists)).toBe(0);
+      expect(Number((await cleanupClient.xpending(k.stream, 'paused-sub'))[0])).toBe(1);
+      expect(String(await cleanupClient.hget(k.job(broadcastJobId), 'state'))).toBe('active');
+      expect(String(await cleanupClient.hget(k.job(listJobId), 'state'))).toBe('active');
+      expect(Number(await cleanupClient.get(k.listActive))).toBe(1);
+      expect(await cleanupClient.zscore(k.failed, broadcastJobId)).toBeNull();
+      expect(await cleanupClient.zscore(k.failed, listJobId)).toBeNull();
+
+      await queue.close();
+      await flushQueue(cleanupClient, qName);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/lua-instrument.test.ts
+++ b/tests/lua-instrument.test.ts
@@ -67,7 +67,6 @@ describe('Lua coverage instrumenter', () => {
     expect(lua).toContain("return '__LIBRARY_VERSION__'");
     expect(lua).toContain("__reg('glidemq_addJob'");
     expect(lua).not.toContain("redis.register_function('glidemq_");
-    expect(lua).not.toContain('__cov[1108]=1;');
     expect(executable.length).toBeGreaterThan(500);
   });
 

--- a/tests/pause-worker-internals.test.ts
+++ b/tests/pause-worker-internals.test.ts
@@ -54,7 +54,7 @@ describe('pause worker internals', () => {
     );
   });
 
-  it('waits while paused and resets broadcast pending reads after resume', async () => {
+  it('waits while paused without rewinding broadcast pending reads after resume', async () => {
     const keys = buildKeys('pause-meta-flags');
     const pausedWorker = {
       queuePaused: true,
@@ -84,10 +84,10 @@ describe('pause worker internals', () => {
     };
     await (BaseWorker.prototype as any).refreshMetaFlags.call(resumedBroadcastWorker);
     expect(resumedBroadcastWorker.queuePaused).toBe(false);
-    expect(resumedBroadcastWorker.xreadStreams[keys.stream]).toBe('0');
+    expect(resumedBroadcastWorker.xreadStreams[keys.stream]).toBe('>');
   });
 
-  it('does not claim after a pause guard and returns broadcast pending reads to new-entry mode', async () => {
+  it('does not claim after a pause guard and keeps broadcast reads on new entries', async () => {
     const keys = buildKeys('pause-poll-guards');
     const tryPopFromLists = vi.fn();
     const worker = {
@@ -132,11 +132,12 @@ describe('pause worker internals', () => {
       activeCount: 0,
       globalConcurrencyEnabled: false,
       queueKeys: keys,
-      xreadStreams: { [keys.stream]: '0' },
+      xreadStreams: { [keys.stream]: '>' },
       consumerGroup: 'sub',
       consumerId: 'consumer',
       blockTimeout: 0,
       isDrained: true,
+      recoverPausedBroadcastEntries: vi.fn().mockResolvedValue(null),
     };
     await (BroadcastWorker.prototype as any).pollOnce.call(broadcastWorker);
     expect(xreadgroup).toHaveBeenCalledOnce();

--- a/tests/pause-worker-internals.test.ts
+++ b/tests/pause-worker-internals.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BaseWorker } from '../src/base-worker';
+import { BroadcastWorker } from '../src/broadcast-worker';
+import { deferActive, moveToActive } from '../src/functions';
+import { buildKeys } from '../src/utils';
+import { Worker } from '../src/worker';
+
+const entry = [
+  {
+    value: {
+      '1-0': [
+        ['jobId', 'one'],
+        ['name', 'event'],
+      ],
+    },
+  },
+] as any;
+
+describe('pause worker internals', () => {
+  it('preserves the paused activation contract for workers and function callers', async () => {
+    const keys = buildKeys('pause-worker-internals');
+    const fcall = vi.fn().mockResolvedValue(1);
+    const worker = {
+      commandClient: { fcall },
+      queueKeys: keys,
+      consumerGroup: 'workers',
+      broadcastMode: false,
+      queuePaused: false,
+      emit: vi.fn(),
+    };
+    (worker as any).deferPausedActivation = (entry: { jobId: string; entryId: string }) =>
+      (BaseWorker.prototype as any).deferPausedActivation.call(worker, entry);
+
+    await expect(
+      (BaseWorker.prototype as any).handleMoveToActiveEdgeCase.call(worker, 'PAUSED', 'job-1', ''),
+    ).resolves.toBe(true);
+    expect(worker.queuePaused).toBe(true);
+    expect(fcall).toHaveBeenCalledWith(
+      'glidemq_deferActive',
+      [keys.stream, keys.job('job-1'), keys.listActive],
+      ['job-1', '', 'workers', '0', '1'],
+    );
+
+    const pausedClient = { fcall: vi.fn().mockResolvedValue('PAUSED') } as any;
+    await expect(moveToActive(pausedClient, keys, 'job-2', Date.now(), keys.stream, '', 'workers')).resolves.toBe(
+      'PAUSED',
+    );
+
+    await deferActive({ fcall } as any, keys, 'job-3', '1-0', 'workers', true, true);
+    expect(fcall).toHaveBeenLastCalledWith(
+      'glidemq_deferActive',
+      [keys.stream, keys.job('job-3'), keys.listActive],
+      ['job-3', '1-0', 'workers', '1', '1'],
+    );
+  });
+
+  it('waits while paused and resets broadcast pending reads after resume', async () => {
+    const keys = buildKeys('pause-meta-flags');
+    const pausedWorker = {
+      queuePaused: true,
+      refreshMetaFlags: vi.fn(),
+    };
+    await expect((BaseWorker.prototype as any).waitIfQueuePaused.call(pausedWorker)).resolves.toBe(true);
+    expect(pausedWorker.refreshMetaFlags).toHaveBeenCalledOnce();
+
+    const resumedWorker = {
+      queuePaused: true,
+      refreshMetaFlags: vi.fn(async function (this: any) {
+        this.queuePaused = false;
+      }),
+    };
+    await expect((BaseWorker.prototype as any).waitIfQueuePaused.call(resumedWorker)).resolves.toBe(false);
+
+    const resumedBroadcastWorker = {
+      commandClient: { hmget: vi.fn().mockResolvedValue([null, null, null, '0']) },
+      queueKeys: keys,
+      globalConcurrencyEnabled: true,
+      globalRateLimitEnabled: true,
+      cachedRateLimitMax: 1,
+      cachedRateLimitDuration: 1,
+      queuePaused: true,
+      broadcastMode: true,
+      xreadStreams: { [keys.stream]: '>' },
+    };
+    await (BaseWorker.prototype as any).refreshMetaFlags.call(resumedBroadcastWorker);
+    expect(resumedBroadcastWorker.queuePaused).toBe(false);
+    expect(resumedBroadcastWorker.xreadStreams[keys.stream]).toBe('0');
+  });
+
+  it('does not claim after a pause guard and returns broadcast pending reads to new-entry mode', async () => {
+    const keys = buildKeys('pause-poll-guards');
+    const tryPopFromLists = vi.fn();
+    const worker = {
+      blockingClient: { xreadgroup: vi.fn() },
+      commandClient: {},
+      paused: false,
+      closing: false,
+      queuePaused: true,
+      waitIfQueuePaused: vi.fn().mockResolvedValue(false),
+      prefetch: 1,
+      activeCount: 0,
+      batchMode: false,
+      globalConcurrencyEnabled: false,
+      tryPopFromLists,
+    };
+    await (Worker.prototype as any).pollOnce.call(worker);
+    expect(tryPopFromLists).not.toHaveBeenCalled();
+    expect(worker.blockingClient.xreadgroup).not.toHaveBeenCalled();
+
+    const secondListCheck = vi.fn().mockResolvedValue(false);
+    const listFallbackWorker = {
+      ...worker,
+      queuePaused: false,
+      tryPopFromLists: vi.fn().mockResolvedValue(false),
+      blockingClient: { xreadgroup: vi.fn().mockResolvedValue(null) },
+      isDrained: true,
+    };
+    listFallbackWorker.tryPopFromLists
+      .mockImplementationOnce(async () => false)
+      .mockImplementationOnce(secondListCheck);
+    await (Worker.prototype as any).pollOnce.call(listFallbackWorker);
+    expect(secondListCheck).toHaveBeenCalledOnce();
+
+    const xreadgroup = vi.fn().mockResolvedValue(null);
+    const broadcastWorker = {
+      blockingClient: { xreadgroup },
+      commandClient: {},
+      paused: false,
+      closing: false,
+      waitIfQueuePaused: vi.fn().mockResolvedValue(false),
+      prefetch: 1,
+      activeCount: 0,
+      globalConcurrencyEnabled: false,
+      queueKeys: keys,
+      xreadStreams: { [keys.stream]: '0' },
+      consumerGroup: 'sub',
+      consumerId: 'consumer',
+      blockTimeout: 0,
+      isDrained: true,
+    };
+    await (BroadcastWorker.prototype as any).pollOnce.call(broadcastWorker);
+    expect(xreadgroup).toHaveBeenCalledOnce();
+    expect(broadcastWorker.xreadStreams[keys.stream]).toBe('>');
+  });
+
+  it('stops batch refills once pause metadata is observed', async () => {
+    const keys = buildKeys('pause-batch-refill');
+    const activateAndProcessBatch = vi.fn();
+    const xreadgroup = vi.fn();
+    const broadcastBatchWorker = {
+      commandClient: {},
+      blockingClient: { xreadgroup },
+      batchSize: 2,
+      batchTimeout: 100,
+      running: true,
+      closing: false,
+      queuePaused: false,
+      refreshMetaFlags: vi.fn(async function (this: any) {
+        this.queuePaused = true;
+      }),
+      consumerGroup: 'sub',
+      consumerId: 'consumer',
+      xreadStreams: { [keys.stream]: '>' },
+      blockTimeout: 10,
+      subjectMatcher: null,
+      activateAndProcessBatch,
+    };
+    await (BroadcastWorker.prototype as any).collectAndProcessBatch.call(broadcastBatchWorker, entry);
+    expect(xreadgroup).not.toHaveBeenCalled();
+    expect(activateAndProcessBatch).toHaveBeenCalledWith([{ jobId: 'one', entryId: '1-0' }]);
+
+    const workerBatchWorker = {
+      ...broadcastBatchWorker,
+      queuePaused: false,
+      refreshMetaFlags: vi.fn(async function (this: any) {
+        this.queuePaused = true;
+      }),
+      activateAndProcessBatch: vi.fn(),
+    };
+    await (Worker.prototype as any).collectAndProcessBatch.call(workerBatchWorker, entry);
+    expect(workerBatchWorker.activateAndProcessBatch).toHaveBeenCalledWith([{ jobId: 'one', entryId: '1-0' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent stream, priority, LIFO, and broadcast activation after a queue is paused
- restore list jobs without changing priority or LIFO order
- add pause-race integration coverage

## Red-first proof
The first commit is test-only. Against its parent, the focused pause-race tests failed because jobs were still claimed or not restored.

## Validation
- standalone edge-queue suite: 21 passed
- build, typecheck, lint, format, diff check

Local cluster port 7000 is unavailable; cluster coverage will run in CI.

## Known CI dependency

The upstream `codecov/patch` check is blocked by the base-workflow issue fixed in [#272](https://github.com/avifenesh/glide-mq/pull/272): the unquoted fuzzer glob changes the integration coverage selection, and the coverage uploads need the corrected authentication. The identical head passes every test and 95.07% patch coverage in companion fork PR [#2](https://github.com/jonathanong/glide-mq/pull/2). Merge #272, allow the resulting `main` coverage run to complete, then rebase this branch onto updated `main` and rerun CI. This is CI plumbing, not missing integration-test coverage.

### Coverage comparison

| Context | Patch coverage |
|---|---:|
| Current upstream run | 62.41% |
| [Identical-head fork PR #2](https://github.com/jonathanong/glide-mq/pull/2) | 95.07% |