### PR TITLE
fix: sweep expired suspended jobs when pausing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Queue pause now expires suspended jobs**: `Queue.pause()` immediately sweeps suspended jobs whose timeouts have elapsed, so pausing does not leave expired human-in-the-loop jobs pending until the background sweep.
+
 ## [0.15.4] - 2026-06-04
 
 ### Fixed

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,10 +2,11 @@
 
 ## Current State
 
-- **Branch**: `ci/lua-coverage`, top of the coverage stack.
+- **In flight**: `Queue.pause()` immediately sweeps expired suspended jobs after setting the queue pause flag.
+- **Branch**: `fix/pause-suspended-sweep`, independent from upstream `main`.
 - **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
 - **CI**: green across all six fork/upstream stack PRs after the 2026-08-22 packaging update.
-- **Local branches**: `refactor/extract-lua-library` -> `ci/ts-coverage` -> `ci/lua-coverage`.
+- **Local branches**: no stacked branch dependency.
 - **Review gate**: automatic Claude review is retired; the Revuto GitHub App check reviews pull requests.
 - **Dependency security**: the lockfile carries protobufjs 7.6.5, brace-expansion 5.0.9, PostCSS 8.5.25, and body-parser 2.3.0.
 
@@ -31,7 +32,7 @@ See CHANGELOG.md `0.15.4` for the full list. Highlights:
 
 - **Bun/Deno NAPI compatibility testing**: still pending from 0.14.0 handover.
 - **Valkey CI images**: CI is off release candidates. Standalone and cluster coverage use stable `valkey/valkey:9.1.0`; search coverage uses stable `valkey/valkey-bundle:9.1.0`, which carries Valkey Search 1.2.x and keeps the Search 1.1+ option tests active.
-- **Coverage**: stacked fork PRs. Extract Lua (`refactor/extract-lua-library`) -> TS V8 coverage (`ci/ts-coverage`) -> Lua line probes (`ci/lua-coverage`). Codecov project status is informational; patch target 80%. Integration and lua are separate flags. `npm run build:lua-cov` instruments dist Lua and stamps dist `LIBRARY_VERSION` as `93-cov`; Vitest aliases `src/functions` to `dist/functions` so src-imported clients cannot REPLACE the probed library. CI dumps LCOV with `node scripts/dump-lua-coverage.cjs` after the suite. The build now copies both `glidemq.lua` and `glidemq.embedded.json` to `dist/functions`, and npm CD smoke-loads `dist` before publishing.
+- **Coverage**: coverage jobs and Lua instrumentation are maintained on upstream `main`; this branch has no coverage-stack dependency.
 
 ## API Design Decisions (locked)
 

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -95,6 +95,7 @@ const SCHEDULER_LOCK_MAX_ATTEMPTS = Math.ceil(SCHEDULER_LOCK_TTL_MS / SCHEDULER_
 const SUSPEND_SWEEP_INTERVAL_MS = 1000;
 const SUSPEND_SWEEP_IDLE_POLL_MS = 5000;
 const SUSPEND_SWEEP_LOCK_TTL_MS = 5000;
+const SUSPEND_SWEEP_BATCH_SIZE = 100;
 const SUSPEND_NO_TIMEOUT_SCORE = 9_999_999_999_999;
 const DEFAULT_USAGE_WINDOW_MS = 60 * 60 * 1000;
 const MAX_USAGE_SUMMARY_KEY_READS = 100_000;
@@ -505,15 +506,27 @@ export class Queue<D = any, R = any> extends EventEmitter {
     );
   }
 
