### PR TITLE
fix: return all waiting dispatch sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - `getJobs('waiting')` now follows worker dispatch order across priority, LIFO, and FIFO sources, excludes pending stream entries, and does not expose revoked or removed list jobs.
-- `Job.remove()` skips the FIFO stream scan for waiting LIFO and priority jobs, avoiding an unnecessary O(stream-length) operation.
+- Job removal and revocation scan the FIFO stream only when the waiting job was absent from both list-backed sources, avoiding unnecessary O(stream-length) work without orphaning stream entries whose legacy source fields are stale.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - `getJobs('waiting')` now follows worker dispatch order across priority, LIFO, and FIFO sources, excludes pending stream entries, and does not expose revoked or removed list jobs.
+- `Job.remove()` skips the FIFO stream scan for waiting LIFO and priority jobs, avoiding an unnecessary O(stream-length) operation.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- `getJobs('waiting')` now follows worker dispatch order across priority, LIFO, and FIFO sources, excludes pending stream entries, and does not expose revoked or removed list jobs.
+
+---
+
 ## [0.15.4] - 2026-06-04
 
 ### Fixed

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,10 +2,10 @@
 
 ## Current State
 
-- **Branch**: `ci/lua-coverage`, top of the coverage stack.
+- **Branch**: `fix/get-jobs-waiting`, based directly on `upstream/main`.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
-- **CI**: green across all six fork/upstream stack PRs after the 2026-08-22 packaging update.
-- **Local branches**: `refactor/extract-lua-library` -> `ci/ts-coverage` -> `ci/lua-coverage`.
+- **Validation**: waiting-source integration tests pass on isolated standalone Valkey; fork and upstream CI are pending.
+- **Unreleased**: `getJobs('waiting')` reads priority, LIFO, and non-pending FIFO sources; revoke/remove clean list entries. Server-function library identity is `108`.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -44,3 +44,4 @@ See CHANGELOG.md `0.15.4` for the full list. Highlights:
 - streamChunk: thin wrapper over stream(), not new infrastructure.
 - Search 1.1+ options: forward-compatible types, graceful skip on older servers.
 - Plugins: AI endpoints under `/flows/:id/usage`, `/flows/:id/budget`, `/jobs/:id/stream`.
+- **In flight**: `Queue.getJobs('waiting')` follows worker dispatch order across priority, LIFO, and FIFO sources; it pages FIFO stream reads and excludes entries in the consumer-group PEL.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -5,7 +5,7 @@
 - **Branch**: `fix/get-jobs-waiting`, based directly on `upstream/main`.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
 - **Validation**: waiting-source integration tests pass on isolated standalone Valkey; fork and upstream CI are pending.
-- **Unreleased**: `getJobs('waiting')` reads priority, LIFO, and non-pending FIFO sources; revoke/remove clean list entries. Server-function library identity is `108`.
+- **Unreleased**: `getJobs('waiting')` reads priority, LIFO, and non-pending FIFO sources; revoke/remove clean list entries. Server-function library identity is `110`.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -5,7 +5,7 @@
 - **Branch**: `fix/get-jobs-waiting`, based directly on `upstream/main`.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
 - **Validation**: waiting-source integration tests pass on isolated standalone Valkey; fork and upstream CI are pending.
-- **Unreleased**: `getJobs('waiting')` reads priority, LIFO, and non-pending FIFO sources; revoke/remove clean list entries. List-backed removals skip the FIFO stream scan. Server-function library identity is `111`.
+- **Unreleased**: `getJobs('waiting')` reads priority, LIFO, and non-pending FIFO sources; revoke/remove clean list entries. Removal and revocation route FIFO cleanup by actual list membership so list-backed jobs skip the scan while stale source fields cannot orphan stream entries. Server-function library identity is `112`.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -5,7 +5,7 @@
 - **Branch**: `fix/get-jobs-waiting`, based directly on `upstream/main`.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
 - **Validation**: waiting-source integration tests pass on isolated standalone Valkey; fork and upstream CI are pending.
