### PR TITLE
ci: make coverage uploads tokenless and preserve fuzzer exclusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
     timeout-minutes: 40
     permissions:
       contents: read
+      id-token: write
     strategy:
       matrix:
         node-version: [20, 22]
@@ -142,7 +143,7 @@ jobs:
           --exclude 'tests/worker-saturation.test.ts'
           --exclude 'tests/worker.test.ts'
           --exclude 'tests/search-index.test.ts'
-          ${{ matrix.node-version == '22' && '--exclude tests/fuzzer/**' || '' }}
+          ${{ matrix.node-version == '22' && '--exclude "tests/fuzzer/**"' || '' }}
 
       - name: Upload coverage
         if: ${{ !cancelled() && matrix.node-version == '22' }}
@@ -151,7 +152,7 @@ jobs:
           files: coverage/lcov.info
           flags: integration
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
 
   test-lua-coverage:
     needs: quality
@@ -159,6 +160,7 @@ jobs:
     timeout-minutes: 40
     permissions:
       contents: read
+      id-token: write
     services:
       valkey:
         image: valkey/valkey:9.1.0
@@ -216,7 +218,7 @@ jobs:
           files: coverage/lua.info
           flags: lua
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
 
   test-search:
     needs: quality

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,6 +2,7 @@
 
 ## Current State
 
+- **In flight**: coverage CI quotes the fuzzer exclusion and uses Codecov OIDC (`id-token: write`, `use_oidc: true`) for integration and Lua uploads.
 - **Branch**: `ci/lua-coverage`, top of the coverage stack.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
 - **CI**: green across all six fork/upstream stack PRs after the 2026-08-22 packaging update.

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -1,0 +1,40 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readCiWorkflow(): string {
+  const ref = process.env.CI_WORKFLOW_REF;
+  if (ref) {
+    return execFileSync('git', ['show', `${ref}:.github/workflows/ci.yml`], { encoding: 'utf8' });
+  }
+  return readFileSync(join(process.cwd(), '.github/workflows/ci.yml'), 'utf8');
+}
+
+describe('CI workflow', () => {
+  it('passes the fuzzer exclusion to Vitest as one shell-quoted argument', () => {
+    const workflow = readCiWorkflow();
+    const integrationJob = workflow.slice(
+      workflow.indexOf('  test-integration:'),
+      workflow.indexOf('  test-lua-coverage:'),
+    );
+
+    expect(integrationJob).toContain("${{ matrix.node-version == '22' && '--exclude \"tests/fuzzer/**\"' || '' }}");
+    expect(integrationJob).not.toContain("'--exclude tests/fuzzer/**'");
+  });
+
+  it('uses Codecov OIDC for coverage uploads', () => {
+    const workflow = readCiWorkflow();
+    const integrationJob = workflow.slice(
+      workflow.indexOf('  test-integration:'),
+      workflow.indexOf('  test-lua-coverage:'),
+    );
+    const luaCoverageJob = workflow.slice(workflow.indexOf('  test-lua-coverage:'), workflow.indexOf('  test-search:'));
+
+    for (const job of [integrationJob, luaCoverageJob]) {
+      expect(job).toContain('id-token: write');
+      expect(job).toContain('use_oidc: true');
+      expect(job).not.toContain('token: ${{ secrets.CODECOV_TOKEN }}');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- quote the conditional Node 22 fuzzer exclusion so Vitest receives one glob argument
- upload Codecov reports through GitHub OIDC instead of a repository token
- add workflow regression coverage

## Red-first proof
The first commit is test-only. Against its parent, the workflow regression reported the unquoted exclusion and missing OIDC configuration.

## Validation
- CI workflow regression test
- build, typecheck, lint, format, diff check
- Codecov configuration verified against the official action contract.

## Merge impact

Merge this PR before [#269](https://github.com/avifenesh/glide-mq/pull/269), [#270](https://github.com/avifenesh/glide-mq/pull/270), [#271](https://github.com/avifenesh/glide-mq/pull/271), [#273](https://github.com/avifenesh/glide-mq/pull/273), and [#276](https://github.com/avifenesh/glide-mq/pull/276). Their identical-head companion PRs prove patch coverage above 92%, but their upstream Codecov checks cannot consume the corrected integration coverage until this workflow lands on `main`. After merge, allow the `main` coverage run to complete, then rerun or rebase those five PRs. Companion validation: [fork PR #10](https://github.com/jonathanong/glide-mq/pull/10).