-  private async sweepExpiredSuspended(client: Client): Promise<boolean> {
+  private async sweepExpiredSuspended(client: Client, timestamp = Date.now()): Promise<boolean> {
     const lockKey = this.suspendSweepLockKey();
     const token = randomBytes(8).toString('hex');
     const acquired = await tryLock(client, lockKey, token, SUSPEND_SWEEP_LOCK_TTL_MS);
     if (!acquired) return false;
 
     try {
+      // glidemq_sweepSuspended processes at most 100 members per invocation.
+      // Bound the repeated calls to the number of jobs that were expired at
+      // this sweep's timestamp. Jobs suspended while the sweep runs have a
+      // later deadline and are intentionally left for a future sweep.
+      const expiredCount = await client.zcount(
+        this.keys.suspended,
+        { value: 0, isInclusive: true },
+        { value: timestamp, isInclusive: true },
+      );
+      const batches = Math.ceil(expiredCount / SUSPEND_SWEEP_BATCH_SIZE);
       const keyPrefix = this.keys.id.slice(0, -2);
-      await sweepSuspended(client, this.keys, Date.now(), keyPrefix);
+      for (let i = 0; i < batches; i++) {
+        await sweepSuspended(client, this.keys, timestamp, keyPrefix);
+      }
       return true;
     } finally {
       try {
@@ -1286,7 +1299,9 @@ export class Queue<D = any, R = any> extends EventEmitter {
    */
   async pause(): Promise<void> {
     const client = await this.getClient();
+    const timestamp = Date.now();
     await pause(client, this.keys);
+    await this.sweepExpiredSuspended(client, timestamp);
   }
 
   /**

--- a/tests/api-completeness.test.ts
+++ b/tests/api-completeness.test.ts
@@ -79,6 +79,7 @@ function makeMockClient(overrides: Record<string, unknown> = {}) {
     rpopCount: vi.fn().mockResolvedValue(null),
     zadd: vi.fn(),
     zcard: vi.fn().mockResolvedValue(0),
+    zcount: vi.fn().mockResolvedValue(0),
     zrange: vi.fn().mockResolvedValue([]),
     del: vi.fn(),
     unlink: vi.fn(),
@@ -199,6 +200,32 @@ describe('Job state check methods', () => {
     job.entryId = '1-0';
     await expect(job.moveToDelayed(Date.now() + 100, 'next')).rejects.toThrow('plain-object job data');
     expect(job.moveToDelayedRequest).toBeUndefined();
+  });
+});
+
+// ---- Queue.pause suspended timeout sweep ----
+
+describe('Queue.pause suspended timeout sweep', () => {
+  let mockClient: ReturnType<typeof makeMockClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = makeMockClient();
+    mockClient.zcount.mockResolvedValue(1);
+    vi.mocked(GlideClient.createClient).mockResolvedValue(mockClient as any);
+  });
+
+  it('sweeps expired suspended jobs when pausing locally', async () => {
+    mockClient.fcall.mockImplementation(async (name: string) => (name === 'glidemq_tryLock' ? 1 : 0));
+    const queue = new Queue('pause-sweep-test', connOpts);
+
+    await queue.pause();
+
+    expect(mockClient.fcall).toHaveBeenCalledWith('glidemq_pause', expect.any(Array), []);
+    expect(mockClient.fcall).toHaveBeenCalledWith('glidemq_sweepSuspended', expect.any(Array), expect.any(Array));
+    expect(mockClient.fcall).toHaveBeenCalledWith('glidemq_unlock', expect.any(Array), expect.any(Array));
+
+    await queue.close();
   });
 });
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -11,7 +11,7 @@ const { Worker } = require('../dist/worker') as typeof import('../src/worker');
 const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
 const { LIBRARY_VERSION } = require('../dist/functions/index') as typeof import('../src/functions/index');
 
-import { describeEachMode, createCleanupClient, flushQueue } from './helpers/fixture';
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
 
 describeEachMode('Function Library', (CONNECTION) => {
   let cleanupClient: any;
@@ -114,6 +114,41 @@ describeEachMode('Queue pause/resume', (CONNECTION) => {
     await queue.resume();
     expect(String(await cleanupClient.hget(k.meta, 'paused'))).toBe('0');
   });
+
+  it('pause sweeps all expired suspended jobs, not just the first batch', async () => {
+    const qName = `test-pause-suspended-sweep-${Date.now()}`;
+    const queue = new Queue(qName, { connection: CONNECTION });
+    const worker = new Worker(
+      qName,
+      async (job: any) => {
+        await job.suspend({ timeout: 60000 });
+      },
+      { connection: CONNECTION, concurrency: 128, prefetch: 128, blockTimeout: 1000 },
+    );
+    const jobs = [] as any[];
+    const k = buildKeys(qName);
+
+    try {
+      worker.on('error', () => {});
+      await worker.waitUntilReady();
+      for (let i = 0; i < 101; i++) {
+        jobs.push(await queue.add(`suspend-${i}`, { i }));
+      }
+
+      await waitFor(async () => Number(await cleanupClient.zcard(k.suspended)) === jobs.length, 15000, 50);
+      await cleanupClient.zadd(k.suspended, Object.fromEntries(jobs.map((job) => [job.id, 0])));
+
+      await queue.pause();
+
+      expect(await cleanupClient.zcard(k.suspended)).toBe(0);
+      const states = await Promise.all(jobs.map((job) => cleanupClient.hget(k.job(job.id), 'state')));
+      expect(states.every((state) => String(state) === 'failed')).toBe(true);
+    } finally {
+      await worker.close(true).catch(() => undefined);
+      await queue.close().catch(() => undefined);
+      await flushQueue(cleanupClient, qName);
+    }
+  }, 30000);
 });
 
 describeEachMode('Worker processes jobs', (CONNECTION) => {


### PR DESCRIPTION
## Summary
- sweep suspended-job timeouts before finalizing Queue.pause
- prevent expired suspended jobs from remaining indefinitely when workers stop
- keep this behavior separate from namespace obliteration

## Red-first proof
The first commit is test-only. Against its parent, Queue.pause never called the suspended timeout sweep.

## Validation
- API suite: 25 passed
- suspended-job integration coverage
- build, typecheck, lint, format, diff check

Local cluster port 7000 is unavailable; cluster coverage will run in CI.