-- **Unreleased**: `getJobs('waiting')` reads priority, LIFO, and non-pending FIFO sources; revoke/remove clean list entries. Server-function library identity is `110`.
+- **Unreleased**: `getJobs('waiting')` reads priority, LIFO, and non-pending FIFO sources; revoke/remove clean list entries. List-backed removals skip the FIFO stream scan. Server-function library identity is `111`.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -2645,6 +2645,8 @@ redis.register_function('glidemq_removeJob', function(keys, args)
   local failedKey = keys[5]
   local eventsKey = keys[6]
   local logKey = keys[7]
+  local lifoKey = keys[8]
+  local priorityKey = keys[9]
   local jobId = args[1]
   local exists = redis.call('EXISTS', jobKey)
   if exists == 0 then
@@ -2673,6 +2675,8 @@ redis.register_function('glidemq_removeJob', function(keys, args)
   redis.call('ZREM', scheduledKey, jobId)
   redis.call('ZREM', completedKey, jobId)
   redis.call('ZREM', failedKey, jobId)
+  redis.call('LREM', lifoKey, 0, jobId)
+  redis.call('LREM', priorityKey, 0, jobId)
   markOrderingDone(jobKey, jobId)
   -- Clean up DAG parents SET, per-job streaming channel, and signals.
   -- Job hash + log can be MB-sized; parents/jstream/signals carry per-step
@@ -2716,6 +2720,8 @@ redis.register_function('glidemq_revoke', function(keys, args)
   local scheduledKey = keys[3]
   local failedKey = keys[4]
   local eventsKey = keys[5]
+  local lifoKey = keys[6]
+  local priorityKey = keys[7]
   local jobId = args[1]
   local timestamp = tonumber(args[2])
   local group = args[3]
@@ -2743,6 +2749,8 @@ redis.register_function('glidemq_revoke', function(keys, args)
   end
   if state == 'waiting' or state == 'delayed' or state == 'prioritized' then
     redis.call('ZREM', scheduledKey, jobId)
+    redis.call('LREM', lifoKey, 0, jobId)
+    redis.call('LREM', priorityKey, 0, jobId)
     local cursor = '-'
     local found = false
     while not found do

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -2645,20 +2645,18 @@ redis.register_function('glidemq_removeJob', function(keys, args)
   local failedKey = keys[5]
   local eventsKey = keys[6]
   local logKey = keys[7]
-  local lifoKey = keys[8]
-  local priorityKey = keys[9]
   local jobId = args[1]
   local exists = redis.call('EXISTS', jobKey)
   if exists == 0 then
     return 0
   end
   local state = redis.call('HGET', jobKey, 'state')
+  local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
   local groupKey = redis.call('HGET', jobKey, 'groupKey')
   if groupKey and groupKey ~= '' then
     if state == 'active' then
       releaseGroupSlotAndPromote(jobKey, jobId, 0)
     elseif state == 'group-waiting' then
-      local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
       local waitListKey = prefix .. 'groupq:' .. groupKey
       redis.call('ZREM', waitListKey, jobId)
     end
@@ -2675,11 +2673,36 @@ redis.register_function('glidemq_removeJob', function(keys, args)
   redis.call('ZREM', scheduledKey, jobId)
   redis.call('ZREM', completedKey, jobId)
   redis.call('ZREM', failedKey, jobId)
-  -- Keep accepting the pre-108 seven-key call shape during rolling upgrades.
-  -- Older workers do not pass the list-backed waiting keys.
-  if lifoKey then redis.call('LREM', lifoKey, 0, jobId) end
-  if priorityKey then redis.call('LREM', priorityKey, 0, jobId) end
+  -- Derive list keys from the job key so the pre-108 seven-key call shape
+  -- remains valid during rolling upgrades.
+  redis.call('LREM', prefix .. 'lifo', 0, jobId)
+  redis.call('LREM', prefix .. 'priority', 0, jobId)
   markOrderingDone(jobKey, jobId)
+  if state == 'waiting' then
+    local cursor = '-'
+    local found = false
+    while not found do
+      local entries = redis.call('XRANGE', streamKey, cursor, '+', 'COUNT', 1000)
+      if #entries == 0 then break end
+      for i = 1, #entries do
+        local entryId = entries[i][1]
+        local fields = entries[i][2]
+        for j = 1, #fields, 2 do
+          if fields[j] == 'jobId' and fields[j + 1] == jobId then
+            redis.call('XDEL', streamKey, entryId)
+            found = true
+            break
+          end
+        end
+        if found then break end
+      end
+      if not found then
+        local lastId = entries[#entries][1]
+        local dashPos = lastId:find('-')
+        cursor = lastId:sub(1, dashPos) .. tostring(tonumber(lastId:sub(dashPos + 1)) + 1)
+      end
+    end
+  end
   -- Clean up DAG parents SET, per-job streaming channel, and signals.
   -- Job hash + log can be MB-sized; parents/jstream/signals carry per-step
   -- data. Use UNLINK so the server reclaims memory off the main thread.
@@ -2722,8 +2745,6 @@ redis.register_function('glidemq_revoke', function(keys, args)
   local scheduledKey = keys[3]
   local failedKey = keys[4]
   local eventsKey = keys[5]
-  local lifoKey = keys[6]
-  local priorityKey = keys[7]
   local jobId = args[1]
   local timestamp = tonumber(args[2])
   local group = args[3]
@@ -2733,10 +2754,10 @@ redis.register_function('glidemq_revoke', function(keys, args)
   end
   redis.call('HSET', jobKey, 'revoked', '1')
   local state = redis.call('HGET', jobKey, 'state')
+  local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
   if state == 'group-waiting' then
     local gk = redis.call('HGET', jobKey, 'groupKey')
     if gk and gk ~= '' then
-      local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
       local waitListKey = prefix .. 'groupq:' .. gk
       redis.call('ZREM', waitListKey, jobId)
     end
@@ -2751,8 +2772,8 @@ redis.register_function('glidemq_revoke', function(keys, args)
   end
   if state == 'waiting' or state == 'delayed' or state == 'prioritized' then
     redis.call('ZREM', scheduledKey, jobId)
-    redis.call('LREM', lifoKey, 0, jobId)
-    redis.call('LREM', priorityKey, 0, jobId)
+    redis.call('LREM', prefix .. 'lifo', 0, jobId)
+    redis.call('LREM', prefix .. 'priority', 0, jobId)
     local cursor = '-'
     local found = false
     while not found do

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -2675,8 +2675,10 @@ redis.register_function('glidemq_removeJob', function(keys, args)
   redis.call('ZREM', scheduledKey, jobId)
   redis.call('ZREM', completedKey, jobId)
   redis.call('ZREM', failedKey, jobId)
-  redis.call('LREM', lifoKey, 0, jobId)
-  redis.call('LREM', priorityKey, 0, jobId)
+  -- Keep accepting the pre-108 seven-key call shape during rolling upgrades.
+  -- Older workers do not pass the list-backed waiting keys.
+  if lifoKey then redis.call('LREM', lifoKey, 0, jobId) end
+  if priorityKey then redis.call('LREM', priorityKey, 0, jobId) end
   markOrderingDone(jobKey, jobId)
   -- Clean up DAG parents SET, per-job streaming channel, and signals.
   -- Job hash + log can be MB-sized; parents/jstream/signals carry per-step

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -2678,7 +2678,9 @@ redis.register_function('glidemq_removeJob', function(keys, args)
   redis.call('LREM', prefix .. 'lifo', 0, jobId)
   redis.call('LREM', prefix .. 'priority', 0, jobId)
   markOrderingDone(jobKey, jobId)
-  if state == 'waiting' then
+  local jobLifo = redis.call('HGET', jobKey, 'lifo')
+  local jobPriority = tonumber(redis.call('HGET', jobKey, 'priority')) or 0
+  if state == 'waiting' and jobLifo ~= '1' and jobPriority <= 0 then
     local cursor = '-'
     local found = false
     while not found do

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -2675,12 +2675,10 @@ redis.register_function('glidemq_removeJob', function(keys, args)
   redis.call('ZREM', failedKey, jobId)
   -- Derive list keys from the job key so the pre-108 seven-key call shape
   -- remains valid during rolling upgrades.
-  redis.call('LREM', prefix .. 'lifo', 0, jobId)
-  redis.call('LREM', prefix .. 'priority', 0, jobId)
+  local removedLifo = redis.call('LREM', prefix .. 'lifo', 0, jobId)
+  local removedPriority = redis.call('LREM', prefix .. 'priority', 0, jobId)
   markOrderingDone(jobKey, jobId)
-  local jobLifo = redis.call('HGET', jobKey, 'lifo')
-  local jobPriority = tonumber(redis.call('HGET', jobKey, 'priority')) or 0
-  if state == 'waiting' and jobLifo ~= '1' and jobPriority <= 0 then
+  if state == 'waiting' and removedLifo == 0 and removedPriority == 0 then
     local cursor = '-'
     local found = false
     while not found do
@@ -2774,30 +2772,32 @@ redis.register_function('glidemq_revoke', function(keys, args)
   end
   if state == 'waiting' or state == 'delayed' or state == 'prioritized' then
     redis.call('ZREM', scheduledKey, jobId)
-    redis.call('LREM', prefix .. 'lifo', 0, jobId)
-    redis.call('LREM', prefix .. 'priority', 0, jobId)
-    local cursor = '-'
-    local found = false
-    while not found do
-      local entries = redis.call('XRANGE', streamKey, cursor, '+', 'COUNT', 1000)
-      if #entries == 0 then break end
-      for i = 1, #entries do
-        local entryId = entries[i][1]
-        local fields = entries[i][2]
-        for j = 1, #fields, 2 do
-          if fields[j] == 'jobId' and fields[j+1] == jobId then
-            if entryId ~= '' then redis.call('XACK', streamKey, group, entryId) end
-            if entryId ~= '' then redis.call('XDEL', streamKey, entryId) end
-            found = true
-            break
+    local removedLifo = redis.call('LREM', prefix .. 'lifo', 0, jobId)
+    local removedPriority = redis.call('LREM', prefix .. 'priority', 0, jobId)
+    if state == 'waiting' and removedLifo == 0 and removedPriority == 0 then
+      local cursor = '-'
+      local found = false
+      while not found do
+        local entries = redis.call('XRANGE', streamKey, cursor, '+', 'COUNT', 1000)
+        if #entries == 0 then break end
+        for i = 1, #entries do
+          local entryId = entries[i][1]
+          local fields = entries[i][2]
+          for j = 1, #fields, 2 do
+            if fields[j] == 'jobId' and fields[j+1] == jobId then
+              if entryId ~= '' then redis.call('XACK', streamKey, group, entryId) end
+              if entryId ~= '' then redis.call('XDEL', streamKey, entryId) end
+              found = true
+              break
+            end
           end
+          if found then break end
         end
-        if found then break end
-      end
-      if not found then
-        local lastId = entries[#entries][1]
-        local dashPos = lastId:find('-')
-        cursor = lastId:sub(1, dashPos) .. tostring(tonumber(lastId:sub(dashPos + 1)) + 1)
+        if not found then
+          local lastId = entries[#entries][1]
+          local dashPos = lastId:find('-')
+          cursor = lastId:sub(1, dashPos) .. tostring(tonumber(lastId:sub(dashPos + 1)) + 1)
+        end
       end
     end
     redis.call('ZADD', failedKey, timestamp, jobId)

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -57,6 +57,7 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 108: revoke/remove delete list-backed waiting entries so getJobs pagination cannot expose or count stale jobs.
 // Version 110: derive list keys in remove/revoke and remove waiting FIFO stream entries.
 // Version 111: skip the FIFO stream scan when removing list-backed waiting jobs.
+// Version 112: route remove/revoke FIFO cleanup by actual waiting-list membership.
 export const LIBRARY_VERSION = '112';
 
 // Consumer group name used by workers

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -55,7 +55,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
 // Version 108: revoke/remove delete list-backed waiting entries so getJobs pagination cannot expose or count stale jobs.
-export const LIBRARY_VERSION = '108';
+// Version 109: keep glidemq_removeJob compatible with pre-108 callers that pass seven keys.
+export const LIBRARY_VERSION = '109';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -56,7 +56,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
 // Version 108: revoke/remove delete list-backed waiting entries so getJobs pagination cannot expose or count stale jobs.
 // Version 110: derive list keys in remove/revoke and remove waiting FIFO stream entries.
-export const LIBRARY_VERSION = '110';
+// Version 111: skip the FIFO stream scan when removing list-backed waiting jobs.
+export const LIBRARY_VERSION = '111';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -55,8 +55,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
 // Version 108: revoke/remove delete list-backed waiting entries so getJobs pagination cannot expose or count stale jobs.
-// Version 109: keep glidemq_removeJob compatible with pre-108 callers that pass seven keys.
-export const LIBRARY_VERSION = '109';
+// Version 110: derive list keys in remove/revoke and remove waiting FIFO stream entries.
+export const LIBRARY_VERSION = '110';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -824,7 +824,7 @@ export async function deferActive(
 export async function removeJob(client: Client, k: QueueKeys, jobId: string): Promise<number> {
   const result = await client.fcall(
     'glidemq_removeJob',
-    [k.job(jobId), k.stream, k.scheduled, k.completed, k.failed, k.events, k.log(jobId), k.lifo, k.priority],
+    [k.job(jobId), k.stream, k.scheduled, k.completed, k.failed, k.events, k.log(jobId)],
     [jobId],
   );
   return result as number;
@@ -905,7 +905,7 @@ export async function revokeJob(
 ): Promise<string> {
   const result = await client.fcall(
     'glidemq_revoke',
-    [k.job(jobId), k.stream, k.scheduled, k.failed, k.events, k.lifo, k.priority],
+    [k.job(jobId), k.stream, k.scheduled, k.failed, k.events],
     [jobId, timestamp.toString(), group],
   );
   return result as string;

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -57,7 +57,7 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 108: revoke/remove delete list-backed waiting entries so getJobs pagination cannot expose or count stale jobs.
 // Version 110: derive list keys in remove/revoke and remove waiting FIFO stream entries.
 // Version 111: skip the FIFO stream scan when removing list-backed waiting jobs.
-export const LIBRARY_VERSION = '111';
+export const LIBRARY_VERSION = '112';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -54,7 +54,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#242).
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
-export const LIBRARY_VERSION = '93';
+// Version 108: revoke/remove delete list-backed waiting entries so getJobs pagination cannot expose or count stale jobs.
+export const LIBRARY_VERSION = '108';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -822,7 +823,7 @@ export async function deferActive(
 export async function removeJob(client: Client, k: QueueKeys, jobId: string): Promise<number> {
   const result = await client.fcall(
     'glidemq_removeJob',
-    [k.job(jobId), k.stream, k.scheduled, k.completed, k.failed, k.events, k.log(jobId)],
+    [k.job(jobId), k.stream, k.scheduled, k.completed, k.failed, k.events, k.log(jobId), k.lifo, k.priority],
     [jobId],
   );
   return result as number;
@@ -903,7 +904,7 @@ export async function revokeJob(
 ): Promise<string> {
   const result = await client.fcall(
     'glidemq_revoke',
-    [k.job(jobId), k.stream, k.scheduled, k.failed, k.events],
+    [k.job(jobId), k.stream, k.scheduled, k.failed, k.events, k.lifo, k.priority],
     [jobId, timestamp.toString(), group],
   );
   return result as string;

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -417,7 +417,9 @@ export class Queue<D = any, R = any> extends EventEmitter {
       InfBoundary.NegativeInfinity;
 
     while (limit < 0 || jobIds.length < limit) {
-      const count = limit < 0 ? PIPELINE_CHUNK_SIZE : limit - jobIds.length;
+      // Read a full chunk even for limited pages so a run of PEL entries does
+      // not turn into one XRANGE/XPENDING round trip per in-flight job.
+      const count = PIPELINE_CHUNK_SIZE;
       const entries = await client.xrange(this.keys.stream, streamStart, InfBoundary.PositiveInfinity, { count });
       if (!entries) break;
 
@@ -432,7 +434,8 @@ export class Queue<D = any, R = any> extends EventEmitter {
       for (const entryId of entryIds) {
         if (!pendingEntryIds.has(entryId)) waitingEntries[entryId] = entries[entryId]!;
       }
-      jobIds.push(...extractJobIdsFromStreamEntries(waitingEntries));
+      const waitingIds = extractJobIdsFromStreamEntries(waitingEntries);
+      jobIds.push(...(limit < 0 ? waitingIds : waitingIds.slice(0, limit - jobIds.length)));
 
       if (entryIds.length < count) break;
       streamStart = { value: lastEntryId, isInclusive: false };

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -383,7 +383,29 @@ export class Queue<D = any, R = any> extends EventEmitter {
   private async getWaitingListJobIds(client: Client, key: string, limit: number): Promise<string[]> {
     if (limit === 0) return [];
     const ids = await client.lrange(key, limit < 0 ? 0 : -limit, -1);
-    return ids.map((id) => String(id)).reverse();
+    return ids.map(String).reverse();
+  }
+
+  /** @internal Read every pending entry ID in an inclusive stream range. */
+  private async getPendingEntryIds(client: Client, firstEntryId: string, lastEntryId: string): Promise<Set<string>> {
+    const pendingEntryIds = new Set<string>();
+    try {
+      let pendingStart: { value: string; isInclusive?: boolean } = { value: firstEntryId };
+      while (true) {
+        const pendingEntries = await client.xpendingWithOptions(this.keys.stream, CONSUMER_GROUP, {
+          start: pendingStart,
+          end: { value: lastEntryId },
+          count: PIPELINE_CHUNK_SIZE,
+        });
+        for (const [entryId] of pendingEntries) pendingEntryIds.add(String(entryId));
+        if (pendingEntries.length < PIPELINE_CHUNK_SIZE) return pendingEntryIds;
+        pendingStart = { value: String(pendingEntries.at(-1)![0]), isInclusive: false };
+      }
+    } catch (err) {
+      // The stream can legitimately have no consumer group before any worker starts.
+      if (err instanceof RequestError && err.message.startsWith('NOGROUP')) return pendingEntryIds;
+      throw err;
+    }
   }
 
   /** @internal Read FIFO waiting jobs while excluding entries in the consumer-group PEL. */
@@ -403,24 +425,8 @@ export class Queue<D = any, R = any> extends EventEmitter {
       if (entryIds.length === 0) break;
 
       const firstEntryId = entryIds[0]!;
-      const lastEntryId = entryIds[entryIds.length - 1]!;
-      const pendingEntryIds = new Set<string>();
-      try {
-        let pendingStart: { value: string; isInclusive?: boolean } = { value: firstEntryId };
-        while (true) {
-          const pendingEntries = await client.xpendingWithOptions(this.keys.stream, CONSUMER_GROUP, {
-            start: pendingStart,
-            end: { value: lastEntryId },
-            count: PIPELINE_CHUNK_SIZE,
-          });
-          for (const [entryId] of pendingEntries) pendingEntryIds.add(String(entryId));
-          if (pendingEntries.length < PIPELINE_CHUNK_SIZE) break;
-          pendingStart = { value: String(pendingEntries[pendingEntries.length - 1]![0]), isInclusive: false };
-        }
-      } catch (err) {
-        // The stream can legitimately have no consumer group before any worker starts.
-        if (!(err instanceof RequestError) || !err.message.startsWith('NOGROUP')) throw err;
-      }
+      const lastEntryId = entryIds.at(-1)!;
+      const pendingEntryIds = await this.getPendingEntryIds(client, firstEntryId, lastEntryId);
 
       const waitingEntries: Record<string, [unknown, unknown][]> = {};
       for (const entryId of entryIds) {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -404,14 +404,19 @@ export class Queue<D = any, R = any> extends EventEmitter {
 
       const firstEntryId = entryIds[0]!;
       const lastEntryId = entryIds[entryIds.length - 1]!;
-      let pendingEntryIds = new Set<string>();
+      const pendingEntryIds = new Set<string>();
       try {
-        const pendingEntries = await client.xpendingWithOptions(this.keys.stream, CONSUMER_GROUP, {
-          start: { value: firstEntryId },
-          end: { value: lastEntryId },
-          count: entryIds.length,
-        });
-        pendingEntryIds = new Set(pendingEntries.map(([entryId]) => String(entryId)));
+        let pendingStart: { value: string; isInclusive?: boolean } = { value: firstEntryId };
+        while (true) {
+          const pendingEntries = await client.xpendingWithOptions(this.keys.stream, CONSUMER_GROUP, {
+            start: pendingStart,
+            end: { value: lastEntryId },
+            count: PIPELINE_CHUNK_SIZE,
+          });
+          for (const [entryId] of pendingEntries) pendingEntryIds.add(String(entryId));
+          if (pendingEntries.length < PIPELINE_CHUNK_SIZE) break;
+          pendingStart = { value: String(pendingEntries[pendingEntries.length - 1]![0]), isInclusive: false };
+        }
       } catch (err) {
         // The stream can legitimately have no consumer group before any worker starts.
         if (!(err instanceof RequestError) || !err.message.startsWith('NOGROUP')) throw err;

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,6 +1,14 @@
 import { EventEmitter } from 'events';
 import { randomBytes } from 'crypto';
-import { InfBoundary, Batch, ClusterBatch, ClusterScanCursor, GlideFt, SortOrder } from '@glidemq/speedkey';
+import {
+  InfBoundary,
+  Batch,
+  ClusterBatch,
+  ClusterScanCursor,
+  GlideFt,
+  RequestError,
+  SortOrder,
+} from '@glidemq/speedkey';
 import type { GlideClient, GlideClusterClient, Field, FtCreateOptions } from '@glidemq/speedkey';
 import type {
   QueueOptions,
@@ -368,6 +376,57 @@ export class Queue<D = any, R = any> extends EventEmitter {
         jobIds.push(...extractJobIdsFromStreamEntries(result as any));
       }
     }
+    return jobIds;
+  }
+
+  /** @internal Read list-backed waiting jobs in the same order workers RPOP them. */
+  private async getWaitingListJobIds(client: Client, key: string, limit: number): Promise<string[]> {
+    if (limit === 0) return [];
+    const ids = await client.lrange(key, limit < 0 ? 0 : -limit, -1);
+    return ids.map((id) => String(id)).reverse();
+  }
+
+  /** @internal Read FIFO waiting jobs while excluding entries in the consumer-group PEL. */
+  private async getWaitingStreamJobIds(client: Client, limit: number): Promise<string[]> {
+    if (limit === 0) return [];
+
+    const jobIds: string[] = [];
+    let streamStart: typeof InfBoundary.NegativeInfinity | { value: string; isInclusive: false } =
+      InfBoundary.NegativeInfinity;
+
+    while (limit < 0 || jobIds.length < limit) {
+      const count = limit < 0 ? PIPELINE_CHUNK_SIZE : limit - jobIds.length;
+      const entries = await client.xrange(this.keys.stream, streamStart, InfBoundary.PositiveInfinity, { count });
+      if (!entries) break;
+
+      const entryIds = Object.keys(entries);
+      if (entryIds.length === 0) break;
+
+      const firstEntryId = entryIds[0]!;
+      const lastEntryId = entryIds[entryIds.length - 1]!;
+      let pendingEntryIds = new Set<string>();
+      try {
+        const pendingEntries = await client.xpendingWithOptions(this.keys.stream, CONSUMER_GROUP, {
+          start: { value: firstEntryId },
+          end: { value: lastEntryId },
+          count: entryIds.length,
+        });
+        pendingEntryIds = new Set(pendingEntries.map(([entryId]) => String(entryId)));
+      } catch (err) {
+        // The stream can legitimately have no consumer group before any worker starts.
+        if (!(err instanceof RequestError) || !err.message.startsWith('NOGROUP')) throw err;
+      }
+
+      const waitingEntries: Record<string, [unknown, unknown][]> = {};
+      for (const entryId of entryIds) {
+        if (!pendingEntryIds.has(entryId)) waitingEntries[entryId] = entries[entryId]!;
+      }
+      jobIds.push(...extractJobIdsFromStreamEntries(waitingEntries));
+
+      if (entryIds.length < count) break;
+      streamStart = { value: lastEntryId, isInclusive: false };
+    }
+
     return jobIds;
   }
 
@@ -1795,18 +1854,15 @@ export class Queue<D = any, R = any> extends EventEmitter {
 
     switch (type) {
       case 'waiting': {
-        // Note: stream pagination reads from start to end+1, then slices.
-        // For large offsets this is O(end) rather than O(end-start).
-        // Consider cursor-based pagination for better performance at scale.
-        const entries = await client.xrange(
-          this.keys.stream,
-          InfBoundary.NegativeInfinity,
-          InfBoundary.PositiveInfinity,
-          end >= 0 ? { count: end + 1 } : undefined,
-        );
-        if (!entries) return [];
-        const allIds = extractJobIdsFromStreamEntries(entries);
-        jobIds = allIds.slice(start, end >= 0 ? end + 1 : undefined);
+        // Workers dispatch priority, then LIFO, then FIFO jobs. Read each source
+        // only through the requested inclusive end index before applying start.
+        const limit = end >= 0 ? end + 1 : -1;
+        const priorityJobIds = await this.getWaitingListJobIds(client, this.keys.priority, limit);
+        const lifoLimit = limit < 0 ? -1 : Math.max(0, limit - priorityJobIds.length);
+        const lifoJobIds = await this.getWaitingListJobIds(client, this.keys.lifo, lifoLimit);
+        const fifoLimit = limit < 0 ? -1 : Math.max(0, lifoLimit - lifoJobIds.length);
+        const fifoJobIds = await this.getWaitingStreamJobIds(client, fifoLimit);
+        jobIds = priorityJobIds.concat(lifoJobIds, fifoJobIds).slice(start, end >= 0 ? end + 1 : undefined);
         break;
       }
       case 'active': {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -435,6 +435,16 @@ export class Queue<D = any, R = any> extends EventEmitter {
     return jobIds;
   }
 
+  /** @internal Read waiting jobs in worker dispatch order across all backing structures. */
+  private async getWaitingJobIds(client: Client, limit: number): Promise<string[]> {
+    const priorityJobIds = await this.getWaitingListJobIds(client, this.keys.priority, limit);
+    const lifoLimit = limit < 0 ? -1 : Math.max(0, limit - priorityJobIds.length);
+    const lifoJobIds = await this.getWaitingListJobIds(client, this.keys.lifo, lifoLimit);
+    const fifoLimit = limit < 0 ? -1 : Math.max(0, lifoLimit - lifoJobIds.length);
+    const fifoJobIds = await this.getWaitingStreamJobIds(client, fifoLimit);
+    return priorityJobIds.concat(lifoJobIds, fifoJobIds);
+  }
+
   private suspendSweepLockKey(): string {
     return `${this.keys.suspended}:lock:__sweep__`;
   }
@@ -1862,12 +1872,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
         // Workers dispatch priority, then LIFO, then FIFO jobs. Read each source
         // only through the requested inclusive end index before applying start.
         const limit = end >= 0 ? end + 1 : -1;
-        const priorityJobIds = await this.getWaitingListJobIds(client, this.keys.priority, limit);
-        const lifoLimit = limit < 0 ? -1 : Math.max(0, limit - priorityJobIds.length);
-        const lifoJobIds = await this.getWaitingListJobIds(client, this.keys.lifo, lifoLimit);
-        const fifoLimit = limit < 0 ? -1 : Math.max(0, lifoLimit - lifoJobIds.length);
-        const fifoJobIds = await this.getWaitingStreamJobIds(client, fifoLimit);
-        jobIds = priorityJobIds.concat(lifoJobIds, fifoJobIds).slice(start, end >= 0 ? end + 1 : undefined);
+        jobIds = (await this.getWaitingJobIds(client, limit)).slice(start, end >= 0 ? end + 1 : undefined);
         break;
       }
       case 'active': {
@@ -1936,21 +1941,22 @@ export class Queue<D = any, R = any> extends EventEmitter {
     const client = await this.getClient();
     const limit = opts.limit ?? 100;
     const pfx = keyPrefix(this.opts.prefix ?? 'glide', this.name);
+    const hasDataFilter = opts.data && Object.keys(opts.data).length > 0;
+    const filterWaitingInJs = opts.state === 'waiting' && (Boolean(opts.name) || hasDataFilter);
 
     let jobIds: string[];
 
-    if (opts.state && opts.name) {
+    if (opts.state && opts.name && opts.state !== 'waiting') {
       // Use Lua function for name-based filtering within a state
       jobIds = await this.searchByNameInState(client, opts.state, opts.name, limit, pfx);
     } else if (opts.state) {
       // Get all IDs from the state, will filter by data below
-      jobIds = await this.getJobIdsForState(client, opts.state, limit);
+      jobIds = await this.getJobIdsForState(client, opts.state, filterWaitingInJs ? -1 : limit);
     } else {
       // No state: SCAN all job hashes
       jobIds = await this.scanJobIds(client, pfx, opts.name, limit);
     }
 
-    const hasDataFilter = opts.data && Object.keys(opts.data).length > 0;
     const excludeData = opts.excludeData === true && !hasDataFilter;
     const jobs: Job<D, R>[] = [];
     const CHUNK = 100;
@@ -1974,7 +1980,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
         const job = Job.fromHash<D, R>(client, this.keys, chunk[i], hash, this.serializer, excludeData);
 
         // Apply name filter if we used a non-Lua path
-        if (opts.name && !opts.state && job.name !== opts.name) continue;
+        if (opts.name && (!opts.state || opts.state === 'waiting') && job.name !== opts.name) continue;
 
         // Apply data filter (shallow key-value match)
         if (opts.data && !matchesData(job.data as Record<string, unknown>, opts.data)) continue;
@@ -2012,14 +2018,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
   ): Promise<string[]> {
     switch (state) {
       case 'waiting': {
-        const entries = await client.xrange(
-          this.keys.stream,
-          InfBoundary.NegativeInfinity,
-          InfBoundary.PositiveInfinity,
-          { count: limit },
-        );
-        if (!entries) return [];
-        return extractJobIdsFromStreamEntries(entries);
+        return this.getWaitingJobIds(client, limit);
       }
       case 'active': {
         try {
@@ -2046,7 +2045,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
   /** @internal Use Lua searchByName within a specific state. */
   private async searchByNameInState(
     client: Client,
-    state: 'waiting' | 'active' | 'delayed' | 'completed' | 'failed',
+    state: 'active' | 'delayed' | 'completed' | 'failed',
     name: string,
     limit: number,
     pfx: string,
@@ -2062,10 +2061,6 @@ export class Queue<D = any, R = any> extends EventEmitter {
         if (String(names?.[i]) === name) matched.push(allIds[i]);
       }
       return matched;
-    }
-
-    if (state === 'waiting') {
-      return searchByName(client, this.keys.stream, 'stream', name, limit, pfx + ':');
     }
 
     return searchByName(client, this.zsetKeyForState(state), 'zset', name, limit, pfx + ':');

--- a/tests/api-completeness.test.ts
+++ b/tests/api-completeness.test.ts
@@ -373,10 +373,11 @@ describe('Queue.getJobs', () => {
       if (key.endsWith(':lifo')) return ['lifo-1', 'lifo-2'];
       return [];
     });
-    mockClient.xrange
-      .mockResolvedValueOnce({ '1-0': [['jobId', 'active-fifo']] })
-      .mockResolvedValueOnce({ '2-0': [['jobId', 'fifo-1']] });
-    mockClient.xpendingWithOptions.mockResolvedValueOnce([['1-0', 'consumer', 0, 1]]).mockResolvedValueOnce([]);
+    mockClient.xrange.mockResolvedValueOnce({
+      '1-0': [['jobId', 'active-fifo']],
+      '2-0': [['jobId', 'fifo-1']],
+    });
+    mockClient.xpendingWithOptions.mockResolvedValueOnce([['1-0', 'consumer', 0, 1]]);
 
     const queue = new Queue('getjobs-test', connOpts);
     const jobs = await queue.getJobs('waiting', 1, 4);
@@ -384,14 +385,7 @@ describe('Queue.getJobs', () => {
     expect(jobs.map((job) => job.id)).toEqual(['prio-2', 'lifo-2', 'lifo-1', 'fifo-1']);
     expect(mockClient.lrange).toHaveBeenCalledWith('glide:{getjobs-test}:priority', -5, -1);
     expect(mockClient.lrange).toHaveBeenCalledWith('glide:{getjobs-test}:lifo', -3, -1);
-    expect(mockClient.xrange).toHaveBeenNthCalledWith(1, 'glide:{getjobs-test}:stream', '-', '+', { count: 1 });
-    expect(mockClient.xrange).toHaveBeenNthCalledWith(
-      2,
-      'glide:{getjobs-test}:stream',
-      { value: '1-0', isInclusive: false },
-      '+',
-      { count: 1 },
-    );
+    expect(mockClient.xrange).toHaveBeenCalledWith('glide:{getjobs-test}:stream', '-', '+', { count: 1000 });
 
     await queue.close();
   });

--- a/tests/api-completeness.test.ts
+++ b/tests/api-completeness.test.ts
@@ -362,13 +362,7 @@ describe('Queue.getJobs', () => {
     expect(jobs.map((job) => job.id)).toEqual(['prio-2', 'lifo-2', 'lifo-1', 'fifo-1']);
     expect(mockClient.lrange).toHaveBeenCalledWith('glide:{getjobs-test}:priority', -5, -1);
     expect(mockClient.lrange).toHaveBeenCalledWith('glide:{getjobs-test}:lifo', -3, -1);
-    expect(mockClient.xrange).toHaveBeenNthCalledWith(
-      1,
-      'glide:{getjobs-test}:stream',
-      '-',
-      '+',
-      { count: 1 },
-    );
+    expect(mockClient.xrange).toHaveBeenNthCalledWith(1, 'glide:{getjobs-test}:stream', '-', '+', { count: 1 });
     expect(mockClient.xrange).toHaveBeenNthCalledWith(
       2,
       'glide:{getjobs-test}:stream',

--- a/tests/api-completeness.test.ts
+++ b/tests/api-completeness.test.ts
@@ -3,7 +3,8 @@ import { GlideClient, RequestError } from '@glidemq/speedkey';
 import { Queue } from '../src/queue';
 import { Worker } from '../src/worker';
 import { Job } from '../src/job';
-import { LIBRARY_VERSION } from '../src/functions/index';
+import { LIBRARY_VERSION, removeJob, revokeJob } from '../src/functions/index';
+import { buildKeys } from '../src/utils';
 
 // Mock speedkey module
 vi.mock('@glidemq/speedkey', () => {
@@ -301,6 +302,37 @@ describe('Queue.getJobs', () => {
     vi.clearAllMocks();
     mockClient = makeMockClient();
     vi.mocked(GlideClient.createClient).mockResolvedValue(mockClient as any);
+  });
+
+  it('passes list keys when removing or revoking waiting jobs', async () => {
+    const keys = buildKeys('getjobs-cleanup');
+    mockClient.fcall.mockResolvedValueOnce(1).mockResolvedValueOnce('revoked');
+
+    await removeJob(mockClient, keys, '1');
+    expect(mockClient.fcall).toHaveBeenNthCalledWith(
+      1,
+      'glidemq_removeJob',
+      [
+        keys.job('1'),
+        keys.stream,
+        keys.scheduled,
+        keys.completed,
+        keys.failed,
+        keys.events,
+        keys.log('1'),
+        keys.lifo,
+        keys.priority,
+      ],
+      ['1'],
+    );
+
+    await revokeJob(mockClient, keys, '2', 123, 'workers');
+    expect(mockClient.fcall).toHaveBeenNthCalledWith(
+      2,
+      'glidemq_revoke',
+      [keys.job('2'), keys.stream, keys.scheduled, keys.failed, keys.events, keys.lifo, keys.priority],
+      ['2', '123', 'workers'],
+    );
   });
 
   it('returns waiting jobs from the stream', async () => {

--- a/tests/api-completeness.test.ts
+++ b/tests/api-completeness.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { GlideClient } from '@glidemq/speedkey';
+import { GlideClient, RequestError } from '@glidemq/speedkey';
 import { Queue } from '../src/queue';
 import { Worker } from '../src/worker';
 import { Job } from '../src/job';
@@ -47,6 +47,12 @@ vi.mock('@glidemq/speedkey', () => {
       return '0';
     }
   }
+  class MockRequestError extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = 'RequestError';
+    }
+  }
   return {
     GlideClient: MockGlideClient,
     GlideClusterClient: MockGlideClusterClient,
@@ -57,6 +63,7 @@ vi.mock('@glidemq/speedkey', () => {
     Batch: MockBatch,
     ClusterBatch: MockBatch,
     ClusterScanCursor: MockClusterScanCursor,
+    RequestError: MockRequestError,
   };
 });
 
@@ -80,6 +87,7 @@ function makeMockClient(overrides: Record<string, unknown> = {}) {
     zadd: vi.fn(),
     zcard: vi.fn().mockResolvedValue(0),
     zrange: vi.fn().mockResolvedValue([]),
+    lrange: vi.fn().mockResolvedValue([]),
     del: vi.fn(),
     unlink: vi.fn(),
     scan: vi.fn().mockResolvedValue(['0', []]),
@@ -322,6 +330,63 @@ describe('Queue.getJobs', () => {
     expect(jobs).toHaveLength(2);
     expect(jobs[0].id).toBe('1');
     expect(jobs[1].id).toBe('2');
+
+    await queue.close();
+  });
+
+  it('returns waiting jobs from every dispatch source and skips pending stream entries', async () => {
+    const hashes: Record<string, { field: string; value: string }[]> = {};
+    for (const id of ['prio-1', 'prio-2', 'lifo-2', 'lifo-1', 'fifo-1']) {
+      hashes[`glide:{getjobs-test}:job:${id}`] = [
+        { field: 'id', value: id },
+        { field: 'name', value: id },
+        { field: 'data', value: '{}' },
+        { field: 'opts', value: '{}' },
+        { field: 'state', value: 'waiting' },
+      ];
+    }
+    mockClient.hgetall.mockImplementation(async (key: string) => hashes[key] ?? []);
+    mockClient.lrange.mockImplementation(async (key: string) => {
+      if (key.endsWith(':priority')) return ['prio-2', 'prio-1'];
+      if (key.endsWith(':lifo')) return ['lifo-1', 'lifo-2'];
+      return [];
+    });
+    mockClient.xrange
+      .mockResolvedValueOnce({ '1-0': [['jobId', 'active-fifo']] })
+      .mockResolvedValueOnce({ '2-0': [['jobId', 'fifo-1']] });
+    mockClient.xpendingWithOptions.mockResolvedValueOnce([['1-0', 'consumer', 0, 1]]).mockResolvedValueOnce([]);
+
+    const queue = new Queue('getjobs-test', connOpts);
+    const jobs = await queue.getJobs('waiting', 1, 4);
+
+    expect(jobs.map((job) => job.id)).toEqual(['prio-2', 'lifo-2', 'lifo-1', 'fifo-1']);
+    expect(mockClient.lrange).toHaveBeenCalledWith('glide:{getjobs-test}:priority', -5, -1);
+    expect(mockClient.lrange).toHaveBeenCalledWith('glide:{getjobs-test}:lifo', -3, -1);
+    expect(mockClient.xrange).toHaveBeenNthCalledWith(
+      1,
+      'glide:{getjobs-test}:stream',
+      '-',
+      '+',
+      { count: 1 },
+    );
+    expect(mockClient.xrange).toHaveBeenNthCalledWith(
+      2,
+      'glide:{getjobs-test}:stream',
+      { value: '1-0', isInclusive: false },
+      '+',
+      { count: 1 },
+    );
+
+    await queue.close();
+  });
+
+  it('propagates non-NOGROUP errors while checking pending waiting jobs', async () => {
+    mockClient.xrange.mockResolvedValue({ '1-0': [['jobId', 'fifo-1']] });
+    mockClient.xpendingWithOptions.mockRejectedValue(new RequestError('ERR ACL user lacks XPENDING permission'));
+
+    const queue = new Queue('getjobs-test', connOpts);
+
+    await expect(queue.getJobs('waiting')).rejects.toThrow('ERR ACL user lacks XPENDING permission');
 
     await queue.close();
   });

--- a/tests/api-completeness.test.ts
+++ b/tests/api-completeness.test.ts
@@ -304,7 +304,7 @@ describe('Queue.getJobs', () => {
     vi.mocked(GlideClient.createClient).mockResolvedValue(mockClient as any);
   });
 
-  it('passes list keys when removing or revoking waiting jobs', async () => {
+  it('keeps remove and revoke FCALL key signatures stable', async () => {
     const keys = buildKeys('getjobs-cleanup');
     mockClient.fcall.mockResolvedValueOnce(1).mockResolvedValueOnce('revoked');
 
@@ -312,17 +312,7 @@ describe('Queue.getJobs', () => {
     expect(mockClient.fcall).toHaveBeenNthCalledWith(
       1,
       'glidemq_removeJob',
-      [
-        keys.job('1'),
-        keys.stream,
-        keys.scheduled,
-        keys.completed,
-        keys.failed,
-        keys.events,
-        keys.log('1'),
-        keys.lifo,
-        keys.priority,
-      ],
+      [keys.job('1'), keys.stream, keys.scheduled, keys.completed, keys.failed, keys.events, keys.log('1')],
       ['1'],
     );
 
@@ -330,7 +320,7 @@ describe('Queue.getJobs', () => {
     expect(mockClient.fcall).toHaveBeenNthCalledWith(
       2,
       'glidemq_revoke',
-      [keys.job('2'), keys.stream, keys.scheduled, keys.failed, keys.events, keys.lifo, keys.priority],
+      [keys.job('2'), keys.stream, keys.scheduled, keys.failed, keys.events],
       ['2', '123', 'workers'],
     );
   });

--- a/tests/get-jobs-waiting.test.ts
+++ b/tests/get-jobs-waiting.test.ts
@@ -98,4 +98,31 @@ describeEachMode('Queue.getJobs waiting sources', (CONNECTION) => {
     await isolatedQueue.close();
     await flushQueue(cleanupClient, isolatedName);
   });
+
+  it('removes a waiting FIFO stream entry with the legacy seven-key call shape', async () => {
+    const isolatedName = `${queueName}-stale-stream`;
+    const isolatedQueue = new Queue(isolatedName, { connection: CONNECTION });
+    const removed = await isolatedQueue.add('removed-fifo', {});
+    const waiting = await isolatedQueue.add('waiting-fifo', {});
+    const keys = buildKeys(isolatedName);
+
+    await cleanupClient.fcall(
+      'glidemq_removeJob',
+      [
+        keys.job(removed!.id),
+        keys.stream,
+        keys.scheduled,
+        keys.completed,
+        keys.failed,
+        keys.events,
+        keys.log(removed!.id),
+      ],
+      [removed!.id],
+    );
+
+    expect((await isolatedQueue.getJobs('waiting')).map((job) => job.id)).toEqual([waiting!.id]);
+
+    await isolatedQueue.close();
+    await flushQueue(cleanupClient, isolatedName);
+  });
 });

--- a/tests/get-jobs-waiting.test.ts
+++ b/tests/get-jobs-waiting.test.ts
@@ -125,4 +125,21 @@ describeEachMode('Queue.getJobs waiting sources', (CONNECTION) => {
     await isolatedQueue.close();
     await flushQueue(cleanupClient, isolatedName);
   });
+
+  it('paginates both the stream and PEL when the first 1000 entries are pending', async () => {
+    const isolatedName = `${queueName}-paged-pel`;
+    const isolatedQueue = new Queue(isolatedName, { connection: CONNECTION });
+    const keys = buildKeys(isolatedName);
+    const jobs = await isolatedQueue.addBulk(
+      Array.from({ length: 1001 }, (_, index) => ({ name: 'paged-fifo', data: { index } })),
+    );
+
+    await cleanupClient.xgroupCreate(keys.stream, CONSUMER_GROUP, '0');
+    await cleanupClient.xreadgroup(CONSUMER_GROUP, 'paged-pel-test', { [keys.stream]: '>' }, { count: 1000 });
+
+    expect((await isolatedQueue.getJobs('waiting')).map((job) => job.id)).toEqual([jobs[1000]!.id]);
+
+    await isolatedQueue.close();
+    await flushQueue(cleanupClient, isolatedName);
+  });
 });

--- a/tests/get-jobs-waiting.test.ts
+++ b/tests/get-jobs-waiting.test.ts
@@ -133,6 +133,22 @@ describeEachMode('Queue.getJobs waiting sources', (CONNECTION) => {
     await flushQueue(cleanupClient, isolatedName);
   });
 
+  it('removes list-backed waiting jobs without scanning the FIFO stream', async () => {
+    const isolatedName = `${queueName}-remove-list-no-scan`;
+    const isolatedQueue = new Queue(isolatedName, { connection: CONNECTION });
+    try {
+      const listJob = await isolatedQueue.add('remove-list', {}, { lifo: true });
+      const keys = buildKeys(isolatedName);
+
+      // A FIFO scan would raise WRONGTYPE. A list-backed removal must not touch this key.
+      await cleanupClient.set(keys.stream, 'list-backed-sentinel');
+      await expect(listJob!.remove()).resolves.toBeUndefined();
+    } finally {
+      await isolatedQueue.close();
+      await flushQueue(cleanupClient, isolatedName);
+    }
+  });
+
   it('removes a waiting FIFO stream entry with the legacy seven-key call shape', async () => {
     const isolatedName = `${queueName}-stale-stream`;
     const isolatedQueue = new Queue(isolatedName, { connection: CONNECTION });

--- a/tests/get-jobs-waiting.test.ts
+++ b/tests/get-jobs-waiting.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+const { CONSUMER_GROUP, promote } = require('../dist/functions/index') as typeof import('../src/functions/index');
+const { RequestError } = require('@glidemq/speedkey') as typeof import('@glidemq/speedkey');
+
+import { createCleanupClient, describeEachMode, flushQueue } from './helpers/fixture';
+
+describeEachMode('Queue.getJobs waiting sources', (CONNECTION) => {
+  const queueName = `get-jobs-waiting-${Date.now()}`;
+  let cleanupClient: any;
+  let queue: InstanceType<typeof Queue>;
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+    queue = new Queue(queueName, { connection: CONNECTION });
+  });
+
+  afterAll(async () => {
+    await queue?.close();
+    if (cleanupClient) {
+      await flushQueue(cleanupClient, queueName);
+      await cleanupClient.close();
+    }
+  });
+
+  it('includes priority and LIFO jobs while excluding FIFO jobs pending in a worker', async () => {
+    const keys = buildKeys(queueName);
+    const fifoActive = await queue.add('fifo-active', {});
+    const fifoWaiting = await queue.add('fifo-waiting', {});
+    const lifoFirst = await queue.add('lifo-first', {}, { lifo: true });
+    const lifoSecond = await queue.add('lifo-second', {}, { lifo: true });
+    const priorityFirst = await queue.add('priority-first', {}, { priority: 1 });
+    const prioritySecond = await queue.add('priority-second', {}, { priority: 2 });
+
+    await promote(cleanupClient, keys, Number.MAX_SAFE_INTEGER);
+    await cleanupClient.xgroupCreate(keys.stream, CONSUMER_GROUP, '0');
+    await cleanupClient.xreadgroup(CONSUMER_GROUP, 'get-jobs-waiting-test', { [keys.stream]: '>' }, { count: 1 });
+
+    const jobs = await queue.getJobs('waiting', 1, 4);
+
+    expect(jobs.map((job) => job.id)).toEqual([prioritySecond.id, lifoSecond.id, lifoFirst.id, fifoWaiting.id]);
+    expect(jobs.map((job) => job.id)).not.toContain(fifoActive.id);
+    expect((await queue.getJobs('waiting', 0, 0)).map((job) => job.id)).toEqual([priorityFirst.id]);
+  });
+
+  it('paginates the stream and treats only NOGROUP as an empty PEL', async () => {
+    const entries: Record<string, [string, string][]> = {};
+    const pending: [string, string, number, number][] = [];
+    for (let i = 0; i < 1000; i++) {
+      const entryId = `${i + 1}-0`;
+      entries[entryId] = [['jobId', `pending-${i}`]];
+      pending.push([entryId, 'consumer', 0, 1]);
+    }
+
+    let page = 0;
+    const pagedClient = {
+      xrange: async () => (page++ === 0 ? entries : { '1001-0': [['jobId', 'waiting-final']] }),
+      xpendingWithOptions: async () => (page === 1 ? pending : []),
+    };
+    expect(await (queue as any).getWaitingStreamJobIds(pagedClient, -1)).toEqual(['waiting-final']);
+
+    const noGroupClient = {
+      xrange: async () => ({ '1-0': [['jobId', 'waiting-without-group']] }),
+      xpendingWithOptions: async () => {
+        throw new RequestError('NOGROUP: No such key or consumer group');
+      },
+    };
+    expect(await (queue as any).getWaitingStreamJobIds(noGroupClient, -1)).toEqual(['waiting-without-group']);
+  });
+});

--- a/tests/get-jobs-waiting.test.ts
+++ b/tests/get-jobs-waiting.test.ts
@@ -54,10 +54,11 @@ describeEachMode('Queue.getJobs waiting sources', (CONNECTION) => {
       pending.push([entryId, 'consumer', 0, 1]);
     }
 
-    let page = 0;
+    let streamPage = 0;
+    let pelPage = 0;
     const pagedClient = {
-      xrange: async () => (page++ === 0 ? entries : { '1001-0': [['jobId', 'waiting-final']] }),
-      xpendingWithOptions: async () => (page === 1 ? pending : []),
+      xrange: async () => (streamPage++ === 0 ? entries : { '1001-0': [['jobId', 'waiting-final']] }),
+      xpendingWithOptions: async () => (pelPage++ === 0 ? pending : []),
     };
     expect(await (queue as any).getWaitingStreamJobIds(pagedClient, -1)).toEqual(['waiting-final']);
 
@@ -68,6 +69,17 @@ describeEachMode('Queue.getJobs waiting sources', (CONNECTION) => {
       },
     };
     expect(await (queue as any).getWaitingStreamJobIds(noGroupClient, -1)).toEqual(['waiting-without-group']);
+
+    const deletedPending = Array.from({ length: 1000 }, (_, index) => [`${index + 2}-0`, 'consumer', 0, 1]);
+    let deletedPelPage = 0;
+    const deletedPelClient = {
+      xrange: async () => ({
+        '1-0': [['jobId', 'waiting-live']],
+        '2000-0': [['jobId', 'active-live']],
+      }),
+      xpendingWithOptions: async () => (deletedPelPage++ === 0 ? deletedPending : [['2000-0', 'consumer', 0, 1]]),
+    };
+    expect(await (queue as any).getWaitingStreamJobIds(deletedPelClient, -1)).toEqual(['waiting-live']);
   });
 
   it('removes revoked and deleted jobs from list-backed waiting sources', async () => {

--- a/tests/get-jobs-waiting.test.ts
+++ b/tests/get-jobs-waiting.test.ts
@@ -149,6 +149,72 @@ describeEachMode('Queue.getJobs waiting sources', (CONNECTION) => {
     }
   });
 
+  it('removes a stream-backed job after clearing a delayed LIFO job', async () => {
+    const isolatedName = `${queueName}-remove-cleared-lifo-delay`;
+    const isolatedQueue = new Queue(isolatedName, { connection: CONNECTION });
+    try {
+      const job = await isolatedQueue.add('cleared-lifo-delay', {}, { delay: 60_000, lifo: true });
+      const keys = buildKeys(isolatedName);
+
+      await job!.changeDelay(0);
+      expect(await cleanupClient.xlen(keys.stream)).toBe(1);
+
+      await job!.remove();
+      expect(await cleanupClient.xlen(keys.stream)).toBe(0);
+      expect(await isolatedQueue.getJobs('waiting')).toEqual([]);
+      expect((await isolatedQueue.getJobCounts()).waiting).toBe(0);
+    } finally {
+      await isolatedQueue.close();
+      await flushQueue(cleanupClient, isolatedName);
+    }
+  });
+
+  it('revokes non-FIFO jobs without scanning the FIFO stream', async () => {
+    const cases = [
+      { suffix: 'waiting-lifo', options: { lifo: true }, promote: false },
+      { suffix: 'waiting-priority', options: { priority: 1 }, promote: true },
+      { suffix: 'delayed', options: { delay: 60_000 }, promote: false },
+      { suffix: 'prioritized', options: { priority: 1 }, promote: false },
+    ];
+
+    for (const testCase of cases) {
+      const isolatedName = `${queueName}-revoke-no-scan-${testCase.suffix}`;
+      const isolatedQueue = new Queue(isolatedName, { connection: CONNECTION });
+      try {
+        const job = await isolatedQueue.add('revoke-no-scan', {}, testCase.options);
+        const keys = buildKeys(isolatedName);
+        if (testCase.promote) {
+          await promote(cleanupClient, keys, Number.MAX_SAFE_INTEGER);
+        }
+
+        // A FIFO scan would raise WRONGTYPE. These jobs cannot have a stream entry.
+        await cleanupClient.set(keys.stream, 'non-fifo-sentinel');
+        await expect(isolatedQueue.revoke(job!.id)).resolves.toBe('revoked');
+      } finally {
+        await isolatedQueue.close();
+        await flushQueue(cleanupClient, isolatedName);
+      }
+    }
+  });
+
+  it('revokes a stream-backed job after clearing a delayed LIFO job', async () => {
+    const isolatedName = `${queueName}-revoke-cleared-lifo-delay`;
+    const isolatedQueue = new Queue(isolatedName, { connection: CONNECTION });
+    try {
+      const job = await isolatedQueue.add('cleared-lifo-delay', {}, { delay: 60_000, lifo: true });
+      const keys = buildKeys(isolatedName);
+
+      await job!.changeDelay(0);
+      expect(await cleanupClient.xlen(keys.stream)).toBe(1);
+
+      expect(await isolatedQueue.revoke(job!.id)).toBe('revoked');
+      expect(await cleanupClient.xlen(keys.stream)).toBe(0);
+    } finally {
+      await isolatedQueue.close();
+      await flushQueue(cleanupClient, isolatedName);
+    }
+  });
+
   it('removes a waiting FIFO stream entry with the legacy seven-key call shape', async () => {
     const isolatedName = `${queueName}-stale-stream`;
     const isolatedQueue = new Queue(isolatedName, { connection: CONNECTION });

--- a/tests/get-jobs-waiting.test.ts
+++ b/tests/get-jobs-waiting.test.ts
@@ -69,4 +69,21 @@ describeEachMode('Queue.getJobs waiting sources', (CONNECTION) => {
     };
     expect(await (queue as any).getWaitingStreamJobIds(noGroupClient, -1)).toEqual(['waiting-without-group']);
   });
+
+  it('removes revoked and deleted jobs from list-backed waiting sources', async () => {
+    const isolatedName = `${queueName}-stale-list`;
+    const isolatedQueue = new Queue(isolatedName, { connection: CONNECTION });
+    const revoked = await isolatedQueue.add('revoked-priority', {}, { priority: 1 });
+    const removed = await isolatedQueue.add('removed-lifo', {}, { lifo: true });
+    const waiting = await isolatedQueue.add('waiting-priority', {}, { priority: 2 });
+    await promote(cleanupClient, buildKeys(isolatedName), Number.MAX_SAFE_INTEGER);
+
+    expect(await isolatedQueue.revoke(revoked!.id)).toBe('revoked');
+    await removed!.remove();
+
+    expect((await isolatedQueue.getJobs('waiting')).map((job) => job.id)).toEqual([waiting!.id]);
+
+    await isolatedQueue.close();
+    await flushQueue(cleanupClient, isolatedName);
+  });
 });

--- a/tests/get-jobs-waiting.test.ts
+++ b/tests/get-jobs-waiting.test.ts
@@ -82,6 +82,40 @@ describeEachMode('Queue.getJobs waiting sources', (CONNECTION) => {
     expect(await (queue as any).getWaitingStreamJobIds(deletedPelClient, -1)).toEqual(['waiting-live']);
   });
 
+  it('reads a full stream chunk when a limited page starts with PEL entries', async () => {
+    const ids = ['1-0', '2-0', '3-0', '4-0', '5-0', '6-0'];
+    const pendingIds = new Set(ids.slice(0, 3));
+    const xrangeCounts: number[] = [];
+    const chunkedClient = {
+      xrange: async (
+        _key: string,
+        start: '-' | { value: string; isInclusive: false },
+        _end: '+',
+        options: { count: number },
+      ) => {
+        xrangeCounts.push(options.count);
+        const startId = typeof start === 'string' ? undefined : start.value;
+        const startIndex = startId == null ? 0 : ids.indexOf(startId) + 1;
+        const pageIds = ids.slice(startIndex, startIndex + options.count);
+        return Object.fromEntries(pageIds.map((id) => [id, [['jobId', id]]]));
+      },
+      xpendingWithOptions: async (
+        _key: string,
+        _group: string,
+        options: { start: { value: string }; end: { value: string } },
+      ) =>
+        ids
+          .filter((id) => pendingIds.has(id))
+          .filter((id) => id >= options.start.value && id <= options.end.value)
+          .map((id) => [id, 'consumer', 0, 1] as [string, string, number, number]),
+    };
+
+    const result = await (queue as any).getWaitingStreamJobIds(chunkedClient, 1);
+    expect(result).toEqual(['4-0']);
+    expect(result).toHaveLength(1);
+    expect(xrangeCounts).toEqual([1000]);
+  });
+
   it('removes revoked and deleted jobs from list-backed waiting sources', async () => {
     const isolatedName = `${queueName}-stale-list`;
     const isolatedQueue = new Queue(isolatedName, { connection: CONNECTION });

--- a/tests/job.test.ts
+++ b/tests/job.test.ts
@@ -248,6 +248,8 @@ describe('Job', () => {
         'glide:{test-queue}:failed',
         'glide:{test-queue}:events',
         'glide:{test-queue}:log:8',
+        'glide:{test-queue}:lifo',
+        'glide:{test-queue}:priority',
       ]);
       expect(call[2]).toEqual(['8']);
     });

--- a/tests/job.test.ts
+++ b/tests/job.test.ts
@@ -248,8 +248,6 @@ describe('Job', () => {
         'glide:{test-queue}:failed',
         'glide:{test-queue}:events',
         'glide:{test-queue}:log:8',
-        'glide:{test-queue}:lifo',
-        'glide:{test-queue}:priority',
       ]);
       expect(call[2]).toEqual(['8']);
     });

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -7,6 +7,8 @@ import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './he
 
 const { Queue } = require('../dist/queue') as typeof import('../src/queue');
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+const { CONSUMER_GROUP, promote } = require('../dist/functions/index') as typeof import('../src/functions/index');
 
 describeEachMode('Queue.searchJobs', (CONNECTION) => {
   let cleanupClient: any;
@@ -55,6 +57,29 @@ describeEachMode('Queue.searchJobs', (CONNECTION) => {
     for (const job of results) {
       expect((job.data as any).userId).toBe('123');
     }
+
+    await q.close();
+    await flushQueue(cleanupClient, qName);
+  });
+
+  it('searches every waiting source and excludes FIFO jobs in the PEL', async () => {
+    const qName = Q + '-waiting-sources';
+    const q = new Queue(qName, { connection: CONNECTION });
+    const keys = buildKeys(qName);
+
+    const active = await q.add('target', { group: 'match', source: 'active' });
+    const fifo = await q.add('target', { group: 'match', source: 'fifo' });
+    const lifo = await q.add('target', { group: 'match', source: 'lifo' }, { lifo: true });
+    const priority = await q.add('target', { group: 'match', source: 'priority' }, { priority: 1 });
+
+    await promote(cleanupClient, keys, Number.MAX_SAFE_INTEGER);
+    await cleanupClient.xgroupCreate(keys.stream, CONSUMER_GROUP, '0');
+    await cleanupClient.xreadgroup(CONSUMER_GROUP, 'search-waiting-test', { [keys.stream]: '>' }, { count: 1 });
+
+    const expected = [priority.id, lifo.id, fifo.id];
+    expect((await q.searchJobs({ state: 'waiting', name: 'target' })).map((job) => job.id)).toEqual(expected);
+    expect((await q.searchJobs({ state: 'waiting', data: { group: 'match' } })).map((job) => job.id)).toEqual(expected);
+    expect(expected).not.toContain(active.id);
 
     await q.close();
     await flushQueue(cleanupClient, qName);


### PR DESCRIPTION
## Summary
- return waiting priority, LIFO, and FIFO stream jobs in worker dispatch order
- exclude stream entries already present in the consumer-group PEL
- suppress only genuine NOGROUP errors and propagate transport/server/ACL failures
- add mocked and live standalone coverage

## Red-first proof
The first commit is test-only. Against its parent, waiting priority/LIFO jobs were absent and XPENDING errors were silently treated as an empty PEL.

## Validation
- focused API and standalone tests: 27 passed
- build, typecheck, lint, format, diff check

Local cluster port 7000 is unavailable; cluster coverage will run in CI.

## Known CI dependency

The upstream `codecov/patch` check is blocked by the base-workflow issue fixed in [#272](https://github.com/avifenesh/glide-mq/pull/272): the unquoted fuzzer glob changes the integration coverage selection, and the coverage uploads need the corrected authentication. The identical head passes every test and 93.65% patch coverage in companion fork PR [#15](https://github.com/jonathanong/glide-mq/pull/15). Merge #272, allow the resulting `main` coverage run to complete, then rebase this branch onto updated `main` and rerun CI. This is CI plumbing, not missing integration-test coverage.

### Coverage comparison

| Context | Patch coverage |
|---|---:|
| Current upstream run | 51.58% |
| [Identical-head fork PR #15](https://github.com/jonathanong/glide-mq/pull/15) | 93.65% |