### PR TITLE
fix: persist stalled reclaim cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Stalled recovery cursor**: `glidemq_reclaimStalled` now persists a per-consumer-group `XAUTOCLAIM` cursor in queue metadata and bounds each reclaim batch, preventing every scheduler tick from restarting at `0-0` and repeatedly rescanning the same PEL entries.
+
+---
+
 ## [0.15.4] - 2026-06-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Stalled recovery cursor**: `glidemq_reclaimStalled` now persists a per-consumer-group `XAUTOCLAIM` cursor in queue metadata and bounds each reclaim batch, preventing every scheduler tick from restarting at `0-0` and repeatedly rescanning the same PEL entries.
+- **Stalled recovery cursor**: `glidemq_reclaimStalled` now persists a per-consumer-group `XAUTOCLAIM` cursor in queue metadata and bounds each reclaim batch. Schedulers follow full pages with a guarded yielding continuation instead of waiting another stalled interval.
 
 ---
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,10 +2,9 @@
 
 ## Current State
 
-- **Branch**: `ci/lua-coverage`, top of the coverage stack.
+- **Branch**: `fix/stalled-cursor`, based on current `upstream/main`.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
-- **CI**: green across all six fork/upstream stack PRs after the 2026-08-22 packaging update.
-- **Local branches**: `refactor/extract-lua-library` -> `ci/ts-coverage` -> `ci/lua-coverage`.
+- **CI**: this branch is an independent stalled-recovery fix on current main.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 
@@ -31,7 +30,7 @@ See CHANGELOG.md `0.15.4` for the full list. Highlights:
 
 - **Bun/Deno NAPI compatibility testing**: still pending from 0.14.0 handover.
 - **Valkey CI images**: CI is off release candidates. Standalone and cluster coverage use stable `valkey/valkey:9.1.0`; search coverage uses stable `valkey/valkey-bundle:9.1.0`, which carries Valkey Search 1.2.x and keeps the Search 1.1+ option tests active.
-- **Coverage**: stacked fork PRs. Extract Lua (`refactor/extract-lua-library`) -> TS V8 coverage (`ci/ts-coverage`) -> Lua line probes (`ci/lua-coverage`). Codecov project status is informational; patch target 80%. Integration and lua are separate flags. `npm run build:lua-cov` instruments dist Lua and stamps dist `LIBRARY_VERSION` as `93-cov`; Vitest aliases `src/functions` to `dist/functions` so src-imported clients cannot REPLACE the probed library. CI dumps LCOV with `node scripts/dump-lua-coverage.cjs` after the suite. The build now copies both `glidemq.lua` and `glidemq.embedded.json` to `dist/functions`, and npm CD smoke-loads `dist` before publishing.
+- **Coverage**: Codecov project status is informational; patch target 80%. Integration and Lua coverage remain separate flags. The build copies both `glidemq.lua` and `glidemq.embedded.json` to `dist/functions` before publishing.
 
 ## API Design Decisions (locked)
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -5,6 +5,7 @@
 - **Branch**: `fix/stalled-cursor`, based on current `upstream/main`.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
 - **CI**: this branch is an independent stalled-recovery fix on current main.
