### PR TITLE
fix: clear the full queue namespace on obliterate

### DIFF
--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1693,35 +1693,22 @@ export class Queue<D = any, R = any> extends EventEmitter {
       this.keys.metricsCompleted,
       this.keys.metricsFailed,
       this.keys.lifo,
+      this.keys.priority,
+      this.keys.listActive,
+      this.keys.suspended,
+      this.keys.tpm,
     ];
     // Static keys include the stream, completed/failed ZSets, and several
     // hashes that can hold many entries on busy queues. UNLINK frees them
     // on a background thread instead of blocking the server thread.
     await client.unlink(staticKeys);
+    await client.srem(this.keys.usageQueues, [this.name]);
 
-    // Scan and delete job hashes and deps sets
-    // Use escaped prefix to prevent glob injection from queue names containing * ? [ ]
+    // Scan the complete hash-tagged queue namespace. This includes dynamic
+    // job, group, worker, lock, usage, budget, parent, signal, and stream keys.
+    // The escaped prefix prevents glob injection from queue names containing * ? [ ].
     const pfx = keyPrefixPattern(this.opts.prefix ?? 'glide', this.name);
-    const jobPattern = `${pfx}:job:*`;
-    const logPattern = `${pfx}:log:*`;
-    const depsPattern = `${pfx}:deps:*`;
-    const groupPattern = `${pfx}:group:*`;
-    const groupqPattern = `${pfx}:groupq:*`;
-    const orderPendingPattern = `${pfx}:orderdone:pending:*`;
-
-    const workerPattern = `${pfx}:w:*`;
-
-    for (const pattern of [
-      jobPattern,
-      logPattern,
-      depsPattern,
-      groupPattern,
-      groupqPattern,
-      orderPendingPattern,
-      workerPattern,
-    ]) {
-      await this.scanAndDelete(client, pattern);
-    }
+    await this.scanAndDelete(client, `${pfx}:*`);
   }
 
   /**

--- a/tests/api-completeness.test.ts
+++ b/tests/api-completeness.test.ts
@@ -84,6 +84,7 @@ function makeMockClient(overrides: Record<string, unknown> = {}) {
     unlink: vi.fn(),
     scan: vi.fn().mockResolvedValue(['0', []]),
     smembers: vi.fn().mockResolvedValue(new Set()),
+    srem: vi.fn(),
     hmget: vi.fn().mockResolvedValue([null, null]),
     close: vi.fn(),
     ...overrides,
@@ -237,21 +238,59 @@ describe('Queue.obliterate', () => {
   });
 
   it('scans and deletes job hashes and deps sets', async () => {
-    // First scan call (job pattern): returns keys, then empty
-    // Second scan call (deps pattern): returns keys, then empty
-    mockClient.scan
-      .mockResolvedValueOnce(['123', ['glide:{obliterate-test}:job:1', 'glide:{obliterate-test}:job:2']])
-      .mockResolvedValueOnce(['0', []])
-      .mockResolvedValueOnce(['456', ['glide:{obliterate-test}:deps:1']])
-      .mockResolvedValueOnce(['0', []]);
+    mockClient.scan.mockResolvedValueOnce([
+      '0',
+      ['glide:{obliterate-test}:job:1', 'glide:{obliterate-test}:job:2', 'glide:{obliterate-test}:deps:1'],
+    ]);
 
     const queue = new Queue('obliterate-test', connOpts);
     await queue.obliterate({ force: true });
 
-    // unlink called: once for static keys, once for job batch, once for deps batch
-    expect(mockClient.unlink).toHaveBeenCalledTimes(3);
-    expect(mockClient.unlink).toHaveBeenCalledWith(['glide:{obliterate-test}:job:1', 'glide:{obliterate-test}:job:2']);
-    expect(mockClient.unlink).toHaveBeenCalledWith(['glide:{obliterate-test}:deps:1']);
+    expect(mockClient.unlink).toHaveBeenCalledTimes(2);
+    expect(mockClient.unlink).toHaveBeenCalledWith([
+      'glide:{obliterate-test}:job:1',
+      'glide:{obliterate-test}:job:2',
+      'glide:{obliterate-test}:deps:1',
+    ]);
+
+    await queue.close();
+  });
+
+  it('deletes the full queue namespace and removes its usage registry entry', async () => {
+    const namespaceKeys = [
+      'glide:{obliterate-test}:job:1',
+      'glide:{obliterate-test}:job:1:usage-lock',
+      'glide:{obliterate-test}:job:1:sub:subscriber',
+      'glide:{obliterate-test}:log:1',
+      'glide:{obliterate-test}:deps:1',
+      'glide:{obliterate-test}:parents:1',
+      'glide:{obliterate-test}:jstream:1',
+      'glide:{obliterate-test}:signals:1',
+      'glide:{obliterate-test}:group:group-a',
+      'glide:{obliterate-test}:groupq:group-a',
+      'glide:{obliterate-test}:orderdone:pending:group-a',
+      'glide:{obliterate-test}:w:worker-a',
+      'glide:{obliterate-test}:budget:flow-a',
+      'glide:{obliterate-test}:usage:60000',
+      'glide:{obliterate-test}:schedulers:lock:__tick__',
+      'glide:{obliterate-test}:suspended:lock:__sweep__',
+    ];
+    mockClient.scan.mockResolvedValueOnce(['0', namespaceKeys]);
+
+    const queue = new Queue('obliterate-test', connOpts);
+    await queue.obliterate({ force: true });
+
+    expect(mockClient.unlink).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        'glide:{obliterate-test}:priority',
+        'glide:{obliterate-test}:list-active',
+        'glide:{obliterate-test}:suspended',
+        'glide:{obliterate-test}:tpm',
+      ]),
+    );
+    expect(mockClient.scan).toHaveBeenCalledWith('0', { match: 'glide:{obliterate-test}:*', count: 100 });
+    expect(mockClient.unlink).toHaveBeenCalledWith(namespaceKeys);
+    expect(mockClient.srem).toHaveBeenCalledWith('glide:usage:queues', ['obliterate-test']);
 
     await queue.close();
   });

--- a/tests/compat-reliability.test.ts
+++ b/tests/compat-reliability.test.ts
@@ -908,6 +908,42 @@ describeEachMode('Operational patterns', (CONNECTION) => {
     await queue.close();
   }, 10000);
 
+  it('Queue.obliterate removes every dynamic queue key family', async () => {
+    const Q = uniqueQueue('op-obliterate-namespace');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const k = buildKeys(Q);
+    const prefix = k.id.slice(0, -2);
+    const namespaceKeys = [
+      k.job('orphan'),
+      `${k.job('orphan')}:usage-lock`,
+      `${k.job('orphan')}:sub:subscriber`,
+      k.log('orphan'),
+      k.deps('orphan'),
+      k.parents('orphan'),
+      k.jstream('orphan'),
+      k.signals('orphan'),
+      k.group('group-a'),
+      k.groupq('group-a'),
+      `${prefix}orderdone:pending:group-a`,
+      k.worker('worker-a'),
+      k.budget('flow-a'),
+      k.usageBucket(60_000),
+      `${k.schedulers}:lock:__tick__`,
+      `${k.suspended}:lock:__sweep__`,
+    ];
+
+    await Promise.all(namespaceKeys.map((key) => cleanupClient.hset(key, { marker: '1' })));
+    await cleanupClient.sadd(k.usageQueues, [Q]);
+
+    await queue.obliterate({ force: true });
+
+    const exists = await Promise.all(namespaceKeys.map((key) => cleanupClient.exists([key])));
+    expect(exists.every((count) => Number(count) === 0)).toBe(true);
+    expect([...(await cleanupClient.smembers(k.usageQueues))].map(String)).not.toContain(Q);
+
+    await queue.close();
+  }, 10000);
+
   it('failed job can be retried via job.retry() and succeeds', async () => {
     const Q = uniqueQueue('op-retry-failed');
     const queue = new Queue(Q, { connection: CONNECTION });


### PR DESCRIPTION
## Summary
- scan the escaped full queue namespace instead of a narrower job-key pattern
- delete all static queue structures and unregister usage tracking
- cover wildcard queue names and leaked namespace keys

## Red-first proof
The first commit is test-only. Against its parent, namespace keys and the usage registry entry survived obliterate.

## Validation
- focused unit and standalone namespace tests: 47 passed
- build, typecheck, lint, format, diff check

Local cluster port 7000 is unavailable; cluster coverage will run in CI.