+- **Stalled recovery**: `XAUTOCLAIM` persists a per-group cursor. Full 100-entry pages continue on a guarded zero-delay timer, yielding to I/O between pages without waiting another stalled interval.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -1464,12 +1464,20 @@ redis.register_function('glidemq_reclaimStalled', function(keys, args)
   -- job has no opts.lockDuration of its own. Falls back to minIdleMs (the
   -- stalledInterval cadence) when neither is set, matching old behavior. (#213)
   local workerLockDuration = tonumber(args[8]) or 0
-  local result = redis.call('XAUTOCLAIM', streamKey, group, consumer, minIdleMs, '0-0')
+  local prefix = string.sub(streamKey, 1, #streamKey - 6)
+  local metaKey = prefix .. 'meta'
+  local cursorField = 'stalledCursor:' .. group
+  local startCursor = redis.call('HGET', metaKey, cursorField) or '0-0'
+  -- Bound each reclaim call and continue from the previous XAUTOCLAIM cursor.
+  -- The meta hash is shared by schedulers for this consumer group, so concurrent
+  -- schedulers advance one queue-wide scan instead of repeatedly rescanning 0-0.
+  local result = redis.call('XAUTOCLAIM', streamKey, group, consumer, minIdleMs, startCursor, 'COUNT', '100')
+  local nextCursor = result[1] or '0-0'
+  redis.call('HSET', metaKey, cursorField, nextCursor)
   local entries = result[2]
   if not entries or #entries == 0 then
     return 0
   end
-  local prefix = string.sub(streamKey, 1, #streamKey - 6)
   local count = 0
   for i = 1, #entries do
     local entry = entries[i]

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -54,7 +54,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#242).
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
-export const LIBRARY_VERSION = '93';
+// Version 94: glidemq_reclaimStalled persists a per-group XAUTOCLAIM cursor and bounds each reclaim batch to 100 entries so repeated scheduler ticks progress through large PELs.
+export const LIBRARY_VERSION = '94';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -20,6 +20,8 @@ import type { buildKeys } from './utils';
 import { computeFollowingSchedulerNextRun, isValidSchedulerEvery, MAX_JOB_DATA_SIZE } from './utils';
 import { isClusterClient } from './connection';
 
+const STALLED_RECLAIM_BATCH_SIZE = 100;
+
 export interface SchedulerOptions {
   promotionInterval?: number;
   stalledInterval?: number;
@@ -64,9 +66,11 @@ export class Scheduler {
   private promotionWakeTimer: ReturnType<typeof setTimeout> | null = null;
   private nextPromotionWakeAt = 0;
   private stalledTimer: ReturnType<typeof setInterval> | null = null;
+  private stalledRecoveryContinuationTimer: ReturnType<typeof setTimeout> | null = null;
   private running = false;
   private promotionInFlight = false;
   private promotionQueued = false;
+  private stalledRecoveryInFlight = false;
   private pendingRuns = new Set<Promise<unknown>>();
   private tickCount = 0;
 
@@ -121,6 +125,10 @@ export class Scheduler {
     if (this.stalledTimer) {
       clearInterval(this.stalledTimer);
       this.stalledTimer = null;
+    }
+    if (this.stalledRecoveryContinuationTimer) {
+      clearTimeout(this.stalledRecoveryContinuationTimer);
+      this.stalledRecoveryContinuationTimer = null;
     }
   }
 
@@ -219,13 +227,35 @@ export class Scheduler {
   }
 
   private runStalledRecovery(): void {
+    if (!this.running || this.stalledRecoveryInFlight || this.stalledRecoveryContinuationTimer) return;
+
+    this.stalledRecoveryInFlight = true;
+    let continueRecovery = false;
     this.trackRun(
-      Promise.all([this.reclaimStalledJobs(), this.reclaimStalledListJobs(), this.sweepExpiredSuspended()]).catch(
-        (err) => {
+      Promise.all([this.reclaimStalledJobs(), this.reclaimStalledListJobs(), this.sweepExpiredSuspended()])
+        .then(([reclaimed]) => {
+          continueRecovery = reclaimed === STALLED_RECLAIM_BATCH_SIZE;
+        })
+        .catch((err) => {
           this.reportError(err);
-        },
-      ),
+        })
+        .finally(() => {
+          this.stalledRecoveryInFlight = false;
+          if (this.running && continueRecovery) this.scheduleStalledRecoveryContinuation();
+        }),
     );
+  }
+
+  private scheduleStalledRecoveryContinuation(): void {
+    if (this.stalledRecoveryContinuationTimer) return;
+
+    // One bounded XAUTOCLAIM page is processed per timer turn. Yielding here
+    // lets I/O and job processing run between pages while avoiding an interval
+    // of stalledInterval between full PEL pages.
+    this.stalledRecoveryContinuationTimer = setTimeout(() => {
+      this.stalledRecoveryContinuationTimer = null;
+      this.runStalledRecovery();
+    }, 0);
   }
 
   /**

--- a/tests/scheduler-internals.test.ts
+++ b/tests/scheduler-internals.test.ts
@@ -72,4 +72,63 @@ describe('Scheduler internals', () => {
       vi.useRealTimers();
     }
   });
+
+  it('does not overlap or run a queued continuation after stop', async () => {
+    vi.useFakeTimers();
+    let reclaimCalls = 0;
+    const client = {
+      fcall: vi.fn((name: string) => {
+        if (name === 'glidemq_reclaimStalled') {
+          reclaimCalls++;
+          return Promise.resolve(100);
+        }
+        if (name === 'glidemq_nextDue') return Promise.resolve(-1);
+        return Promise.resolve(0);
+      }),
+    } as any;
+    const scheduler = new Scheduler(client, buildKeys('scheduler-stalled-stop'), {
+      promotionInterval: 60_000,
+      stalledInterval: 60_000,
+    });
+
+    try {
+      scheduler.start();
+      await scheduler.waitForIdle();
+
+      (scheduler as any).runStalledRecovery();
+      expect(reclaimCalls).toBe(1);
+
+      scheduler.stop();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(reclaimCalls).toBe(1);
+    } finally {
+      scheduler.stop();
+      await scheduler.waitForIdle();
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports a stalled recovery failure without rejecting scheduler idle', async () => {
+    const error = new Error('reclaim failed');
+    const errors: Error[] = [];
+    const client = {
+      fcall: vi.fn((name: string) => {
+        if (name === 'glidemq_reclaimStalled') return Promise.reject(error);
+        if (name === 'glidemq_nextDue') return Promise.resolve(-1);
+        return Promise.resolve(0);
+      }),
+      hgetall: vi.fn().mockResolvedValue([]),
+    } as any;
+    const scheduler = new Scheduler(client, buildKeys('scheduler-stalled-error'), {
+      promotionInterval: 60_000,
+      stalledInterval: 60_000,
+      onError: (err) => errors.push(err),
+    });
+
+    scheduler.start();
+    await scheduler.waitForIdle();
+    scheduler.stop();
+
+    expect(errors).toContain(error);
+  });
 });

--- a/tests/scheduler-internals.test.ts
+++ b/tests/scheduler-internals.test.ts
@@ -37,4 +37,39 @@ describe('Scheduler internals', () => {
     expect(exec).not.toHaveBeenCalled();
     expect(errors.map((err) => err.message)).toContain('Lost scheduler tick lock while processing schedulers');
   });
+
+  it('continues a full stalled reclaim page without overlapping recovery', async () => {
+    vi.useFakeTimers();
+    let resolveFirstReclaim!: (count: number) => void;
+    let reclaimCalls = 0;
+    const client = {
+      fcall: vi.fn((name: string) => {
+        if (name === 'glidemq_reclaimStalled') {
+          reclaimCalls++;
+          if (reclaimCalls === 1) return new Promise<number>((resolve) => (resolveFirstReclaim = resolve));
+          return Promise.resolve(0);
+        }
+        if (name === 'glidemq_nextDue') return Promise.resolve(-1);
+        return Promise.resolve(0);
+      }),
+    } as any;
+    const scheduler = new Scheduler(client, buildKeys('scheduler-stalled-continuation'), {
+      promotionInterval: 60_000,
+      stalledInterval: 60_000,
+    });
+
+    try {
+      scheduler.start();
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(reclaimCalls).toBe(1);
+
+      resolveFirstReclaim(100);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(reclaimCalls).toBe(2);
+    } finally {
+      scheduler.stop();
+      await scheduler.waitForIdle();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/stalled-cursor.test.ts
+++ b/tests/stalled-cursor.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { Scheduler } from '../dist/scheduler';
+import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './helpers/fixture';
+
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+
+describeEachMode('Stalled reclaim cursor', (CONNECTION) => {
+  let cleanupClient: any;
+  const queueName = `stalled-cursor-${Date.now()}`;
+  const group = 'broadcast-cursor';
+  const jobCount = 101;
+  const stalledInterval = 60_000;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    if (!cleanupClient) return;
+    await flushQueue(cleanupClient, queueName);
+    await cleanupClient.close();
+  });
+
+  it('continues a full reclaim page before the next stalled interval', async () => {
+    const keys = buildKeys(queueName);
+    const jobIds = Array.from({ length: jobCount }, (_, index) => `job-${index}`);
+    const entryIds: string[] = [];
+
+    for (const jobId of jobIds) {
+      await cleanupClient.hset(keys.job(jobId), {
+        id: jobId,
+        name: 'stalled',
+        state: 'active',
+        lastActive: '0',
+      });
+      entryIds.push(
+        String(
+          await cleanupClient.xadd(keys.stream, [
+            ['jobId', jobId],
+            ['name', 'stalled'],
+          ]),
+        ),
+      );
+    }
+    await cleanupClient.xgroupCreate(keys.stream, group, '0', { mkStream: true });
+    const claimed = await cleanupClient.xreadgroup(group, 'stalled-owner', { [keys.stream]: '>' }, { count: jobCount });
+    expect(claimed).not.toBeNull();
+    await cleanupClient.xclaim(keys.stream, group, 'stalled-owner', 0, entryIds, {
+      idle: stalledInterval,
+    });
+
+    const scheduler = new Scheduler(cleanupClient, keys, {
+      stalledInterval,
+      lockDuration: stalledInterval,
+      maxStalledCount: 10,
+      consumerGroup: group,
+      broadcastMode: true,
+    });
+    scheduler.start();
+
+    try {
+      await waitFor(
+        async () => (await cleanupClient.hget(keys.job(jobIds[jobCount - 1]), 'stalledCount')) === '1',
+        5000,
+        25,
+      );
+      expect(Number(await cleanupClient.hget(keys.job(jobIds[0]), 'stalledCount'))).toBe(1);
+    } finally {
+      scheduler.stop();
+      await scheduler.waitForIdle();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- persist the XAUTOCLAIM cursor per consumer group in queue metadata
- continue bounded stalled scans instead of repeatedly reclaiming only the first 100 entries
- add standalone cursor-progression coverage

## Red-first proof
The first commit is test-only. Against its parent, the second reclaim returned the first page again instead of progressing to the remaining job.

## Validation
- focused standalone regression
- build, typecheck, lint, format, diff check

Local cluster port 7000 is unavailable; cluster coverage will run in CI.

## Known CI dependency

The upstream `codecov/patch` check is blocked by the base-workflow issue fixed in [#272](https://github.com/avifenesh/glide-mq/pull/272): the unquoted fuzzer glob changes the integration coverage selection, and the coverage uploads need the corrected authentication. The identical head passes every test and 97.44% patch coverage in companion fork PR [#17](https://github.com/jonathanong/glide-mq/pull/17). Merge #272, allow the resulting `main` coverage run to complete, then rebase this branch onto updated `main` and rerun CI. This is CI plumbing, not missing integration-test coverage.

### Coverage comparison

| Context | Patch coverage |
|---|---:|
| Current upstream run | 64.10% |
| [Identical-head fork PR #17](https://github.com/jonathanong/glide-mq/pull/17) | 97.44% |