### PR TITLE
fix: complete nested cross-queue parents safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, reconciles removed children without recreating hashes, and ignores stale notifications for deleted parents. Pending notifications use unambiguous JSON encoding and are removed by `obliterate`. DAG Phase B now reconciles children deleted after existence checks, including cross-queue cases. `LIBRARY_VERSION` bumped to `108`.
+- **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, reconciles removed children without recreating hashes, and ignores stale notifications for deleted parents. Pending notifications use unambiguous JSON encoding and are removed by `obliterate`. DAG Phase B now reconciles children deleted after existence checks, including cross-queue cases. Completion FCALLs return newly queued cross-queue edges for eager delivery without an extra parent lookup or waiting for a promotion tick. `LIBRARY_VERSION` bumped to `109`.
 
 ## [0.15.4] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Nested cross-queue flow parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, re-reads late parent metadata, and retries cross-queue notifications from the child slot. `LIBRARY_VERSION` bumped to `101`.
+
 ## [0.15.4] - 2026-06-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Nested cross-queue flow parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, re-reads late parent metadata, and retries cross-queue notifications from the child slot. `LIBRARY_VERSION` bumped to `101`.
+- **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, and ignores stale notifications for deleted parents. `LIBRARY_VERSION` bumped to `102`.
 
 ## [0.15.4] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, reconciles removed children without recreating hashes, and ignores stale notifications for deleted parents. Pending notifications use unambiguous JSON encoding and are removed by `obliterate`. DAG Phase B now reconciles children deleted after existence checks, including cross-queue cases. Completion FCALLs return newly queued cross-queue edges for eager delivery without an extra parent lookup or waiting for a promotion tick. `LIBRARY_VERSION` bumped to `109`.
+- **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, reconciles removed children without recreating hashes, and ignores stale notifications for deleted parents. Pending notifications use unambiguous JSON encoding and are removed by `obliterate`. DAG Phase B now reconciles children deleted after existence checks, including cross-queue cases. Completion FCALLs return newly queued cross-queue edges for eager delivery without an extra parent lookup or waiting for a promotion tick, deduplicating overlapping tree and DAG metadata. `LIBRARY_VERSION` bumped to `110`.
 
 ## [0.15.4] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, and ignores stale notifications for deleted parents. `LIBRARY_VERSION` bumped to `102`.
+- **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, reconciles removed children without recreating hashes, and ignores stale notifications for deleted parents. Pending notifications use unambiguous JSON encoding and are removed by `obliterate`. `LIBRARY_VERSION` bumped to `104`.
 
 ## [0.15.4] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, reconciles removed children without recreating hashes, and ignores stale notifications for deleted parents. Pending notifications use unambiguous JSON encoding and are removed by `obliterate`. DAG Phase B now reconciles children deleted after existence checks, including cross-queue cases. `LIBRARY_VERSION` bumped to `106`.
+- **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, reconciles removed children without recreating hashes, and ignores stale notifications for deleted parents. Pending notifications use unambiguous JSON encoding and are removed by `obliterate`. DAG Phase B now reconciles children deleted after existence checks, including cross-queue cases. `LIBRARY_VERSION` bumped to `108`.
 
 ## [0.15.4] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, reconciles removed children without recreating hashes, and ignores stale notifications for deleted parents. Pending notifications use unambiguous JSON encoding and are removed by `obliterate`. `LIBRARY_VERSION` bumped to `104`.
+- **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, reconciles removed children without recreating hashes, and ignores stale notifications for deleted parents. Pending notifications use unambiguous JSON encoding and are removed by `obliterate`. DAG Phase B now reconciles children deleted after existence checks, including cross-queue cases. `LIBRARY_VERSION` bumped to `106`.
 
 ## [0.15.4] - 2026-06-04
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -21,7 +21,7 @@
 
 ### In flight (fork)
 
-- **Nested/cross-queue parents**: test-first regression `211d3b7`; implementation `fec97d1` + `bb6e9b7`. Lua source is `src/functions/glidemq.lua`; cross-slot parent notifications are retried by the child queue scheduler.
+- **Nested/cross-queue parents**: test-first regression `d3a9782`; implementation `1cc2530` + `8cef166` + `c5eaaab` + `507fb63`. Lua source is `src/functions/glidemq.lua`; cross-slot DAG parent deps use single-slot commands and child-scheduler notifications are retryable/idempotent.
 
 ### 0.15.4 Release Notes
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -21,7 +21,7 @@
 
 ### In flight (fork)
 
-- **Nested/cross-queue parents**: test-first regression `211d3b7`; implementation `fec97d1`. Lua source is `src/functions/glidemq.lua`; cross-slot parent notifications are retried by the child queue scheduler.
+- **Nested/cross-queue parents**: test-first regression `211d3b7`; implementation `fec97d1` + `bb6e9b7`. Lua source is `src/functions/glidemq.lua`; cross-slot parent notifications are retried by the child queue scheduler.
 
 ### 0.15.4 Release Notes
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -21,7 +21,7 @@
 
 ### In flight (fork)
 
-- **Nested/cross-queue parents**: test-first regression `d31d6d3`; implementation commits include `df7fbac`, `b292c2c`, `fd145cc`, `a7cd7fa`, `4d5057c`, and `1765895`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 106, reconciles removed children including nested and DAG exists-to-HSET TOCTOU races with ghost parent-set cleanup, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone flow and distinct-queue DAG execution regressions are green; cluster services were not available locally.
+- **Nested/cross-queue parents**: test-first regression `d31d6d3`; implementation commits include `df7fbac`, `b292c2c`, `fd145cc`, `a7cd7fa`, `4d5057c`, and `1765895`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 108, reconciles removed children including nested and DAG exists-to-HSET TOCTOU races with ghost parent-set cleanup, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone flow and distinct-queue DAG execution regressions are green; cluster services were not available locally.
 
 ### 0.15.4 Release Notes
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -21,7 +21,7 @@
 
 ### In flight (fork)
 
-- **Nested/cross-queue parents**: test-first regression `cec217e`; implementation commits `feda517`, `2328af9`, `1605889`, `6446530`, and `3465f30`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 104, reconciles removed children including nested and DAG exists-to-HSET TOCTOU races with ghost parent-set cleanup, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone flow and distinct-queue DAG execution regressions are green; cluster services were not available locally.
+- **Nested/cross-queue parents**: test-first regression `d31d6d3`; implementation commits include `df7fbac`, `b292c2c`, `fd145cc`, `a7cd7fa`, `4d5057c`, and `1765895`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 106, reconciles removed children including nested and DAG exists-to-HSET TOCTOU races with ghost parent-set cleanup, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone flow and distinct-queue DAG execution regressions are green; cluster services were not available locally.
 
 ### 0.15.4 Release Notes
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -21,7 +21,7 @@
 
 ### In flight (fork)
 
-- **Nested/cross-queue parents**: test-first regression `d31d6d3`; implementation commits include `df7fbac`, `b292c2c`, `fd145cc`, `a7cd7fa`, `4d5057c`, and `1765895`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 108, reconciles removed children including nested and DAG exists-to-HSET TOCTOU races with ghost parent-set cleanup, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone flow and distinct-queue DAG execution regressions are green; cluster services were not available locally.
+- **Nested/cross-queue parents**: test-first regression `a39d87a`; implementation spans `5603dc0` through `32f1395`, followed by the Sonar cleanup in `79a573a`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 110, reconciles removed children including nested and DAG exists-to-HSET TOCTOU races with ghost parent-set cleanup, JSON-encodes retryable child-slot notifications, eagerly delivers completion-time cross-queue notifications without adding a steady-state RTT, deduplicates overlapping tree/DAG edges, and removes `xq-pending` during obliterate. Standalone and cluster integration CI are green.
 
 ### 0.15.4 Release Notes
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -21,7 +21,7 @@
 
 ### In flight (fork)
 
-- **Nested/cross-queue parents**: test-first regression `aa04aa0`; implementation commits `a56e1dd`, `164107b`, `5c9fc52`, and `84a914f`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 104, reconciles removed children including the exists-to-HSET TOCTOU and ghost parent-set cleanup, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone flow and distinct-queue DAG execution regressions are green; cluster services were not available locally.
+- **Nested/cross-queue parents**: test-first regression `cec217e`; implementation commits `feda517`, `2328af9`, `1605889`, `6446530`, and `3465f30`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 104, reconciles removed children including nested and DAG exists-to-HSET TOCTOU races with ghost parent-set cleanup, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone flow and distinct-queue DAG execution regressions are green; cluster services were not available locally.
 
 ### 0.15.4 Release Notes
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -21,7 +21,7 @@
 
 ### In flight (fork)
 
-- **Nested/cross-queue parents**: test-first regression `d3a9782`; implementation `1cc2530` + `8cef166` + `c5eaaab` + `507fb63`. Lua source is `src/functions/glidemq.lua`; cross-slot DAG parent deps use single-slot commands and child-scheduler notifications are retryable/idempotent.
+- **Nested/cross-queue parents**: test-first regression `42e35b4`; implementation commits `6fe1f48`, `937e9aa`, and `e793cf9`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 104, reconciles removed children, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone targeted flow and distinct-queue DAG regressions are green; cluster services were not available locally.
 
 ### 0.15.4 Release Notes
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -21,7 +21,7 @@
 
 ### In flight (fork)
 
-- **Nested/cross-queue parents**: test-first regression `89a2140`; implementation commits `9201ffe`, `1bd8d57`, and `515b8a0`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 104, reconciles removed children including the exists-to-HSET TOCTOU, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone flow and distinct-queue DAG execution regressions are green; cluster services were not available locally.
+- **Nested/cross-queue parents**: test-first regression `aa04aa0`; implementation commits `a56e1dd`, `164107b`, `5c9fc52`, and `84a914f`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 104, reconciles removed children including the exists-to-HSET TOCTOU and ghost parent-set cleanup, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone flow and distinct-queue DAG execution regressions are green; cluster services were not available locally.
 
 ### 0.15.4 Release Notes
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -21,7 +21,7 @@
 
 ### In flight (fork)
 
-- **Nested/cross-queue parents**: test-first regression `42e35b4`; implementation commits `6fe1f48`, `937e9aa`, and `e793cf9`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 104, reconciles removed children, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone targeted flow and distinct-queue DAG regressions are green; cluster services were not available locally.
+- **Nested/cross-queue parents**: test-first regression `89a2140`; implementation commits `9201ffe`, `1bd8d57`, and `515b8a0`. The branch is independent of `upstream/main`, uses `LIBRARY_VERSION` 104, reconciles removed children including the exists-to-HSET TOCTOU, JSON-encodes retryable child-slot notifications, and removes `xq-pending` during obliterate. Standalone flow and distinct-queue DAG execution regressions are green; cluster services were not available locally.
 
 ### 0.15.4 Release Notes
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -19,6 +19,10 @@
 - **0.15.3** (#222-#246): DAG dependency direction/tree rendering/multi-dependent leaf fixes, `addDAG` level batching, stalled-job redispatch semantics, large-key `UNLINK` cleanup, bounded ordering skip-marker advancement, serverless credential cache scoping, flow ID-collision guards, proxy strict opts validation, long-running job heartbeats, broadcast retry isolation, queue client single-flight, and dependency CVE fixes. `LIBRARY_VERSION` 93.
 - **0.15.4**: interval scheduler anchoring prevents late worker ticks from accumulating drift, `npm test` now runs the intended non-fuzzer suite, and CI/local compose coverage use stable Valkey 9.1.0 images.
 
+### In flight (fork)
+
+- **Nested/cross-queue parents**: test-first regression `211d3b7`; implementation `fec97d1`. Lua source is `src/functions/glidemq.lua`; cross-slot parent notifications are retried by the child queue scheduler.
+
 ### 0.15.4 Release Notes
 
 See CHANGELOG.md `0.15.4` for the full list. Highlights:

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -45,6 +45,7 @@ import {
 import {
   completeJob,
   completeAndFetchNext,
+  completeChild,
   failJob,
   addJob,
   rateLimit as rateLimitFn,
@@ -709,9 +710,10 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           Date.now(),
           this.consumerGroup,
           entry.job.opts.removeOnComplete,
-          parentInfo,
+          this.inlineParentInfo(parentInfo),
           this.broadcastMode ? true : undefined,
         );
+        await this.notifyCrossQueueParent(parentInfo);
 
         entry.job.returnvalue = result;
         entry.job.finishedOn = Date.now();
@@ -770,9 +772,10 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
             Date.now(),
             this.consumerGroup,
             entry.job.opts.removeOnComplete,
-            parentInfo,
+            this.inlineParentInfo(parentInfo),
             this.broadcastMode ? true : undefined,
           );
+          await this.notifyCrossQueueParent(parentInfo);
 
           entry.job.returnvalue = result as R;
           entry.job.finishedOn = Date.now();
@@ -1132,11 +1135,9 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     let parentId = job.parentId;
     let parentQueue = job.parentQueue;
 
-    // Fast path: no parent fields at all - skip the Valkey round trip
-    if (!parentId && !parentQueue) return undefined;
-
-    // One field missing: re-fetch from hash to handle partial data
-    if ((!parentId || !parentQueue) && this.commandClient) {
+    // Always re-read: nested flows patch parentId after the child is already
+    // in a worker, so the in-memory snapshot can still be empty at complete.
+    if (this.commandClient) {
       const [refreshedParentId, refreshedParentQueue] = await this.commandClient.hmget(this.queueKeys.job(jobId), [
         'parentId',
         'parentQueue',
@@ -1151,6 +1152,25 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       parentId,
       parentKeys: buildKeys(parentQueue, this.opts.prefix),
     };
+  }
+
+  /** Same-slot parent keys can be inlined in complete FCALLs; other queues must be notified separately. */
+  protected inlineParentInfo(
+    parentInfo: { depsMember: string; parentId: string; parentKeys: QueueKeys } | undefined,
+  ): { depsMember: string; parentId: string; parentKeys: QueueKeys } | undefined {
+    if (!parentInfo) return undefined;
+    return parentInfo.parentKeys.stream === this.queueKeys.stream ? parentInfo : undefined;
+  }
+
+  protected async notifyCrossQueueParent(
+    parentInfo: { depsMember: string; parentId: string; parentKeys: QueueKeys } | undefined,
+  ): Promise<void> {
+    if (!parentInfo || !this.commandClient) return;
+    if (parentInfo.parentKeys.stream === this.queueKeys.stream) return;
+    await completeChild(this.commandClient, parentInfo.parentKeys, parentInfo.parentId, parentInfo.depsMember);
+    await this.commandClient.srem(this.queueKeys.xqPending, [
+      `${parentInfo.parentKeys.name}\t${parentInfo.parentId}\t${parentInfo.depsMember}`,
+    ]);
   }
 
   protected orderingMetaField(job: Job<D, R>): string | null {
@@ -1428,8 +1448,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           return;
         }
       }
-      // Fast path: skip async buildParentInfo when no parent fields present
-      const parentInfo = job.parentId || job.parentQueue ? await this.buildParentInfo(job, currentJobId) : undefined;
+      const parentInfo = await this.buildParentInfo(job, currentJobId);
 
       const now = Date.now();
       const fetchResult = await completeAndFetchNext(
@@ -1442,7 +1461,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         this.consumerGroup,
         this.consumerId,
         job.opts.removeOnComplete,
-        parentInfo,
+        this.inlineParentInfo(parentInfo),
         completionHints,
         this.broadcastMode ? true : undefined,
         job.processedOn,
@@ -1451,6 +1470,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         this.skipMetrics,
       );
 
+      await this.notifyCrossQueueParent(parentInfo);
       job.returnvalue = processResult;
       job.finishedOn = now;
       if (this.hasCompletedListeners) this.emit('completed', job, processResult);

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -18,6 +18,7 @@ import {
   calculateBackoff,
   computeFollowingSchedulerNextRun,
   computeWeightedTotal,
+  encodeCrossQueueParentNotify,
   keyPrefix,
   nextReconnectDelay,
   parseJsonRecord,
@@ -1169,7 +1170,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     if (parentInfo.parentKeys.stream === this.queueKeys.stream) return;
     await completeChild(this.commandClient, parentInfo.parentKeys, parentInfo.parentId, parentInfo.depsMember);
     await this.commandClient.srem(this.queueKeys.xqPending, [
-      `${parentInfo.parentKeys.name}\t${parentInfo.parentId}\t${parentInfo.depsMember}`,
+      encodeCrossQueueParentNotify(parentInfo.parentKeys.name, parentInfo.parentId, parentInfo.depsMember),
     ]);
   }
 

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -18,9 +18,8 @@ import {
   calculateBackoff,
   computeFollowingSchedulerNextRun,
   computeWeightedTotal,
-  encodeCrossQueueParentNotify,
-  keyPrefix,
   nextReconnectDelay,
+  parseCrossQueueParentNotification,
   parseJsonRecord,
   reconnectWithBackoff,
   MAX_JOB_DATA_SIZE,
@@ -59,7 +58,6 @@ import {
   checkBudget,
   recordUsageAndCheckBudget,
 } from './functions/index';
-import type { QueueKeys } from './functions/index';
 import { Scheduler } from './scheduler';
 
 export type WorkerEvent =
@@ -700,9 +698,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           continue;
         }
 
-        const parentInfo = await this.buildParentInfo(entry.job, entry.jobId);
-
-        await completeJob(
+        const notifications = await completeJob(
           this.commandClient!,
           this.queueKeys,
           entry.jobId,
@@ -711,10 +707,10 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           Date.now(),
           this.consumerGroup,
           entry.job.opts.removeOnComplete,
-          this.inlineParentInfo(parentInfo),
+          undefined,
           this.broadcastMode ? true : undefined,
         );
-        await this.notifyCrossQueueParent(parentInfo);
+        await this.notifyCrossQueueParents(notifications);
 
         entry.job.returnvalue = result;
         entry.job.finishedOn = Date.now();
@@ -762,9 +758,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
             continue;
           }
 
-          const parentInfo = await this.buildParentInfo(entry.job, entry.jobId);
-
-          await completeJob(
+          const notifications = await completeJob(
             this.commandClient!,
             this.queueKeys,
             entry.jobId,
@@ -773,10 +767,10 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
             Date.now(),
             this.consumerGroup,
             entry.job.opts.removeOnComplete,
-            this.inlineParentInfo(parentInfo),
+            undefined,
             this.broadcastMode ? true : undefined,
           );
-          await this.notifyCrossQueueParent(parentInfo);
+          await this.notifyCrossQueueParents(notifications);
 
           entry.job.returnvalue = result as R;
           entry.job.finishedOn = Date.now();
@@ -1126,52 +1120,16 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     }
   }
 
-  /**
-   * Build parent dependency info for complete/completeAndFetchNext calls.
-   */
-  protected async buildParentInfo(
-    job: Job<D, R>,
-    jobId: string,
-  ): Promise<{ depsMember: string; parentId: string; parentKeys: QueueKeys } | undefined> {
-    let parentId = job.parentId;
-    let parentQueue = job.parentQueue;
-
-    // Always re-read: nested flows patch parentId after the child is already
-    // in a worker, so the in-memory snapshot can still be empty at complete.
-    if (this.commandClient) {
-      const [refreshedParentId, refreshedParentQueue] = await this.commandClient.hmget(this.queueKeys.job(jobId), [
-        'parentId',
-        'parentQueue',
-      ]);
-      parentId = refreshedParentId ? String(refreshedParentId) : parentId;
-      parentQueue = refreshedParentQueue ? String(refreshedParentQueue) : parentQueue;
+  /** Deliver notifications recorded atomically by the completion FCALL. */
+  protected async notifyCrossQueueParents(notifications: string[]): Promise<void> {
+    if (!this.commandClient) return;
+    for (const member of notifications) {
+      const notification = parseCrossQueueParentNotification(member);
+      if (!notification) continue;
+      const [parentQueue, parentId, depsMember] = notification;
+      await completeChild(this.commandClient, buildKeys(parentQueue, this.opts.prefix), parentId, depsMember);
+      await this.commandClient.srem(this.queueKeys.xqPending, [member]);
     }
-
-    if (!parentId || !parentQueue) return undefined;
-    return {
-      depsMember: `${keyPrefix(this.opts.prefix ?? 'glide', this.name)}:${jobId}`,
-      parentId,
-      parentKeys: buildKeys(parentQueue, this.opts.prefix),
-    };
-  }
-
-  /** Same-slot parent keys can be inlined in complete FCALLs; other queues must be notified separately. */
-  protected inlineParentInfo(
-    parentInfo: { depsMember: string; parentId: string; parentKeys: QueueKeys } | undefined,
-  ): { depsMember: string; parentId: string; parentKeys: QueueKeys } | undefined {
-    if (!parentInfo) return undefined;
-    return parentInfo.parentKeys.stream === this.queueKeys.stream ? parentInfo : undefined;
-  }
-
-  protected async notifyCrossQueueParent(
-    parentInfo: { depsMember: string; parentId: string; parentKeys: QueueKeys } | undefined,
-  ): Promise<void> {
-    if (!parentInfo || !this.commandClient) return;
-    if (parentInfo.parentKeys.stream === this.queueKeys.stream) return;
-    await completeChild(this.commandClient, parentInfo.parentKeys, parentInfo.parentId, parentInfo.depsMember);
-    await this.commandClient.srem(this.queueKeys.xqPending, [
-      encodeCrossQueueParentNotify(parentInfo.parentKeys.name, parentInfo.parentId, parentInfo.depsMember),
-    ]);
   }
 
   protected orderingMetaField(job: Job<D, R>): string | null {
@@ -1449,8 +1407,6 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           return;
         }
       }
-      const parentInfo = await this.buildParentInfo(job, currentJobId);
-
       const now = Date.now();
       const fetchResult = await completeAndFetchNext(
         this.commandClient,
@@ -1462,7 +1418,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         this.consumerGroup,
         this.consumerId,
         job.opts.removeOnComplete,
-        this.inlineParentInfo(parentInfo),
+        undefined,
         completionHints,
         this.broadcastMode ? true : undefined,
         job.processedOn,
@@ -1471,7 +1427,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         this.skipMetrics,
       );
 
-      await this.notifyCrossQueueParent(parentInfo);
+      await this.notifyCrossQueueParents(fetchResult.parentNotifications);
       job.returnvalue = processResult;
       job.finishedOn = now;
       if (this.hasCompletedListeners) this.emit('completed', job, processResult);

--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -393,9 +393,10 @@ export class FlowProducer {
    * parent dependency.
    *
    * Submission is pipelined by topological level: within a level, all primary
-   * FCALLs are sent in one Batch (non-atomic pipeline), then a second Batch
-   * wires cross-level edges (registerParent) and persists parentIds metadata.
-   * RTT is O(levels) instead of O(N).
+   * FCALLs are sent in one Batch (non-atomic pipeline), then a child-slot batch
+   * persists parent metadata and cross-queue parent references. Same-queue
+   * registerParent calls and cross-queue parent notifications are completed
+   * after that batch. RTT is O(levels) plus cross-slot notification wiring.
    *
    * Returns a map of node name to Job instance.
    */
@@ -539,14 +540,15 @@ export class FlowProducer {
               );
               submits.push({ node, kind: 'addFlow', timestamp, opts });
             } else if (myDependents.length === 1) {
-              // Leaf with a single dependent: piggyback on addJob's
+              // Leaf with a same-queue dependent: piggyback on addJob's
               // parentId/parentDepsKey so the leaf atomically registers as
-              // child of that dependent. No second dependent, so no race
-              // between addJob enqueueing and parents-SET wiring.
+              // child of that dependent. Cross-queue keys cannot be passed
+              // to this FCALL; those edges are wired in Phase B instead.
               const firstDepName = myDependents[0];
               const firstParentJob = result.get(firstDepName)!;
               const firstParentNode = nodeByName.get(firstDepName)!;
-              const firstParentKeys = buildKeys(firstParentNode.queueName, prefix);
+              const sameQueue = firstParentNode.queueName === node.queueName;
+              const firstParentKeys = sameQueue ? buildKeys(firstParentNode.queueName, prefix) : undefined;
               const { keys, args } = addJobArgs(
                 queueKeys,
                 node.name,
@@ -555,7 +557,7 @@ export class FlowProducer {
                 timestamp,
                 opts.delay ?? 0,
                 opts.priority ?? 0,
-                firstParentJob.id,
+                sameQueue ? firstParentJob.id : '',
                 opts.attempts ?? 0,
                 orderingKey ?? '',
                 groupConcurrency,
@@ -567,8 +569,8 @@ export class FlowProducer {
                 opts.ttl ?? 0,
                 customJobId,
                 opts.lifo ? 1 : 0,
-                firstParentNode.queueName,
-                firstParentKeys.deps(firstParentJob.id),
+                sameQueue ? firstParentNode.queueName : '',
+                sameQueue ? firstParentKeys!.deps(firstParentJob.id) : '',
                 '',
               );
               batchA.fcall('glidemq_addJob', keys, args);
@@ -685,11 +687,25 @@ export class FlowProducer {
             result.set(sub.node.name, job);
           }
 
-          // Phase B: pipeline cross-level wiring (registerParent + parentIds hset).
+          // Phase B: pipeline child-slot wiring and parent metadata.
+          //
+          // A ClusterBatch may contain commands for different slots, but an
+          // FCALL may not. Keep every batched command single-key and run
+          // registerParent only for same-queue edges. Cross-queue parent deps
+          // are added with a parent-slot SADD, while the child parents SET is
+          // written in this child-slot batch. Both operations are idempotent;
+          // completed-state reconciliation below closes the race where a
+          // child finishes between them.
           const batchB = isCluster ? new ClusterBatch(false) : new Batch(false);
-          let phaseBCount = 0;
-          // Track each batched registerParent's edge so we can report failures.
-          const phaseBRegEdges: { node: string; dep: string }[] = [];
+          const phaseBSlots: { kind: 'hset' | 'parents'; node: string; dep?: string }[] = [];
+          const sameQueueEdges: { node: string; jid: string; dep: string }[] = [];
+          const crossQueueEdges: {
+            node: string;
+            jid: string;
+            dep: string;
+            parentId: string;
+            parentQueue: string;
+          }[] = [];
 
           for (const sub of submits) {
             const node = sub.node;
@@ -714,6 +730,12 @@ export class FlowProducer {
               registerStart = 0;
             } else if (deps.length === 0 && myDependents.length > 1) {
               registerStart = 0;
+            } else if (
+              deps.length === 0 &&
+              myDependents.length === 1 &&
+              nodeByName.get(myDependents[0])!.queueName !== node.queueName
+            ) {
+              registerStart = 0;
             }
 
             if (registerStart >= 0) {
@@ -725,8 +747,7 @@ export class FlowProducer {
                 parentIds: JSON.stringify(pIds),
                 parentQueues: JSON.stringify(pQueues),
               });
-              phaseBCount++;
-              phaseBRegEdges.push({ node: '', dep: '' }); // placeholder for hset slot
+              phaseBSlots.push({ kind: 'hset', node: node.name });
 
               for (let p = registerStart; p < myDependents.length; p++) {
                 const depName = myDependents[p];
@@ -734,25 +755,27 @@ export class FlowProducer {
                 const parentNode = nodeByName.get(depName)!;
                 const parentQueueKeys = buildKeys(parentNode.queueName, prefix);
                 const depsMember = `${queuePrefix}:${jid}`;
-                batchB.fcall(
-                  'glidemq_registerParent',
-                  [
-                    queueKeys.job(jid),
-                    queueKeys.parents(jid),
-                    parentQueueKeys.deps(parentJob.id),
-                    parentQueueKeys.job(parentJob.id),
-                    parentQueueKeys.stream,
-                    parentQueueKeys.events,
-                  ],
-                  [jid, parentJob.id, keyPrefix(prefix, parentNode.queueName), depsMember],
-                );
-                phaseBCount++;
-                phaseBRegEdges.push({ node: node.name, dep: depName });
+                if (parentNode.queueName === node.queueName) {
+                  sameQueueEdges.push({ node: node.name, jid, dep: depName });
+                } else {
+                  // Parent deps live on the parent queue's slot. SADD is
+                  // idempotent, so retries cannot double-count a dependency.
+                  await client.sadd(parentQueueKeys.deps(parentJob.id), [depsMember]);
+                  batchB.sadd(queueKeys.parents(jid), [`${keyPrefix(prefix, parentNode.queueName)}:${parentJob.id}`]);
+                  phaseBSlots.push({ kind: 'parents', node: node.name, dep: depName });
+                  crossQueueEdges.push({
+                    node: node.name,
+                    jid,
+                    dep: depName,
+                    parentId: parentJob.id,
+                    parentQueue: parentNode.queueName,
+                  });
+                }
               }
             }
           }
 
-          if (phaseBCount > 0) {
+          if (phaseBSlots.length > 0) {
             let rawB: unknown;
             try {
               rawB = isCluster
@@ -764,16 +787,50 @@ export class FlowProducer {
                 `DAG partially submitted: cross-level wiring batch failed: ${msg}. Graph may be in inconsistent state.`,
               );
             }
-            if (!Array.isArray(rawB) || rawB.length !== phaseBCount) {
+            if (!Array.isArray(rawB) || rawB.length !== phaseBSlots.length) {
               throw new GlideMQError('addDAG cross-level batch returned unexpected result length');
             }
-            for (let i = 0; i < phaseBCount; i++) {
-              const edge = phaseBRegEdges[i];
-              if (edge.node === '') continue; // hset slot
+            for (let i = 0; i < phaseBSlots.length; i++) {
+              const edge = phaseBSlots[i];
               const res = String(rawB[i]);
               if (res.startsWith('error:')) {
-                throw new GlideMQError(`Failed to register dependent ${edge.dep} for node ${edge.node}: ${res}`);
+                throw new GlideMQError(`Failed to wire dependent ${edge.dep ?? ''} for node ${edge.node}: ${res}`);
               }
+            }
+          }
+
+          for (const edge of sameQueueEdges) {
+            const node = nodeByName.get(edge.node)!;
+            const parentNode = nodeByName.get(edge.dep)!;
+            const parentJob = result.get(edge.dep)!;
+            const childKeys = buildKeys(node.queueName, prefix);
+            const parentKeys = buildKeys(parentNode.queueName, prefix);
+            const depsMember = `${keyPrefix(prefix, node.queueName)}:${edge.jid}`;
+            const registration = await registerParent(
+              client,
+              childKeys,
+              edge.jid,
+              parentJob.id,
+              keyPrefix(prefix, parentNode.queueName),
+              parentKeys,
+              depsMember,
+            );
+            if (registration.startsWith('error:')) {
+              throw new GlideMQError(`Failed to register dependent ${edge.dep} for node ${edge.node}: ${registration}`);
+            }
+          }
+
+          for (const edge of crossQueueEdges) {
+            const node = nodeByName.get(edge.node)!;
+            const childKeys = buildKeys(node.queueName, prefix);
+            const state = await client.hget(childKeys.job(edge.jid), 'state');
+            if (String(state) === 'completed') {
+              await completeChild(
+                client,
+                buildKeys(edge.parentQueue, prefix),
+                edge.parentId,
+                `${keyPrefix(prefix, node.queueName)}:${edge.jid}`,
+              );
             }
           }
         }

--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -771,8 +771,7 @@ export class FlowProducer {
             if (shouldRegister) {
               if ((await client.exists([queueKeys.job(jid)])) === 0) {
                 const depsMember = `${queuePrefix}:${jid}`;
-                for (let p = 0; p < myDependents.length; p++) {
-                  const depName = myDependents[p];
+                for (const depName of myDependents) {
                   const parentJob = result.get(depName)!;
                   const parentNode = nodeByName.get(depName)!;
                   await client.sadd(buildKeys(parentNode.queueName, prefix).deps(parentJob.id), [depsMember]);
@@ -797,8 +796,7 @@ export class FlowProducer {
               phaseBSlots.push({ kind: 'hset', node: node.name });
               phaseBChildren.push({ node: node.name, jid });
 
-              for (let p = 0; p < myDependents.length; p++) {
-                const depName = myDependents[p];
+              for (const depName of myDependents) {
                 const parentJob = result.get(depName)!;
                 const parentNode = nodeByName.get(depName)!;
                 const parentQueueKeys = buildKeys(parentNode.queueName, prefix);

--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -741,6 +741,8 @@ export class FlowProducer {
             parentQueue: string;
             dep: string;
           }[] = [];
+          const phaseBChildren: { node: string; jid: string }[] = [];
+          const removedPhaseBChildren = new Set<string>();
 
           for (const sub of submits) {
             const node = sub.node;
@@ -800,6 +802,7 @@ export class FlowProducer {
                 parentQueues: JSON.stringify(pQueues),
               });
               phaseBSlots.push({ kind: 'hset', node: node.name });
+              phaseBChildren.push({ node: node.name, jid });
 
               for (let p = registerStart; p < myDependents.length; p++) {
                 const depName = myDependents[p];
@@ -851,7 +854,28 @@ export class FlowProducer {
             }
           }
 
+          // A child can be deleted after the Phase-A EXISTS check but before
+          // the Phase-B HSET. HSET would recreate a hash without state, and a
+          // same-queue registerParent would then incorrectly return ok. Remove
+          // that ghost and reconcile every dependent instead.
+          for (const child of phaseBChildren) {
+            const node = nodeByName.get(child.node)!;
+            const childKeys = buildKeys(node.queueName, prefix);
+            const childState = await client.hget(childKeys.job(child.jid), 'state');
+            if (childState != null) continue;
+            removedPhaseBChildren.add(child.node);
+            await client.del([childKeys.job(child.jid), childKeys.parents(child.jid)]);
+            const depsMember = `${keyPrefix(prefix, node.queueName)}:${child.jid}`;
+            for (const depName of dependents.get(child.node) ?? []) {
+              const parentJob = result.get(depName)!;
+              const parentKeys = buildKeys(nodeByName.get(depName)!.queueName, prefix);
+              await client.sadd(parentKeys.deps(parentJob.id), [depsMember]);
+              await completeChild(client, parentKeys, parentJob.id, depsMember);
+            }
+          }
+
           for (const edge of sameQueueEdges) {
+            if (removedPhaseBChildren.has(edge.node)) continue;
             const node = nodeByName.get(edge.node)!;
             const parentNode = nodeByName.get(edge.dep)!;
             const parentJob = result.get(edge.dep)!;
@@ -885,6 +909,7 @@ export class FlowProducer {
           }
 
           for (const edge of crossQueueEdges) {
+            if (removedPhaseBChildren.has(edge.node)) continue;
             const node = nodeByName.get(edge.node)!;
             const childKeys = buildKeys(node.queueName, prefix);
             const state = await client.hget(childKeys.job(edge.jid), 'state');

--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -4,7 +4,7 @@ import { Job } from './job';
 import { buildKeys, keyPrefix, MAX_JOB_DATA_SIZE, validateJobId, validateQueueName } from './utils';
 import { createClient, ensureFunctionLibrary, ensureFunctionLibraryOnce, isClusterClient } from './connection';
 import { GlideMQError } from './errors';
-import { LIBRARY_SOURCE, addFlow, addJob, addJobArgs, completeChild } from './functions/index';
+import { LIBRARY_SOURCE, addFlow, addJob, addJobArgs, completeChild, registerParent } from './functions/index';
 import { withSpan } from './telemetry';
 import { validateDAG, topoSort } from './dag-utils';
 import { Batch, ClusterBatch, type GlideClient, type GlideClusterClient } from '@glidemq/speedkey';
@@ -13,19 +13,6 @@ export interface JobNode {
   job: Job;
   children?: JobNode[];
 }
-
-/**
- * Race-condition constants for late-parent reconciliation in addFlowRecursive.
- *
- * Children are created before the parent job exists. Between child creation and
- * parent creation, a worker may pick up and complete a child job. When that
- * happens, the child's completion Lua script cannot notify the parent (it does
- * not exist yet). The reconcile loop below polls the child state after parent
- * creation; if the child has already completed, it manually calls completeChild
- * so the parent's dependency counter is incremented and the parent can proceed.
- */
-const LATE_PARENT_RECONCILE_ATTEMPTS = 5;
-const LATE_PARENT_RECONCILE_DELAY_MS = 10;
 
 /**
  * Creates parent-child job flows and DAG workflows.
@@ -330,26 +317,36 @@ export class FlowProducer {
     }
     const parentId = ids[0];
 
-    // Set parentId and parentQueue on pre-existing sub-flow children
+    // Wire pre-existing sub-flow children to this parent. registerParent also
+    // notifies the parent if the child already completed during the race.
     for (const [i, subNode] of childNodeMap.entries()) {
       const child = flow.children[i];
       const childKeys = buildKeys(child.queueName, prefix);
       const depsMember = `${keyPrefix(prefix, child.queueName)}:${subNode.job.id}`;
-      await client.hset(childKeys.job(subNode.job.id), {
-        parentId: parentId,
-        parentQueue: parentQueueName,
-      });
-      let state = await client.hget(childKeys.job(subNode.job.id), 'state');
-      for (
-        let attempt = 0;
-        state && String(state) !== 'completed' && attempt < LATE_PARENT_RECONCILE_ATTEMPTS;
-        attempt++
-      ) {
-        await new Promise<void>((resolve) => setTimeout(resolve, LATE_PARENT_RECONCILE_DELAY_MS));
-        state = await client.hget(childKeys.job(subNode.job.id), 'state');
-      }
-      if (state && String(state) === 'completed') {
-        await completeChild(client, parentKeys, parentId, depsMember);
+      if (child.queueName === parentQueueName) {
+        await registerParent(
+          client,
+          childKeys,
+          subNode.job.id,
+          parentId,
+          keyPrefix(prefix, parentQueueName),
+          parentKeys,
+          depsMember,
+        );
+        await client.hset(childKeys.job(subNode.job.id), {
+          parentId: parentId,
+          parentQueue: parentQueueName,
+        });
+      } else {
+        await client.hset(childKeys.job(subNode.job.id), {
+          parentId: parentId,
+          parentQueue: parentQueueName,
+        });
+        await client.sadd(childKeys.parents(subNode.job.id), [`${keyPrefix(prefix, parentQueueName)}:${parentId}`]);
+        const state = await client.hget(childKeys.job(subNode.job.id), 'state');
+        if (state && String(state) === 'completed') {
+          await completeChild(client, parentKeys, parentId, depsMember);
+        }
       }
       subNode.job.parentId = parentId;
       subNode.job.parentQueue = parentQueueName;

--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -344,6 +344,7 @@ export class FlowProducer {
           // The hash was deleted between EXISTS and HSET. Remove the partial
           // hash so a removed child is not resurrected as a ghost job.
           await client.del([childKeys.job(subNode.job.id)]);
+          await client.del([childKeys.parents(subNode.job.id)]);
           await client.sadd(parentKeys.deps(parentId), [depsMember]);
           await completeChild(client, parentKeys, parentId, depsMember);
         } else {
@@ -371,7 +372,9 @@ export class FlowProducer {
         await client.sadd(childKeys.parents(subNode.job.id), [`${keyPrefix(prefix, parentQueueName)}:${parentId}`]);
         const state = await client.hget(childKeys.job(subNode.job.id), 'state');
         if (state == null || String(state) === 'completed') {
-          if (state == null) await client.del([childKeys.job(subNode.job.id)]);
+          if (state == null) {
+            await client.del([childKeys.job(subNode.job.id), childKeys.parents(subNode.job.id)]);
+          }
           await completeChild(client, parentKeys, parentId, depsMember);
         }
       }

--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -324,6 +324,12 @@ export class FlowProducer {
       const childKeys = buildKeys(child.queueName, prefix);
       const depsMember = `${keyPrefix(prefix, child.queueName)}:${subNode.job.id}`;
       if (child.queueName === parentQueueName) {
+        // Persist the edge before registerParent's completed-state check so a
+        // worker completing in this window can re-read parent metadata.
+        await client.hset(childKeys.job(subNode.job.id), {
+          parentId: parentId,
+          parentQueue: parentQueueName,
+        });
         await registerParent(
           client,
           childKeys,
@@ -333,10 +339,6 @@ export class FlowProducer {
           parentKeys,
           depsMember,
         );
-        await client.hset(childKeys.job(subNode.job.id), {
-          parentId: parentId,
-          parentQueue: parentQueueName,
-        });
       } else {
         await client.hset(childKeys.job(subNode.job.id), {
           parentId: parentId,

--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -323,6 +323,15 @@ export class FlowProducer {
       const child = flow.children[i];
       const childKeys = buildKeys(child.queueName, prefix);
       const depsMember = `${keyPrefix(prefix, child.queueName)}:${subNode.job.id}`;
+      if ((await client.exists([childKeys.job(subNode.job.id)])) === 0) {
+        // The recursive child may have been removed after the parent was
+        // created. Reconcile the parent dependency without recreating a ghost
+        // child hash.
+        await completeChild(client, parentKeys, parentId, depsMember);
+        subNode.job.parentId = parentId;
+        subNode.job.parentQueue = parentQueueName;
+        continue;
+      }
       if (child.queueName === parentQueueName) {
         // Persist the edge before registerParent's completed-state check so a
         // worker completing in this window can re-read parent metadata.
@@ -330,15 +339,30 @@ export class FlowProducer {
           parentId: parentId,
           parentQueue: parentQueueName,
         });
-        await registerParent(
-          client,
-          childKeys,
-          subNode.job.id,
-          parentId,
-          keyPrefix(prefix, parentQueueName),
-          parentKeys,
-          depsMember,
-        );
+        const childState = await client.hget(childKeys.job(subNode.job.id), 'state');
+        if (childState == null) {
+          // The hash was deleted between EXISTS and HSET. Remove the partial
+          // hash so a removed child is not resurrected as a ghost job.
+          await client.del([childKeys.job(subNode.job.id)]);
+          await client.sadd(parentKeys.deps(parentId), [depsMember]);
+          await completeChild(client, parentKeys, parentId, depsMember);
+        } else {
+          const registration = await registerParent(
+            client,
+            childKeys,
+            subNode.job.id,
+            parentId,
+            keyPrefix(prefix, parentQueueName),
+            parentKeys,
+            depsMember,
+          );
+          if (registration.startsWith('error:child_not_found')) {
+            await client.sadd(parentKeys.deps(parentId), [depsMember]);
+            await completeChild(client, parentKeys, parentId, depsMember);
+          } else if (registration.startsWith('error:')) {
+            throw new GlideMQError(`Failed to register nested child ${subNode.job.id}: ${registration}`);
+          }
+        }
       } else {
         await client.hset(childKeys.job(subNode.job.id), {
           parentId: parentId,
@@ -346,7 +370,8 @@ export class FlowProducer {
         });
         await client.sadd(childKeys.parents(subNode.job.id), [`${keyPrefix(prefix, parentQueueName)}:${parentId}`]);
         const state = await client.hget(childKeys.job(subNode.job.id), 'state');
-        if (state && String(state) === 'completed') {
+        if (state == null || String(state) === 'completed') {
+          if (state == null) await client.del([childKeys.job(subNode.job.id)]);
           await completeChild(client, parentKeys, parentId, depsMember);
         }
       }
@@ -706,6 +731,13 @@ export class FlowProducer {
             parentId: string;
             parentQueue: string;
           }[] = [];
+          const missingChildEdges: {
+            node: string;
+            jid: string;
+            parentId: string;
+            parentQueue: string;
+            dep: string;
+          }[] = [];
 
           for (const sub of submits) {
             const node = sub.node;
@@ -739,6 +771,23 @@ export class FlowProducer {
             }
 
             if (registerStart >= 0) {
+              if ((await client.exists([queueKeys.job(jid)])) === 0) {
+                const depsMember = `${queuePrefix}:${jid}`;
+                for (let p = registerStart; p < myDependents.length; p++) {
+                  const depName = myDependents[p];
+                  const parentJob = result.get(depName)!;
+                  const parentNode = nodeByName.get(depName)!;
+                  await client.sadd(buildKeys(parentNode.queueName, prefix).deps(parentJob.id), [depsMember]);
+                  missingChildEdges.push({
+                    node: node.name,
+                    jid,
+                    dep: depName,
+                    parentId: parentJob.id,
+                    parentQueue: parentNode.queueName,
+                  });
+                }
+                continue;
+              }
               const pIds = myDependents.map((d) => result.get(d)!.id);
               const pQueues = myDependents.map((d) => nodeByName.get(d)!.queueName);
               job.parentIds = pIds;
@@ -815,16 +864,28 @@ export class FlowProducer {
               parentKeys,
               depsMember,
             );
-            if (registration.startsWith('error:')) {
+            if (registration.startsWith('error:child_not_found')) {
+              await client.sadd(parentKeys.deps(parentJob.id), [depsMember]);
+              await completeChild(client, parentKeys, parentJob.id, depsMember);
+            } else if (registration.startsWith('error:')) {
               throw new GlideMQError(`Failed to register dependent ${edge.dep} for node ${edge.node}: ${registration}`);
             }
+          }
+
+          for (const edge of missingChildEdges) {
+            await completeChild(
+              client,
+              buildKeys(edge.parentQueue, prefix),
+              edge.parentId,
+              `${keyPrefix(prefix, nodeByName.get(edge.node)!.queueName)}:${edge.jid}`,
+            );
           }
 
           for (const edge of crossQueueEdges) {
             const node = nodeByName.get(edge.node)!;
             const childKeys = buildKeys(node.queueName, prefix);
             const state = await client.hget(childKeys.job(edge.jid), 'state');
-            if (String(state) === 'completed') {
+            if (state == null || String(state) === 'completed') {
               await completeChild(
                 client,
                 buildKeys(edge.parentQueue, prefix),

--- a/src/flow-producer.ts
+++ b/src/flow-producer.ts
@@ -762,23 +762,16 @@ export class FlowProducer {
             //    was submitted with no parent fields to avoid the partial-
             //    notification race; registerParent wires every dependent here
             //    and its already_completed path covers late wiring).
-            let registerStart = -1;
-            if (deps.length > 0 && myDependents.length > 0) {
-              registerStart = 0;
-            } else if (deps.length === 0 && myDependents.length > 1) {
-              registerStart = 0;
-            } else if (
-              deps.length === 0 &&
-              myDependents.length === 1 &&
-              nodeByName.get(myDependents[0])!.queueName !== node.queueName
-            ) {
-              registerStart = 0;
-            }
+            const shouldRegister =
+              (deps.length > 0 && myDependents.length > 0) ||
+              (deps.length === 0 &&
+                (myDependents.length > 1 ||
+                  (myDependents.length === 1 && nodeByName.get(myDependents[0])!.queueName !== node.queueName)));
 
-            if (registerStart >= 0) {
+            if (shouldRegister) {
               if ((await client.exists([queueKeys.job(jid)])) === 0) {
                 const depsMember = `${queuePrefix}:${jid}`;
-                for (let p = registerStart; p < myDependents.length; p++) {
+                for (let p = 0; p < myDependents.length; p++) {
                   const depName = myDependents[p];
                   const parentJob = result.get(depName)!;
                   const parentNode = nodeByName.get(depName)!;
@@ -804,7 +797,7 @@ export class FlowProducer {
               phaseBSlots.push({ kind: 'hset', node: node.name });
               phaseBChildren.push({ node: node.name, jid });
 
-              for (let p = registerStart; p < myDependents.length; p++) {
+              for (let p = 0; p < myDependents.length; p++) {
                 const depName = myDependents[p];
                 const parentJob = result.get(depName)!;
                 const parentNode = nodeByName.get(depName)!;

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -2593,6 +2593,10 @@ redis.register_function('glidemq_completeChild', function(keys, args)
   local parentEventsKey = keys[4]
   local depsMember = args[1]
   local parentId = args[2]
+  -- A stale cross-queue notification must not recreate a deleted parent hash.
+  if redis.call('EXISTS', parentJobKey) == 0 then
+    return -1
+  end
   local depMarker = 'depdone:' .. depsMember
   if redis.call('HSETNX', parentJobKey, depMarker, '1') == 0 then
     local doneCount = tonumber(redis.call('HGET', parentJobKey, 'depsCompleted')) or 0

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -293,6 +293,17 @@ local function releaseGroupSlotAndPromote(jobKey, jobId, now, hintGroupKey)
   end
 end
 
+-- Persist a retryable cross-queue parent notification on this child's hash
+-- slot. The scheduler later calls completeChild using only the parent keys.
+-- Member: parentQueueName TAB parentId TAB childQueuePrefix:childId
+local function enqueueCrossQueueParentNotify(prefix, jobId, parentQueueName, parentId)
+  if not parentQueueName or parentQueueName == '' or not parentId or parentId == '' then return end
+  local childQueueName = string.match(prefix, '{([^}]+)}')
+  if childQueueName and parentQueueName == childQueueName then return end
+  local childQueuePrefix = string.sub(prefix, 1, #prefix - 1)
+  redis.call('SADD', prefix .. 'xq-pending', parentQueueName .. '\t' .. parentId .. '\t' .. childQueuePrefix .. ':' .. jobId)
+end
+
 local function expireJob(jobKey, jobId, prefix, now, curState, hintOrderingKey, hintOrderingSeq, hintGroupKey)
   if curState == 'failed' then return true end
   local wasActive = (curState == 'active')
@@ -827,6 +838,7 @@ redis.register_function('glidemq_complete', function(keys, args)
   emitEvent(eventsKey, 'completed', jobId, {'returnvalue', returnvalue})
   recordMetrics(metricsKey, timestamp, timestamp - processedOn)
   local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
+  enqueueCrossQueueParentNotify(prefix, jobId, redis.call('HGET', jobKey, 'parentQueue'), redis.call('HGET', jobKey, 'parentId'))
   if broadcastMode ~= '1' then
     if removeMode == 'true' then
       redis.call('ZREM', completedKey, jobId)
@@ -909,6 +921,9 @@ redis.register_function('glidemq_complete', function(keys, args)
               end
             end
           end
+        else
+          local pTag = string.match(pQueue, '{([^}]+)}')
+          enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
         end
       end
     end
@@ -967,6 +982,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
   if skipEvents ~= '1' then emitEvent(eventsKey, 'completed', jobId, {'returnvalue', returnvalue}) end
   if skipMetrics ~= '1' then recordMetrics(metricsKey, timestamp, timestamp - processedOn) end
   local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
+  enqueueCrossQueueParentNotify(prefix, jobId, redis.call('HGET', jobKey, 'parentQueue'), redis.call('HGET', jobKey, 'parentId'))
   if entryId == '' then decrListActive(prefix .. 'list-active') end
 
   -- Retention cleanup (skip in broadcast mode - job hash must persist for all subscriptions)
@@ -1052,6 +1068,9 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
                 end
               end
             end
+          else
+            local pTag = string.match(pQueue, '{([^}]+)}')
+            enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
           end
         end
       end

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -293,12 +293,18 @@ local function releaseGroupSlotAndPromote(jobKey, jobId, now, hintGroupKey)
   end
 end
 
+-- Extract the queue's hash tag from a queue prefix. The configured prefix may
+-- itself contain braces, so only the final tag is the queue name.
+local function extractQueueTag(queuePrefix)
+  return string.match(queuePrefix, '{([^{}]+)}$')
+end
+
 -- Persist a retryable cross-queue parent notification on this child's hash
 -- slot. The scheduler later calls completeChild using only the parent keys.
 -- Member: JSON array [parentQueueName, parentId, childQueuePrefix:childId]
 local function enqueueCrossQueueParentNotify(prefix, jobId, parentQueueName, parentId)
   if not parentQueueName or parentQueueName == '' or not parentId or parentId == '' then return end
-  local childQueueName = string.match(prefix, '{([^}]+)}')
+  local childQueueName = extractQueueTag(string.sub(prefix, 1, #prefix - 1))
   if childQueueName and parentQueueName == childQueueName then return end
   local childQueuePrefix = string.sub(prefix, 1, #prefix - 1)
   redis.call('SADD', prefix .. 'xq-pending', cjson.encode({parentQueueName, parentId, childQueuePrefix .. ':' .. jobId}))
@@ -922,7 +928,7 @@ redis.register_function('glidemq_complete', function(keys, args)
             end
           end
         else
-          local pTag = string.match(pQueue, '{([^}]+)}')
+          local pTag = extractQueueTag(pQueue)
           enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
         end
       end
@@ -1069,7 +1075,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
               end
             end
           else
-            local pTag = string.match(pQueue, '{([^}]+)}')
+            local pTag = extractQueueTag(pQueue)
             enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
           end
         end

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -140,6 +140,30 @@ end
 local function xaddJob(streamKey, jobId, jobName)
   redis.call('XADD', streamKey, '*', 'jobId', jobId, 'name', jobName or '')
 end
+
+-- Complete one parent dependency without recreating a parent removed while its
+-- child was still in flight. All callers run inside a single FCALL, so the
+-- EXISTS/HSETNX sequence is atomic with respect to removal and completion.
+local function completeParentDependency(parentDepsKey, parentJobKey, parentStreamKey, parentEventsKey, depsMember, parentId)
+  if redis.call('EXISTS', parentJobKey) == 0 then
+    return -1
+  end
+  local depMarker = 'depdone:' .. depsMember
+  if redis.call('HSETNX', parentJobKey, depMarker, '1') == 0 then
+    local doneCount = tonumber(redis.call('HGET', parentJobKey, 'depsCompleted')) or 0
+    return redis.call('SCARD', parentDepsKey) - doneCount
+  end
+  local doneCount = redis.call('HINCRBY', parentJobKey, 'depsCompleted', 1)
+  local totalDeps = redis.call('SCARD', parentDepsKey)
+  local remaining = totalDeps - doneCount
+  if remaining <= 0 and redis.call('HGET', parentJobKey, 'state') == 'waiting-children' then
+    redis.call('HSET', parentJobKey, 'state', 'waiting')
+    xaddJob(parentStreamKey, parentId, redis.call('HGET', parentJobKey, 'name'))
+    emitEvent(parentEventsKey, 'active', parentId, nil)
+  end
+  return remaining
+end
+
 local function groupqScore(jobKey, jobId)
   local seq = tonumber(redis.call('HGET', jobKey, 'orderingSeq'))
   if seq and seq > 0 then return seq end
@@ -875,20 +899,7 @@ redis.register_function('glidemq_complete', function(keys, args)
     local parentJobKey = keys[7]
     local parentStreamKey = keys[8]
     local parentEventsKey = keys[9]
-    local depMarker = 'depdone:' .. depsMember
-    if redis.call('HSETNX', parentJobKey, depMarker, '1') == 1 then
-      local doneCount = redis.call('HINCRBY', parentJobKey, 'depsCompleted', 1)
-      local totalDeps = redis.call('SCARD', parentDepsKey)
-      local remaining = totalDeps - doneCount
-      if remaining <= 0 then
-        local parentState = redis.call('HGET', parentJobKey, 'state')
-        if parentState == 'waiting-children' then
-          redis.call('HSET', parentJobKey, 'state', 'waiting')
-          xaddJob(parentStreamKey, parentId, redis.call('HGET', parentJobKey, 'name'))
-          emitEvent(parentEventsKey, 'active', parentId, nil)
-        end
-      end
-    end
+    completeParentDependency(parentDepsKey, parentJobKey, parentStreamKey, parentEventsKey, depsMember, parentId)
   end
   -- DAG multi-parent: notify additional same-queue parents via parents SET
   local parentsKey = prefix .. 'parents:' .. jobId
@@ -914,19 +925,7 @@ redis.register_function('glidemq_complete', function(keys, args)
           local pDepsKey = pPrefix .. 'deps:' .. pId
           local pStreamKey = pPrefix .. 'stream'
           local pEventsKey = pPrefix .. 'events'
-          local pDepMarker = 'depdone:' .. dagDepsMember
-          if redis.call('HSETNX', pJobKey, pDepMarker, '1') == 1 then
-            local pDoneCount = redis.call('HINCRBY', pJobKey, 'depsCompleted', 1)
-            local pTotalDeps = redis.call('SCARD', pDepsKey)
-            if pTotalDeps - pDoneCount <= 0 then
-              local pState = redis.call('HGET', pJobKey, 'state')
-              if pState == 'waiting-children' then
-                redis.call('HSET', pJobKey, 'state', 'waiting')
-                xaddJob(pStreamKey, pId, redis.call('HGET', pJobKey, 'name'))
-                emitEvent(pEventsKey, 'active', pId, nil)
-              end
-            end
-          end
+          completeParentDependency(pDepsKey, pJobKey, pStreamKey, pEventsKey, dagDepsMember, pId)
         else
           local pTag = extractQueueTag(pQueue)
           enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
@@ -1024,19 +1023,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
     local parentJobKey = keys[7]
     local parentStreamKey = keys[8]
     local parentEventsKey = keys[9]
-    local depMarker = 'depdone:' .. depsMember
-    if redis.call('HSETNX', parentJobKey, depMarker, '1') == 1 then
-      local doneCount = redis.call('HINCRBY', parentJobKey, 'depsCompleted', 1)
-      local totalDeps = redis.call('SCARD', parentDepsKey)
-      if totalDeps - doneCount <= 0 then
-        local parentState = redis.call('HGET', parentJobKey, 'state')
-        if parentState == 'waiting-children' then
-          redis.call('HSET', parentJobKey, 'state', 'waiting')
-          xaddJob(parentStreamKey, parentId, redis.call('HGET', parentJobKey, 'name'))
-          emitEvent(parentEventsKey, 'active', parentId, nil)
-        end
-      end
-    end
+    completeParentDependency(parentDepsKey, parentJobKey, parentStreamKey, parentEventsKey, depsMember, parentId)
   end
   -- DAG multi-parent: always check parents SET. The previous hasParents
   -- arg was sourced from the worker's snapshot of the job hash, which is
@@ -1061,19 +1048,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
             local pDepsKey = pPrefix .. 'deps:' .. pId
             local pStreamKey = pPrefix .. 'stream'
             local pEventsKey = pPrefix .. 'events'
-            local pDepMarker = 'depdone:' .. dagDepsMember
-            if redis.call('HSETNX', pJobKey, pDepMarker, '1') == 1 then
-              local pDoneCount = redis.call('HINCRBY', pJobKey, 'depsCompleted', 1)
-              local pTotalDeps = redis.call('SCARD', pDepsKey)
-              if pTotalDeps - pDoneCount <= 0 then
-                local pState = redis.call('HGET', pJobKey, 'state')
-                if pState == 'waiting-children' then
-                  redis.call('HSET', pJobKey, 'state', 'waiting')
-                  xaddJob(pStreamKey, pId, redis.call('HGET', pJobKey, 'name'))
-                  emitEvent(pEventsKey, 'active', pId, nil)
-                end
-              end
-            end
+            completeParentDependency(pDepsKey, pJobKey, pStreamKey, pEventsKey, dagDepsMember, pId)
           else
             local pTag = extractQueueTag(pQueue)
             enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
@@ -2599,28 +2574,7 @@ redis.register_function('glidemq_completeChild', function(keys, args)
   local parentEventsKey = keys[4]
   local depsMember = args[1]
   local parentId = args[2]
-  -- A stale cross-queue notification must not recreate a deleted parent hash.
-  if redis.call('EXISTS', parentJobKey) == 0 then
-    return -1
-  end
-  local depMarker = 'depdone:' .. depsMember
-  if redis.call('HSETNX', parentJobKey, depMarker, '1') == 0 then
-    local doneCount = tonumber(redis.call('HGET', parentJobKey, 'depsCompleted')) or 0
-    local totalDeps = redis.call('SCARD', depsKey)
-    return totalDeps - doneCount
-  end
-  local doneCount = redis.call('HINCRBY', parentJobKey, 'depsCompleted', 1)
-  local totalDeps = redis.call('SCARD', depsKey)
-  local remaining = totalDeps - doneCount
-  if remaining <= 0 then
-    local parentState = redis.call('HGET', parentJobKey, 'state')
-    if parentState == 'waiting-children' then
-      redis.call('HSET', parentJobKey, 'state', 'waiting')
-      xaddJob(parentStreamKey, parentId, redis.call('HGET', parentJobKey, 'name'))
-      emitEvent(parentEventsKey, 'active', parentId, nil)
-    end
-  end
-  return remaining
+  return completeParentDependency(depsKey, parentJobKey, parentStreamKey, parentEventsKey, depsMember, parentId)
 end)
 
 redis.register_function('glidemq_registerParent', function(keys, args)
@@ -2648,19 +2602,7 @@ redis.register_function('glidemq_registerParent', function(keys, args)
   -- Race condition check: if child already completed, trigger parent notification immediately
   local childState = redis.call('HGET', childJobKey, 'state')
   if childState == 'completed' then
-    local depMarker = 'depdone:' .. depsMember
-    if redis.call('HSETNX', parentJobKey, depMarker, '1') == 1 then
-      local doneCount = redis.call('HINCRBY', parentJobKey, 'depsCompleted', 1)
-      local totalDeps = redis.call('SCARD', parentDepsKey)
-      if totalDeps - doneCount <= 0 then
-        local parentState = redis.call('HGET', parentJobKey, 'state')
-        if parentState == 'waiting-children' then
-          redis.call('HSET', parentJobKey, 'state', 'waiting')
-          xaddJob(parentStreamKey, parentId, redis.call('HGET', parentJobKey, 'name'))
-          emitEvent(parentEventsKey, 'active', parentId, nil)
-        end
-      end
-    end
+    completeParentDependency(parentDepsKey, parentJobKey, parentStreamKey, parentEventsKey, depsMember, parentId)
     return 'already_completed'
   end
   return 'ok'

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -295,13 +295,13 @@ end
 
 -- Persist a retryable cross-queue parent notification on this child's hash
 -- slot. The scheduler later calls completeChild using only the parent keys.
--- Member: parentQueueName TAB parentId TAB childQueuePrefix:childId
+-- Member: JSON array [parentQueueName, parentId, childQueuePrefix:childId]
 local function enqueueCrossQueueParentNotify(prefix, jobId, parentQueueName, parentId)
   if not parentQueueName or parentQueueName == '' or not parentId or parentId == '' then return end
   local childQueueName = string.match(prefix, '{([^}]+)}')
   if childQueueName and parentQueueName == childQueueName then return end
   local childQueuePrefix = string.sub(prefix, 1, #prefix - 1)
-  redis.call('SADD', prefix .. 'xq-pending', parentQueueName .. '\t' .. parentId .. '\t' .. childQueuePrefix .. ':' .. jobId)
+  redis.call('SADD', prefix .. 'xq-pending', cjson.encode({parentQueueName, parentId, childQueuePrefix .. ':' .. jobId}))
 end
 
 local function expireJob(jobKey, jobId, prefix, now, curState, hintOrderingKey, hintOrderingSeq, hintGroupKey)

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -327,11 +327,20 @@ end
 -- slot. The scheduler later calls completeChild using only the parent keys.
 -- Member: JSON array [parentQueueName, parentId, childQueuePrefix:childId]
 local function enqueueCrossQueueParentNotify(prefix, jobId, parentQueueName, parentId)
-  if not parentQueueName or parentQueueName == '' or not parentId or parentId == '' then return end
+  if not parentQueueName or parentQueueName == '' or not parentId or parentId == '' then return nil end
   local childQueueName = extractQueueTag(string.sub(prefix, 1, #prefix - 1))
-  if childQueueName and parentQueueName == childQueueName then return end
+  if childQueueName and parentQueueName == childQueueName then return nil end
   local childQueuePrefix = string.sub(prefix, 1, #prefix - 1)
-  redis.call('SADD', prefix .. 'xq-pending', cjson.encode({parentQueueName, parentId, childQueuePrefix .. ':' .. jobId}))
+  local member = cjson.encode({parentQueueName, parentId, childQueuePrefix .. ':' .. jobId})
+  redis.call('SADD', prefix .. 'xq-pending', member)
+  return member
+end
+
+local function appendParentNotifications(result, notifications)
+  if #notifications == 0 then return result end
+  result[#result + 1] = '__glidemq_parent_notifications__'
+  result[#result + 1] = cjson.encode(notifications)
+  return result
 end
 
 local function expireJob(jobKey, jobId, prefix, now, curState, hintOrderingKey, hintOrderingSeq, hintGroupKey)
@@ -868,7 +877,11 @@ redis.register_function('glidemq_complete', function(keys, args)
   emitEvent(eventsKey, 'completed', jobId, {'returnvalue', returnvalue})
   recordMetrics(metricsKey, timestamp, timestamp - processedOn)
   local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
-  enqueueCrossQueueParentNotify(prefix, jobId, redis.call('HGET', jobKey, 'parentQueue'), redis.call('HGET', jobKey, 'parentId'))
+  local storedParentQueue = redis.call('HGET', jobKey, 'parentQueue')
+  local storedParentId = redis.call('HGET', jobKey, 'parentId')
+  local parentNotifications = {}
+  local parentNotification = enqueueCrossQueueParentNotify(prefix, jobId, storedParentQueue, storedParentId)
+  if parentNotification then parentNotifications[#parentNotifications + 1] = parentNotification end
   if broadcastMode ~= '1' then
     if removeMode == 'true' then
       redis.call('ZREM', completedKey, jobId)
@@ -900,6 +913,15 @@ redis.register_function('glidemq_complete', function(keys, args)
     local parentStreamKey = keys[8]
     local parentEventsKey = keys[9]
     completeParentDependency(parentDepsKey, parentJobKey, parentStreamKey, parentEventsKey, depsMember, parentId)
+  elseif storedParentQueue == extractQueueTag(string.sub(prefix, 1, #prefix - 1)) and storedParentId and storedParentId ~= '' then
+    completeParentDependency(
+      prefix .. 'deps:' .. storedParentId,
+      prefix .. 'job:' .. storedParentId,
+      prefix .. 'stream',
+      prefix .. 'events',
+      string.sub(prefix, 1, #prefix - 1) .. ':' .. jobId,
+      storedParentId
+    )
   end
   -- DAG multi-parent: notify additional same-queue parents via parents SET
   local parentsKey = prefix .. 'parents:' .. jobId
@@ -928,13 +950,14 @@ redis.register_function('glidemq_complete', function(keys, args)
           completeParentDependency(pDepsKey, pJobKey, pStreamKey, pEventsKey, dagDepsMember, pId)
         else
           local pTag = extractQueueTag(pQueue)
-          enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
+          local notification = enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
+          if notification then parentNotifications[#parentNotifications + 1] = notification end
         end
       end
     end
   end
   if entryId == '' then decrListActive(prefix .. 'list-active') end
-  return 1
+  return #parentNotifications > 0 and cjson.encode(parentNotifications) or ''
 end)
 
 redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
@@ -987,7 +1010,11 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
   if skipEvents ~= '1' then emitEvent(eventsKey, 'completed', jobId, {'returnvalue', returnvalue}) end
   if skipMetrics ~= '1' then recordMetrics(metricsKey, timestamp, timestamp - processedOn) end
   local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
-  enqueueCrossQueueParentNotify(prefix, jobId, redis.call('HGET', jobKey, 'parentQueue'), redis.call('HGET', jobKey, 'parentId'))
+  local storedParentQueue = redis.call('HGET', jobKey, 'parentQueue')
+  local storedParentId = redis.call('HGET', jobKey, 'parentId')
+  local parentNotifications = {}
+  local parentNotification = enqueueCrossQueueParentNotify(prefix, jobId, storedParentQueue, storedParentId)
+  if parentNotification then parentNotifications[#parentNotifications + 1] = parentNotification end
   if entryId == '' then decrListActive(prefix .. 'list-active') end
 
   -- Retention cleanup (skip in broadcast mode - job hash must persist for all subscriptions)
@@ -1024,6 +1051,15 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
     local parentStreamKey = keys[8]
     local parentEventsKey = keys[9]
     completeParentDependency(parentDepsKey, parentJobKey, parentStreamKey, parentEventsKey, depsMember, parentId)
+  elseif storedParentQueue == extractQueueTag(string.sub(prefix, 1, #prefix - 1)) and storedParentId and storedParentId ~= '' then
+    completeParentDependency(
+      prefix .. 'deps:' .. storedParentId,
+      prefix .. 'job:' .. storedParentId,
+      prefix .. 'stream',
+      prefix .. 'events',
+      string.sub(prefix, 1, #prefix - 1) .. ':' .. jobId,
+      storedParentId
+    )
   end
   -- DAG multi-parent: always check parents SET. The previous hasParents
   -- arg was sourced from the worker's snapshot of the job hash, which is
@@ -1051,7 +1087,8 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
             completeParentDependency(pDepsKey, pJobKey, pStreamKey, pEventsKey, dagDepsMember, pId)
           else
             local pTag = extractQueueTag(pQueue)
-            enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
+            local notification = enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
+            if notification then parentNotifications[#parentNotifications + 1] = notification end
           end
         end
       end
@@ -1060,13 +1097,14 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
 
   -- In broadcast mode: do not fetch next (avoids XDEL of next entry which would break other consumer groups)
   if broadcastMode == '1' then
-    return {'NEXT_NONE', jobId}
+    return appendParentNotifications({'NEXT_NONE', jobId}, parentNotifications)
   end
 
   -- Return protocol (array-based to avoid cjson encode/decode per job):
-  -- {'NEXT_NONE', completedJobId}
-  -- {'NEXT_REVOKED', completedJobId, nextJobId, nextEntryId}
-  -- {'NEXT_HASH', completedJobId, nextJobId, nextEntryId, field1, value1, field2, value2, ...}
+  -- Cross-queue completions append '__glidemq_parent_notifications__', JSON members.
+  -- {'NEXT_NONE', completedJobId, ...}
+  -- {'NEXT_REVOKED', completedJobId, nextJobId, nextEntryId, ...}
+  -- {'NEXT_HASH', completedJobId, nextJobId, nextEntryId, field1, value1, field2, value2, ..., ...}
 
   -- Phase 1.0: Try priority list first (highest priority: priority > LIFO > FIFO)
   local priorityKey = prefix .. 'priority'
@@ -1122,7 +1160,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
               if skipEvents ~= '1' then emitEvent(eventsKey, 'active', priJobId, nil) end
               local priJobFields = redis.call('HGETALL', priJobKey)
               redis.call('INCR', prefix .. 'list-active')
-              return {'NEXT_HASH', jobId, priJobId, '', unpack(priJobFields)}
+              return appendParentNotifications({'NEXT_HASH', jobId, priJobId, '', unpack(priJobFields)}, parentNotifications)
             end
           else
             -- Non-group job: activate directly
@@ -1130,7 +1168,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
             if skipEvents ~= '1' then emitEvent(eventsKey, 'active', priJobId, nil) end
             local priJobFields = redis.call('HGETALL', priJobKey)
             redis.call('INCR', prefix .. 'list-active')
-            return {'NEXT_HASH', jobId, priJobId, '', unpack(priJobFields)}
+            return appendParentNotifications({'NEXT_HASH', jobId, priJobId, '', unpack(priJobFields)}, parentNotifications)
           end
         else
           expireJob(priJobKey, priJobId, prefix, timestamp, priMeta[1], nil, nil, nil)
@@ -1158,7 +1196,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
           if skipEvents ~= '1' then emitEvent(eventsKey, 'active', lifoJobId, nil) end
           local lifoJobFields = redis.call('HGETALL', lifoJobKey)
           redis.call('INCR', prefix .. 'list-active')
-          return {'NEXT_HASH', jobId, lifoJobId, '', unpack(lifoJobFields)}
+          return appendParentNotifications({'NEXT_HASH', jobId, lifoJobId, '', unpack(lifoJobFields)}, parentNotifications)
         else
           expireJob(lifoJobKey, lifoJobId, prefix, timestamp, lifoMeta[1], nil, nil, nil)
         end
@@ -1172,12 +1210,12 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
   for _fetchAttempt = 1, 3 do
     local nextEntries = redis.call('XREADGROUP', 'GROUP', group, consumer, 'COUNT', 1, 'STREAMS', streamKey, '>')
     if not nextEntries or #nextEntries == 0 then
-      return {'NEXT_NONE', jobId}
+      return appendParentNotifications({'NEXT_NONE', jobId}, parentNotifications)
     end
     local streamData = nextEntries[1]
     local entries = streamData[2]
     if not entries or #entries == 0 then
-      return {'NEXT_NONE', jobId}
+      return appendParentNotifications({'NEXT_NONE', jobId}, parentNotifications)
     end
     local nextEntry = entries[1]
     nextEntryId = nextEntry[1]
@@ -1190,17 +1228,17 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
       end
     end
     if not nextJobId then
-      return {'NEXT_NONE', jobId}
+      return appendParentNotifications({'NEXT_NONE', jobId}, parentNotifications)
     end
     nextJobKey = prefix .. 'job:' .. nextJobId
     -- Single HMGET replaces EXISTS + HGET 'revoked' + checkExpired HGET 'expireAt' + HGET 'groupKey' (4 → 1)
     local nextMeta = redis.call('HMGET', nextJobKey, 'state', 'revoked', 'expireAt', 'groupKey')
     if not nextMeta[1] then
       -- state is nil: job hash does not exist
-      return {'NEXT_NONE', jobId}
+      return appendParentNotifications({'NEXT_NONE', jobId}, parentNotifications)
     end
     if nextMeta[2] == '1' then
-      return {'NEXT_REVOKED', jobId, nextJobId, nextEntryId}
+      return appendParentNotifications({'NEXT_REVOKED', jobId, nextJobId, nextEntryId}, parentNotifications)
     end
     -- Inline expiry check (avoids checkExpired's redundant HGET)
     local nextExpireAt = tonumber(nextMeta[3])
@@ -1216,7 +1254,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
     end
   end
   if not nextJobId then
-    return {'NEXT_NONE', jobId}
+    return appendParentNotifications({'NEXT_NONE', jobId}, parentNotifications)
   end
 
   -- Phase 3: Activate next job (same as moveToActive)
@@ -1246,7 +1284,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
         redis.call('XDEL', streamKey, nextEntryId)
         redis.call('ZADD', nextWaitListKey, nextJobOrderingSeq, nextJobId)
         redis.call('HSET', nextJobKey, 'state', 'group-waiting')
-        return {'NEXT_NONE', jobId}
+        return appendParentNotifications({'NEXT_NONE', jobId}, parentNotifications)
       end
       nextReturning = (nextExpectedSeq > 0 and nextJobOrderingSeq < nextExpectedSeq)
     end
@@ -1256,7 +1294,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
       redis.call('XDEL', streamKey, nextEntryId)
       redis.call('ZADD', nextWaitListKey, groupqScore(nextJobKey, nextJobId), nextJobId)
       redis.call('HSET', nextJobKey, 'state', 'group-waiting')
-      return {'NEXT_NONE', jobId}
+      return appendParentNotifications({'NEXT_NONE', jobId}, parentNotifications)
     end
     -- Token bucket gate (read-only)
     local nextTbCapacity = tonumber(nGrp.tbCapacity) or 0
@@ -1279,7 +1317,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
           'finishedOn', tostring(timestamp))
         if skipEvents ~= '1' then emitEvent(prefix .. 'events', 'failed', nextJobId, {'failedReason', 'cost exceeds token bucket capacity'}) end
         if skipMetrics ~= '1' then recordMetrics(metricsKey, tonumber(timestamp), tonumber(timestamp) - nextProcessedOn) end
-        return {'NEXT_NONE', jobId}
+        return appendParentNotifications({'NEXT_NONE', jobId}, parentNotifications)
       end
       if nextTbTokens < nextJobCostVal then
         nextTbBlocked = true
@@ -1310,7 +1348,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
       local nextMaxDelay = math.max(nextTbDelay, nextRlDelay)
       local rateLimitedKey = prefix .. 'ratelimited'
       redis.call('ZADD', rateLimitedKey, tonumber(timestamp) + nextMaxDelay, nextGroupKey)
-      return {'NEXT_NONE', jobId}
+      return appendParentNotifications({'NEXT_NONE', jobId}, parentNotifications)
     end
     -- All gates passed: mutate state
     if nextTbCapacity > 0 then
@@ -1341,7 +1379,7 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
   for i = 1, #nextHash do
     out[#out + 1] = nextHash[i]
   end
-  return out
+  return appendParentNotifications(out, parentNotifications)
 end)
 
 redis.register_function('glidemq_fail', function(keys, args)

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -343,6 +343,13 @@ local function appendParentNotifications(result, notifications)
   return result
 end
 
+local function addParentNotification(notifications, seen, member)
+  if member and not seen[member] then
+    seen[member] = true
+    notifications[#notifications + 1] = member
+  end
+end
+
 local function expireJob(jobKey, jobId, prefix, now, curState, hintOrderingKey, hintOrderingSeq, hintGroupKey)
   if curState == 'failed' then return true end
   local wasActive = (curState == 'active')
@@ -880,8 +887,12 @@ redis.register_function('glidemq_complete', function(keys, args)
   local storedParentQueue = redis.call('HGET', jobKey, 'parentQueue')
   local storedParentId = redis.call('HGET', jobKey, 'parentId')
   local parentNotifications = {}
-  local parentNotification = enqueueCrossQueueParentNotify(prefix, jobId, storedParentQueue, storedParentId)
-  if parentNotification then parentNotifications[#parentNotifications + 1] = parentNotification end
+  local parentNotificationSet = {}
+  addParentNotification(
+    parentNotifications,
+    parentNotificationSet,
+    enqueueCrossQueueParentNotify(prefix, jobId, storedParentQueue, storedParentId)
+  )
   if broadcastMode ~= '1' then
     if removeMode == 'true' then
       redis.call('ZREM', completedKey, jobId)
@@ -950,8 +961,11 @@ redis.register_function('glidemq_complete', function(keys, args)
           completeParentDependency(pDepsKey, pJobKey, pStreamKey, pEventsKey, dagDepsMember, pId)
         else
           local pTag = extractQueueTag(pQueue)
-          local notification = enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
-          if notification then parentNotifications[#parentNotifications + 1] = notification end
+          addParentNotification(
+            parentNotifications,
+            parentNotificationSet,
+            enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
+          )
         end
       end
     end
@@ -1013,8 +1027,12 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
   local storedParentQueue = redis.call('HGET', jobKey, 'parentQueue')
   local storedParentId = redis.call('HGET', jobKey, 'parentId')
   local parentNotifications = {}
-  local parentNotification = enqueueCrossQueueParentNotify(prefix, jobId, storedParentQueue, storedParentId)
-  if parentNotification then parentNotifications[#parentNotifications + 1] = parentNotification end
+  local parentNotificationSet = {}
+  addParentNotification(
+    parentNotifications,
+    parentNotificationSet,
+    enqueueCrossQueueParentNotify(prefix, jobId, storedParentQueue, storedParentId)
+  )
   if entryId == '' then decrListActive(prefix .. 'list-active') end
 
   -- Retention cleanup (skip in broadcast mode - job hash must persist for all subscriptions)
@@ -1087,8 +1105,11 @@ redis.register_function('glidemq_completeAndFetchNext', function(keys, args)
             completeParentDependency(pDepsKey, pJobKey, pStreamKey, pEventsKey, dagDepsMember, pId)
           else
             local pTag = extractQueueTag(pQueue)
-            local notification = enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
-            if notification then parentNotifications[#parentNotifications + 1] = notification end
+            addParentNotification(
+              parentNotifications,
+              parentNotificationSet,
+              enqueueCrossQueueParentNotify(prefix, jobId, pTag, pId)
+            )
           end
         end
       end

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,4 +1,3 @@
-import type { GlideReturnType } from '@glidemq/speedkey';
 import type { Client } from '../types';
 import { librarySourceFrom, loadLibraryFile } from './load-library-source';
 
@@ -59,7 +58,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 104: encode cross-queue notifications as JSON and reconcile deleted children without recreating hashes.
 // Version 107: extract the final queue hash tag for cross-queue DAG notifications so custom prefixes may contain braces.
 // Version 108: all parent dependency completion paths ignore deleted parent hashes.
-export const LIBRARY_VERSION = '108';
+// Version 109: completion replies carry cross-queue parent notifications for eager delivery.
+export const LIBRARY_VERSION = '109';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -300,6 +300,17 @@ export async function renewLock(client: Client, lockKey: string, token: string, 
  */
 const RETENTION_NONE = { mode: '0', count: 0, age: 0 } as const;
 const RETENTION_TRUE = { mode: 'true', count: 0, age: 0 } as const;
+const PARENT_NOTIFICATIONS_MARKER = '__glidemq_parent_notifications__';
+
+function parseParentNotifications(raw: unknown): string[] {
+  if (typeof raw !== 'string' || raw === '') return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) && parsed.every((member) => typeof member === 'string') ? parsed : [];
+  } catch {
+    return [];
+  }
+}
 
 function encodeRetention(opt?: boolean | number | { age: number; count: number }): {
   mode: string;
@@ -335,7 +346,7 @@ export async function completeJob(
   removeOnComplete?: boolean | number | { age: number; count: number },
   parentInfo?: { depsMember: string; parentId: string; parentKeys: QueueKeys },
   broadcastMode?: boolean,
-): Promise<GlideReturnType> {
+): Promise<string[]> {
   const { mode, count, age } = encodeRetention(removeOnComplete);
 
   const keys: string[] = [k.stream, k.completed, k.events, k.job(jobId), k.metricsCompleted];
@@ -360,7 +371,7 @@ export async function completeJob(
 
   if (broadcastMode) args.push('1');
 
-  return client.fcall('glidemq_complete', keys, args);
+  return parseParentNotifications(await client.fcall('glidemq_complete', keys, args));
 }
 
 /**
@@ -377,6 +388,8 @@ export interface CompleteAndFetchResult {
   next: false | 'REVOKED' | Record<string, string>;
   nextJobId?: string;
   nextEntryId?: string;
+  /** Retryable cross-queue parent notifications recorded by the completion FCALL. */
+  parentNotifications: string[];
 }
 
 export interface CompleteAndFetchHints {
@@ -444,9 +457,12 @@ export async function completeAndFetchNext(
 
   // Fast path: array protocol from Lua function
   if (Array.isArray(raw)) {
+    const notificationOffset =
+      raw.length >= 2 && String(raw[raw.length - 2]) === PARENT_NOTIFICATIONS_MARKER ? raw.length - 2 : raw.length;
+    const parentNotifications = notificationOffset < raw.length ? parseParentNotifications(raw[raw.length - 1]) : [];
     const tag = String(raw[0]);
     if (tag === 'NEXT_NONE') {
-      return { completed: raw[1] != null ? String(raw[1]) : jobId, next: false };
+      return { completed: raw[1] != null ? String(raw[1]) : jobId, next: false, parentNotifications };
     }
     if (tag === 'NEXT_REVOKED') {
       return {
@@ -454,11 +470,12 @@ export async function completeAndFetchNext(
         next: 'REVOKED',
         nextJobId: String(raw[2]),
         nextEntryId: String(raw[3]),
+        parentNotifications,
       };
     }
     if (tag === 'NEXT_HASH') {
       const hash: Record<string, string> = Object.create(null);
-      for (let i = 4; i + 1 < raw.length; i += 2) {
+      for (let i = 4; i + 1 < notificationOffset; i += 2) {
         hash[String(raw[i])] = String(raw[i + 1]);
       }
       return {
@@ -466,6 +483,7 @@ export async function completeAndFetchNext(
         next: hash,
         nextJobId: String(raw[2]),
         nextEntryId: String(raw[3]),
+        parentNotifications,
       };
     }
     throw new Error(`Unexpected glidemq_completeAndFetchNext tag: ${tag}`);
@@ -474,7 +492,7 @@ export async function completeAndFetchNext(
   // Backward compatibility: JSON protocol (older library versions)
   const parsed = JSON.parse(String(raw));
   if (!parsed.next || parsed.next === false) {
-    return { completed: parsed.completed, next: false };
+    return { completed: parsed.completed, next: false, parentNotifications: [] };
   }
   if (parsed.next === 'REVOKED') {
     return {
@@ -482,6 +500,7 @@ export async function completeAndFetchNext(
       next: 'REVOKED',
       nextJobId: parsed.nextJobId,
       nextEntryId: parsed.nextEntryId,
+      parentNotifications: [],
     };
   }
   const parsedHash = parsed.next as string[];
@@ -494,6 +513,7 @@ export async function completeAndFetchNext(
     next: hash,
     nextJobId: parsed.nextJobId,
     nextEntryId: parsed.nextEntryId,
+    parentNotifications: [],
   };
 }
 

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -55,6 +55,7 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
 // Version 101: complete/CAF enqueue cross-queue parent notifies on a same-slot pending set so a later scheduler tick can retry if the worker dies between complete and completeChild.
+// Version 102: completeChild ignores stale notifications for deleted parent hashes.
 export const LIBRARY_VERSION = '102';
 
 // Consumer group name used by workers

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -459,8 +459,8 @@ export async function completeAndFetchNext(
   // Fast path: array protocol from Lua function
   if (Array.isArray(raw)) {
     const notificationOffset =
-      raw.length >= 2 && String(raw[raw.length - 2]) === PARENT_NOTIFICATIONS_MARKER ? raw.length - 2 : raw.length;
-    const parentNotifications = notificationOffset < raw.length ? parseParentNotifications(raw[raw.length - 1]) : [];
+      raw.length >= 2 && String(raw.at(-2)) === PARENT_NOTIFICATIONS_MARKER ? raw.length - 2 : raw.length;
+    const parentNotifications = notificationOffset < raw.length ? parseParentNotifications(raw.at(-1)) : [];
     const tag = String(raw[0]);
     if (tag === 'NEXT_NONE') {
       return { completed: raw[1] != null ? String(raw[1]) : jobId, next: false, parentNotifications };

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -57,7 +57,7 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 101: complete/CAF enqueue cross-queue parent notifies on a same-slot pending set so a later scheduler tick can retry if the worker dies between complete and completeChild.
 // Version 102: completeChild ignores stale notifications for deleted parent hashes.
 // Version 104: encode cross-queue notifications as JSON and reconcile deleted children without recreating hashes.
-export const LIBRARY_VERSION = '104';
+export const LIBRARY_VERSION = '106';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -57,7 +57,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 101: complete/CAF enqueue cross-queue parent notifies on a same-slot pending set so a later scheduler tick can retry if the worker dies between complete and completeChild.
 // Version 102: completeChild ignores stale notifications for deleted parent hashes.
 // Version 104: encode cross-queue notifications as JSON and reconcile deleted children without recreating hashes.
-export const LIBRARY_VERSION = '106';
+// Version 107: extract the final queue hash tag for cross-queue DAG notifications so custom prefixes may contain braces.
+export const LIBRARY_VERSION = '107';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -56,7 +56,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
 // Version 101: complete/CAF enqueue cross-queue parent notifies on a same-slot pending set so a later scheduler tick can retry if the worker dies between complete and completeChild.
 // Version 102: completeChild ignores stale notifications for deleted parent hashes.
-export const LIBRARY_VERSION = '102';
+// Version 104: encode cross-queue notifications as JSON and reconcile deleted children without recreating hashes.
+export const LIBRARY_VERSION = '104';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -54,7 +54,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 91: Stalled-recovery redispatches under-threshold jobs back to the stream / lifo / priority list so a healthy worker can pick them up; jobs only fail once stalledCount > maxStalledCount. Aligns with the at-least-once redelivery promise in DURABILITY.md and matches BullMQ semantics (#242).
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
-export const LIBRARY_VERSION = '93';
+// Version 101: complete/CAF enqueue cross-queue parent notifies on a same-slot pending set so a later scheduler tick can retry if the worker dies between complete and completeChild.
+export const LIBRARY_VERSION = '101';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -58,7 +58,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 102: completeChild ignores stale notifications for deleted parent hashes.
 // Version 104: encode cross-queue notifications as JSON and reconcile deleted children without recreating hashes.
 // Version 107: extract the final queue hash tag for cross-queue DAG notifications so custom prefixes may contain braces.
-export const LIBRARY_VERSION = '107';
+// Version 108: all parent dependency completion paths ignore deleted parent hashes.
+export const LIBRARY_VERSION = '108';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -59,7 +59,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 107: extract the final queue hash tag for cross-queue DAG notifications so custom prefixes may contain braces.
 // Version 108: all parent dependency completion paths ignore deleted parent hashes.
 // Version 109: completion replies carry cross-queue parent notifications for eager delivery.
-export const LIBRARY_VERSION = '109';
+// Version 110: dedupe overlapping tree and DAG parent notifications per completion.
+export const LIBRARY_VERSION = '110';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -55,7 +55,7 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 92: Replace DEL with UNLINK on every multi-key / large-collection delete (job hashes, retention purge, glidemq_clean batches, glidemq_drain stream/zset/lifo/priority sweeps). UNLINK keeps in-script atomicity - the keyspace removal is still synchronous from the script's view - but defers memory reclamation to the bio thread, so obliterate / retention / drain stop blocking the server thread on MB-sized job hashes. Small-key DELs (lockKey) kept as DEL (#243).
 // Version 93: glidemq_completeAndFetchNext always SMEMBERS the child parents SET. The previous hasParents gate sourced its truth from the worker's snapshot of the job hash, which is stale when DAG wiring (hset parentIds + registerParent) lands between the worker's job fetch and the completion FCALL. The SMEMBERS cost on an empty set is negligible; the dropped optimization was unsound (#246).
 // Version 101: complete/CAF enqueue cross-queue parent notifies on a same-slot pending set so a later scheduler tick can retry if the worker dies between complete and completeChild.
-export const LIBRARY_VERSION = '101';
+export const LIBRARY_VERSION = '102';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1690,6 +1690,7 @@ export class Queue<D = any, R = any> extends EventEmitter {
       this.keys.schedulers,
       this.keys.ordering,
       this.keys.ratelimited,
+      this.keys.xqPending,
       this.keys.metricsCompleted,
       this.keys.metricsFailed,
       this.keys.lifo,

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -20,6 +20,20 @@ import {
 import { buildKeys, computeFollowingSchedulerNextRun, isValidSchedulerEvery, MAX_JOB_DATA_SIZE } from './utils';
 import { isClusterClient } from './connection';
 
+function parseCrossQueueParentNotification(member: string): [string, string, string] | undefined {
+  try {
+    const decoded: unknown = JSON.parse(member);
+    if (Array.isArray(decoded) && decoded.length === 3 && decoded.every((part) => typeof part === 'string')) {
+      return decoded as [string, string, string];
+    }
+  } catch {
+    // Support notifications written by version 101 during rolling upgrades.
+    const legacy = member.split('\t');
+    if (legacy.length === 3) return legacy as [string, string, string];
+  }
+  return undefined;
+}
+
 export interface SchedulerOptions {
   promotionInterval?: number;
   stalledInterval?: number;
@@ -276,17 +290,7 @@ export class Scheduler {
     const prefix = this.queueKeys.id.slice(0, -suffix.length);
     for (const raw of members) {
       const member = String(raw);
-      let parts: string[] | undefined;
-      try {
-        const decoded: unknown = JSON.parse(member);
-        if (Array.isArray(decoded) && decoded.length === 3 && decoded.every((part) => typeof part === 'string')) {
-          parts = decoded as string[];
-        }
-      } catch {
-        // Support notifications written by version 101 during rolling upgrades.
-        const legacy = member.split('\t');
-        if (legacy.length === 3) parts = legacy;
-      }
+      const parts = parseCrossQueueParentNotification(member);
       if (!parts) continue;
       const [parentQueue, parentId, depsMember] = parts;
       try {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,11 +13,11 @@ import {
   tryLock,
   renewLock,
   unlock,
+  completeChild,
   healListActive,
   sweepSuspended,
 } from './functions/index';
-import type { buildKeys } from './utils';
-import { computeFollowingSchedulerNextRun, isValidSchedulerEvery, MAX_JOB_DATA_SIZE } from './utils';
+import { buildKeys, computeFollowingSchedulerNextRun, isValidSchedulerEvery, MAX_JOB_DATA_SIZE } from './utils';
 import { isClusterClient } from './connection';
 
 export interface SchedulerOptions {
@@ -152,6 +152,7 @@ export class Scheduler {
     this.trackRun(
       this.promoteDelayed()
         .then(() => this.promoteRateLimitedGroups())
+        .then(() => this.flushCrossQueueParentNotifies())
         .then(() => this.runSchedulers())
         .then(() => {
           this.onPromotionTick?.();
@@ -256,6 +257,32 @@ export class Scheduler {
    */
   async promoteRateLimitedGroups(): Promise<number> {
     return promoteRateLimited(this.client, this.queueKeys, Date.now());
+  }
+
+  /**
+   * Retry cross-queue parent notifications recorded on this child's slot.
+   * The completion FCALL cannot include keys from multiple cluster slots, so
+   * the child records the parent edge and this scheduler completes it later.
+   */
+  async flushCrossQueueParentNotifies(): Promise<void> {
+    const members = await this.client.smembers(this.queueKeys.xqPending);
+    if (!members || members.size === 0) return;
+
+    const idKey = this.queueKeys.id;
+    const brace = idKey.indexOf(':{');
+    const prefix = brace >= 0 ? idKey.slice(0, brace) : 'glide';
+    for (const raw of members) {
+      const member = String(raw);
+      const parts = member.split('\t');
+      if (parts.length !== 3) continue;
+      const [parentQueue, parentId, depsMember] = parts;
+      try {
+        await completeChild(this.client, buildKeys(parentQueue, prefix), parentId, depsMember);
+        await this.client.srem(this.queueKeys.xqPending, [member]);
+      } catch (err) {
+        this.reportError(err);
+      }
+    }
   }
 
   /**

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -273,8 +273,18 @@ export class Scheduler {
     const prefix = brace >= 0 ? idKey.slice(0, brace) : 'glide';
     for (const raw of members) {
       const member = String(raw);
-      const parts = member.split('\t');
-      if (parts.length !== 3) continue;
+      let parts: string[] | undefined;
+      try {
+        const decoded: unknown = JSON.parse(member);
+        if (Array.isArray(decoded) && decoded.length === 3 && decoded.every((part) => typeof part === 'string')) {
+          parts = decoded as string[];
+        }
+      } catch {
+        // Support notifications written by version 101 during rolling upgrades.
+        const legacy = member.split('\t');
+        if (legacy.length === 3) parts = legacy;
+      }
+      if (!parts) continue;
       const [parentQueue, parentId, depsMember] = parts;
       try {
         await completeChild(this.client, buildKeys(parentQueue, prefix), parentId, depsMember);

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -17,22 +17,14 @@ import {
   healListActive,
   sweepSuspended,
 } from './functions/index';
-import { buildKeys, computeFollowingSchedulerNextRun, isValidSchedulerEvery, MAX_JOB_DATA_SIZE } from './utils';
+import {
+  buildKeys,
+  computeFollowingSchedulerNextRun,
+  isValidSchedulerEvery,
+  MAX_JOB_DATA_SIZE,
+  parseCrossQueueParentNotification,
+} from './utils';
 import { isClusterClient } from './connection';
-
-function parseCrossQueueParentNotification(member: string): [string, string, string] | undefined {
-  try {
-    const decoded: unknown = JSON.parse(member);
-    if (Array.isArray(decoded) && decoded.length === 3 && decoded.every((part) => typeof part === 'string')) {
-      return decoded as [string, string, string];
-    }
-  } catch {
-    // Support notifications written by version 101 during rolling upgrades.
-    const legacy = member.split('\t');
-    if (legacy.length === 3) return legacy as [string, string, string];
-  }
-  return undefined;
-}
 
 export interface SchedulerOptions {
   promotionInterval?: number;

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -268,9 +268,12 @@ export class Scheduler {
     const members = await this.client.smembers(this.queueKeys.xqPending);
     if (!members || members.size === 0) return;
 
-    const idKey = this.queueKeys.id;
-    const brace = idKey.indexOf(':{');
-    const prefix = brace >= 0 ? idKey.slice(0, brace) : 'glide';
+    const suffix = `:{${this.queueKeys.name}}:id`;
+    if (!this.queueKeys.id.endsWith(suffix)) {
+      this.reportError(new Error(`Invalid queue id key for cross-queue parent notifications: ${this.queueKeys.id}`));
+      return;
+    }
+    const prefix = this.queueKeys.id.slice(0, -suffix.length);
     for (const raw of members) {
       const member = String(raw);
       let parts: string[] | undefined;
@@ -287,8 +290,12 @@ export class Scheduler {
       if (!parts) continue;
       const [parentQueue, parentId, depsMember] = parts;
       try {
-        await completeChild(this.client, buildKeys(parentQueue, prefix), parentId, depsMember);
-        await this.client.srem(this.queueKeys.xqPending, [member]);
+        const remaining = await completeChild(this.client, buildKeys(parentQueue, prefix), parentId, depsMember);
+        // -1 confirms that the parent was deleted, so this is a stale notification.
+        // Non-negative values are the parent's remaining dependency count.
+        if (Number.isInteger(remaining) && remaining >= -1) {
+          await this.client.srem(this.queueKeys.xqPending, [member]);
+        }
       } catch (err) {
         this.reportError(err);
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,6 +122,7 @@ export function buildKeys(queueName: string, prefix = DEFAULT_PREFIX) {
     groupq: (key: string) => `${p}:groupq:${key}`,
     parents: (id: string) => `${p}:parents:${id}`,
     jstream: (id: string) => `${p}:jstream:${id}`,
+    xqPending: `${p}:xq-pending`,
     worker: (id: string) => `${p}:w:${id}`,
     suspended: `${p}:suspended`,
     signals: (id: string) => `${p}:signals:${id}`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,6 +93,11 @@ export function keyPrefixPattern(prefix: string, queueName: string): string {
   return `${escapeGlob(prefix)}:{${escapeGlob(queueName)}}`;
 }
 
+/** Encode a retryable cross-queue parent notification without delimiter ambiguity. */
+export function encodeCrossQueueParentNotify(parentQueue: string, parentId: string, depsMember: string): string {
+  return JSON.stringify([parentQueue, parentId, depsMember]);
+}
+
 export function buildKeys(queueName: string, prefix = DEFAULT_PREFIX) {
   const p = keyPrefix(prefix, queueName);
   return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,6 +98,20 @@ export function encodeCrossQueueParentNotify(parentQueue: string, parentId: stri
   return JSON.stringify([parentQueue, parentId, depsMember]);
 }
 
+/** Decode a current JSON or legacy tab-delimited parent notification. */
+export function parseCrossQueueParentNotification(member: string): [string, string, string] | undefined {
+  try {
+    const decoded: unknown = JSON.parse(member);
+    if (Array.isArray(decoded) && decoded.length === 3 && decoded.every((part) => typeof part === 'string')) {
+      return decoded as [string, string, string];
+    }
+  } catch {
+    const legacy = member.split('\t');
+    if (legacy.length === 3) return legacy as [string, string, string];
+  }
+  return undefined;
+}
+
 export function buildKeys(queueName: string, prefix = DEFAULT_PREFIX) {
   const p = keyPrefix(prefix, queueName);
   return {

--- a/tests/compat-bull.test.ts
+++ b/tests/compat-bull.test.ts
@@ -457,6 +457,7 @@ describeEachMode('Bull compat: Stalled job recovery', (CONNECTION) => {
 
     // Wait for the reclaim cycle to redispatch the job and worker2 to process it.
     await waitFor(() => recovered, 15000);
+    await waitFor(async () => String(await cleanupClient.hget(k.job(job!.id), 'state')) === 'completed', 15000);
     await worker2.close(true);
 
     // Verify the job was re-enqueued by stalled recovery and ran to completion.

--- a/tests/dag.test.ts
+++ b/tests/dag.test.ts
@@ -438,6 +438,66 @@ describeEachMode('DAG flows', (CONNECTION) => {
     }
   }, 20000);
 
+  it('notifies cross-queue DAG parents without waiting for the promotion tick', async () => {
+    const qA = Q + '-eager-a';
+    const qB = Q + '-eager-b';
+    const flow = new FlowProducer({ connection: CONNECTION });
+    const processed: string[] = [];
+    let releaseA!: () => void;
+    const finishA = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    const workers = [
+      new Worker(
+        qA,
+        async () => {
+          processed.push('A');
+          await finishA;
+          return 'A';
+        },
+        { connection: CONNECTION, blockTimeout: 100, stalledInterval: 60000, promotionInterval: 10000 },
+      ),
+      new Worker(
+        qB,
+        async () => {
+          processed.push('B');
+          return 'B';
+        },
+        { connection: CONNECTION, blockTimeout: 100, stalledInterval: 60000, promotionInterval: 10000 },
+      ),
+    ];
+    for (const worker of workers) {
+      worker.on('error', () => {});
+      await worker.waitUntilReady();
+    }
+    // Let the startup promotion tick finish before submitting the DAG. The
+    // next scheduled tick is deliberately far outside this test's deadline.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    try {
+      const jobs = await flow.addDAG({
+        nodes: [
+          { name: 'A', queueName: qA, data: {} },
+          { name: 'B', queueName: qB, data: {}, deps: ['A'] },
+        ],
+      });
+      releaseA();
+      const bKeys = buildKeys(qB);
+      await waitFor(
+        async () => String(await cleanupClient.hget(bKeys.job(jobs.get('B')!.id), 'state')) === 'completed',
+        1500,
+        25,
+      );
+      expect(processed).toEqual(['A', 'B']);
+    } finally {
+      releaseA();
+      for (const worker of workers) await worker.close(true);
+      await flow.close();
+      await flushQueue(cleanupClient, qA);
+      await flushQueue(cleanupClient, qB);
+    }
+  }, 5000);
+
   it('executes a cross-queue DAG with a prefix containing braces', async () => {
     const prefix = 'test-dag:{tenant}';
     const qA = Q + '-prefix-a';

--- a/tests/dag.test.ts
+++ b/tests/dag.test.ts
@@ -349,6 +349,231 @@ describeEachMode('DAG flows', (CONNECTION) => {
     }
   });
 
+  it('wires a DAG across distinct queue slots', async () => {
+    const qA = Q + '-distinct-a';
+    const qB = Q + '-distinct-b';
+    const qC = Q + '-distinct-c';
+    const flow = new FlowProducer({ connection: CONNECTION });
+
+    try {
+      const jobs = await flow.addDAG({
+        nodes: [
+          { name: 'A', queueName: qA, data: {} },
+          { name: 'B', queueName: qB, data: {}, deps: ['A'] },
+          { name: 'C', queueName: qC, data: {}, deps: ['B'] },
+        ],
+      });
+
+      expect(String(await cleanupClient.hget(buildKeys(qB).job(jobs.get('B')!.id), 'state'))).toBe('waiting-children');
+      expect(String(await cleanupClient.hget(buildKeys(qC).job(jobs.get('C')!.id), 'state'))).toBe('waiting-children');
+      expect((await cleanupClient.smembers(buildKeys(qB).deps(jobs.get('B')!.id))).size).toBe(1);
+      expect((await cleanupClient.smembers(buildKeys(qC).deps(jobs.get('C')!.id))).size).toBe(1);
+      const parentsA = await cleanupClient.smembers(buildKeys(qA).parents(jobs.get('A')!.id));
+      expect(parentsA.size).toBe(1);
+    } finally {
+      await flow.close();
+      await flushQueue(cleanupClient, qA);
+      await flushQueue(cleanupClient, qB);
+      await flushQueue(cleanupClient, qC);
+    }
+  });
+
+  it('executes a DAG across distinct queue workers', async () => {
+    const qA = Q + '-execute-a';
+    const qB = Q + '-execute-b';
+    const qC = Q + '-execute-c';
+    const flow = new FlowProducer({ connection: CONNECTION });
+    const processed: string[] = [];
+    const workers = [
+      new Worker(
+        qA,
+        async () => {
+          processed.push('A');
+          return 'A';
+        },
+        { connection: CONNECTION, blockTimeout: 200, stalledInterval: 60000, promotionInterval: 100 },
+      ),
+      new Worker(
+        qB,
+        async () => {
+          processed.push('B');
+          return 'B';
+        },
+        { connection: CONNECTION, blockTimeout: 200, stalledInterval: 60000, promotionInterval: 100 },
+      ),
+      new Worker(
+        qC,
+        async () => {
+          processed.push('C');
+          return 'C';
+        },
+        { connection: CONNECTION, blockTimeout: 200, stalledInterval: 60000, promotionInterval: 100 },
+      ),
+    ];
+    for (const worker of workers) {
+      worker.on('error', () => {});
+      await worker.waitUntilReady();
+    }
+
+    try {
+      const jobs = await flow.addDAG({
+        nodes: [
+          { name: 'A', queueName: qA, data: {} },
+          { name: 'B', queueName: qB, data: {}, deps: ['A'] },
+          { name: 'C', queueName: qC, data: {}, deps: ['B'] },
+        ],
+      });
+      const cKeys = buildKeys(qC);
+      await waitFor(
+        async () => String(await cleanupClient.hget(cKeys.job(jobs.get('C')!.id), 'state')) === 'completed',
+        10000,
+      );
+      expect(processed).toEqual(['A', 'B', 'C']);
+    } finally {
+      for (const worker of workers) await worker.close(true);
+      await flow.close();
+      await flushQueue(cleanupClient, qA);
+      await flushQueue(cleanupClient, qB);
+      await flushQueue(cleanupClient, qC);
+    }
+  }, 20000);
+
+  it('executes a cross-queue DAG with a prefix containing braces', async () => {
+    const prefix = 'test-dag:{tenant}';
+    const qA = Q + '-prefix-a';
+    const qB = Q + '-prefix-b';
+    const qC = Q + '-prefix-c';
+    const flow = new FlowProducer({ connection: CONNECTION, prefix });
+    const processed: string[] = [];
+    const workers = [
+      new Worker(
+        qA,
+        async () => {
+          processed.push('A');
+          return 'A';
+        },
+        {
+          connection: CONNECTION,
+          prefix,
+          blockTimeout: 200,
+          stalledInterval: 60000,
+          promotionInterval: 100,
+        },
+      ),
+      new Worker(
+        qB,
+        async () => {
+          processed.push('B');
+          return 'B';
+        },
+        {
+          connection: CONNECTION,
+          prefix,
+          blockTimeout: 200,
+          stalledInterval: 60000,
+          promotionInterval: 100,
+        },
+      ),
+      new Worker(
+        qC,
+        async () => {
+          processed.push('C');
+          return 'C';
+        },
+        {
+          connection: CONNECTION,
+          prefix,
+          blockTimeout: 200,
+          stalledInterval: 60000,
+          promotionInterval: 100,
+        },
+      ),
+    ];
+    for (const worker of workers) {
+      worker.on('error', () => {});
+      await worker.waitUntilReady();
+    }
+
+    try {
+      const jobs = await flow.addDAG({
+        nodes: [
+          { name: 'A', queueName: qA, data: {} },
+          { name: 'B', queueName: qB, data: {}, deps: ['A'] },
+          { name: 'C', queueName: qC, data: {}, deps: ['B'] },
+        ],
+      });
+      await waitFor(
+        async () =>
+          String(await cleanupClient.hget(buildKeys(qC, prefix).job(jobs.get('C')!.id), 'state')) === 'completed',
+        10000,
+      );
+      expect(processed).toEqual(['A', 'B', 'C']);
+    } finally {
+      for (const worker of workers) await worker.close(true);
+      await flow.close();
+      await flushQueue(cleanupClient, qA, prefix);
+      await flushQueue(cleanupClient, qB, prefix);
+      await flushQueue(cleanupClient, qC, prefix);
+    }
+  }, 20000);
+
+  it('reconciles a DAG child deleted between Phase A and Phase B', async () => {
+    const queueName = Q + '-phaseb-race';
+    const flow = new FlowProducer({ connection: CONNECTION });
+    let worker: any;
+
+    const client = await (flow as any).getClient();
+    const originalExists = client.exists.bind(client);
+    let deleted = false;
+    client.exists = async (keys: string[]) => {
+      const result = await originalExists(keys);
+      const key = String(keys[0] ?? '');
+      if (!deleted && result === 1 && key.includes(`{${queueName}}:job:`)) {
+        deleted = true;
+        await cleanupClient.del([key]);
+      }
+      return result;
+    };
+
+    try {
+      const jobs = await flow.addDAG({
+        nodes: [
+          { name: 'A', queueName, data: {} },
+          { name: 'B', queueName, data: {}, deps: ['A'] },
+          { name: 'C', queueName, data: {}, deps: ['A'] },
+        ],
+      });
+      expect(deleted).toBe(true);
+      const keys = buildKeys(queueName);
+      const streamEntries = (await cleanupClient.xrange(keys.stream, '-', '+')) as Record<string, [string, string][]>;
+      for (const [entryId, fields] of Object.entries(streamEntries)) {
+        if (fields.some(([field, value]) => String(field) === 'jobId' && String(value) === jobs.get('A')!.id)) {
+          await cleanupClient.xdel(keys.stream, [entryId]);
+        }
+      }
+      worker = new Worker(queueName, async () => 'ok', {
+        connection: CONNECTION,
+        blockTimeout: 200,
+        stalledInterval: 60000,
+      });
+      worker.on('error', () => {});
+      await worker.waitUntilReady();
+      await waitFor(
+        async () =>
+          String(await cleanupClient.hget(keys.job(jobs.get('B')!.id), 'state')) === 'completed' &&
+          String(await cleanupClient.hget(keys.job(jobs.get('C')!.id), 'state')) === 'completed',
+        10000,
+      );
+      expect(await cleanupClient.exists([keys.job(jobs.get('A')!.id)])).toBe(0);
+      expect(await cleanupClient.exists([keys.parents(jobs.get('A')!.id)])).toBe(0);
+    } finally {
+      client.exists = originalExists;
+      await worker?.close(true);
+      await flow.close();
+      await flushQueue(cleanupClient, queueName);
+    }
+  }, 20000);
+
   it('handles race: registerParent after child completes', async () => {
     const qName = Q + '-race';
     const flow = new FlowProducer({ connection: CONNECTION });

--- a/tests/dag.test.ts
+++ b/tests/dag.test.ts
@@ -531,6 +531,7 @@ describeEachMode('DAG flows', (CONNECTION) => {
       if (!deleted && result === 1 && key.includes(`{${queueName}}:job:`)) {
         deleted = true;
         await cleanupClient.del([key]);
+        return 0;
       }
       return result;
     };
@@ -573,6 +574,41 @@ describeEachMode('DAG flows', (CONNECTION) => {
       await flushQueue(cleanupClient, queueName);
     }
   }, 20000);
+
+  it('reconciles a child deleted during same-queue parent registration', async () => {
+    const queueName = Q + '-register-race';
+    const flow = new FlowProducer({ connection: CONNECTION });
+    const client = await (flow as any).getClient();
+    const originalFcall = client.fcall.bind(client);
+    let deleted = false;
+    client.fcall = async (name: string, keys: string[], args: string[]) => {
+      if (!deleted && name === 'glidemq_registerParent') {
+        deleted = true;
+        await cleanupClient.del([String(keys[0])]);
+      }
+      return originalFcall(name, keys, args);
+    };
+
+    try {
+      const jobs = await flow.addDAG({
+        nodes: [
+          { name: 'A', queueName, data: {} },
+          { name: 'B', queueName, data: {}, deps: ['A'] },
+          { name: 'C', queueName, data: {}, deps: ['A'] },
+        ],
+      });
+
+      expect(deleted).toBe(true);
+      const keys = buildKeys(queueName);
+      expect(await cleanupClient.exists([keys.job(jobs.get('A')!.id)])).toBe(0);
+      expect(String(await cleanupClient.hget(keys.job(jobs.get('B')!.id), 'state'))).toBe('waiting');
+      expect(String(await cleanupClient.hget(keys.job(jobs.get('C')!.id), 'state'))).toBe('waiting');
+    } finally {
+      client.fcall = originalFcall;
+      await flow.close();
+      await flushQueue(cleanupClient, queueName);
+    }
+  });
 
   it('handles race: registerParent after child completes', async () => {
     const qName = Q + '-race';

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -386,6 +386,46 @@ describeEachMode('FlowProducer', (CONNECTION) => {
     }
   }, 20000);
 
+  it('returns one eager notification when nested and DAG parent metadata overlap', async () => {
+    const parentQ = Q + '-dedupe-parent';
+    const childQ = Q + '-dedupe-child';
+    const flow = new FlowProducer({ connection: CONNECTION });
+    try {
+      const node = await flow.add({
+        name: 'grandparent',
+        queueName: parentQ,
+        data: {},
+        children: [
+          {
+            name: 'middle',
+            queueName: childQ,
+            data: {},
+            children: [{ name: 'grandchild', queueName: childQ, data: {} }],
+          },
+        ],
+      });
+      const middle = node.children![0].job;
+      const childKeys = buildKeys(childQ);
+      expect((await cleanupClient.smembers(childKeys.parents(middle.id))).size).toBe(1);
+
+      const notifications = await completeJob(
+        cleanupClient,
+        childKeys,
+        middle.id,
+        '',
+        'null',
+        Date.now(),
+        CONSUMER_GROUP,
+      );
+
+      expect(notifications).toHaveLength(1);
+    } finally {
+      await flow.close();
+      await flushQueue(cleanupClient, parentQ);
+      await flushQueue(cleanupClient, childQ);
+    }
+  });
+
   it('completeChild does not recreate a removed parent hash', async () => {
     const parentQ = Q + '-removed-parent';
     const flow = new FlowProducer({ connection: CONNECTION });

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -586,7 +586,7 @@ describeEachMode('FlowProducer', (CONNECTION) => {
 
   it('flushes JSON pending notifications for queue names containing tabs', async () => {
     const parentQ = Q + '-tab-parent\tqueue';
-    const childQ = Q + '-tab-child\tqueue';
+    const childQ = parentQ;
     const flow = new FlowProducer({ connection: CONNECTION });
 
     try {

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -11,6 +11,8 @@ const { FlowProducer } = require('../dist/flow-producer') as typeof import('../s
 const { Queue } = require('../dist/queue') as typeof import('../src/queue');
 const { Scheduler } = require('../dist/scheduler') as typeof import('../src/scheduler');
 const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+const { completeJob, completeAndFetchNext, CONSUMER_GROUP } =
+  require('../dist/functions') as typeof import('../src/functions');
 
 describe('DAG wiring source invariants', () => {
   it('does not FCALL registerParent from the cross-queue Phase B batch', () => {
@@ -18,11 +20,12 @@ describe('DAG wiring source invariants', () => {
     expect(source).not.toMatch(/batchB\.fcall\(\s*['"]glidemq_registerParent/);
   });
 
-  it('guards completeChild against recreating deleted parent hashes', () => {
+  it('shares deleted-parent protection across every parent completion path', () => {
     const source = readFileSync('src/functions/glidemq.lua', 'utf8');
-    const start = source.indexOf("redis.register_function('glidemq_completeChild'");
-    const end = source.indexOf("redis.register_function('glidemq_registerParent'", start);
+    const start = source.indexOf('local function completeParentDependency');
+    const end = source.indexOf('local function groupqScore', start);
     expect(source.slice(start, end)).toMatch(/redis\.call\('EXISTS', parentJobKey\) == 0/);
+    expect(source.match(/HSETNX', parentJobKey, depMarker/g)).toHaveLength(1);
   });
 });
 
@@ -408,6 +411,69 @@ describeEachMode('FlowProducer', (CONNECTION) => {
       await flushQueue(cleanupClient, parentQ);
     }
   });
+
+  it.each(['complete', 'completeAndFetchNext'] as const)(
+    '%s does not recreate a removed inline parent hash',
+    async (completion) => {
+      const queueName = `${Q}-removed-inline-parent-${completion}`;
+      const flow = new FlowProducer({ connection: CONNECTION });
+      const keys = buildKeys(queueName);
+      try {
+        const node = await flow.add({
+          name: 'parent',
+          queueName,
+          data: {},
+          children: [{ name: 'child', queueName, data: {} }],
+        });
+        const parentId = node.job.id;
+        const childId = node.children![0].job.id;
+        const parentInfo = {
+          depsMember: `${keys.name}:${childId}`,
+          parentId,
+          parentKeys: keys,
+        };
+
+        await node.job.remove();
+        expect(await cleanupClient.exists([keys.job(parentId)])).toBe(0);
+
+        if (completion === 'complete') {
+          await completeJob(
+            cleanupClient,
+            keys,
+            childId,
+            '',
+            'null',
+            Date.now(),
+            CONSUMER_GROUP,
+            undefined,
+            parentInfo,
+          );
+        } else {
+          // completeAndFetchNext requires a consumer group even when no next
+          // entry exists. Remove the child's queued entry before creating it.
+          await cleanupClient.del([keys.stream]);
+          await cleanupClient.xgroupCreate(keys.stream, CONSUMER_GROUP, '0', { mkStream: true });
+          await completeAndFetchNext(
+            cleanupClient,
+            keys,
+            childId,
+            '',
+            'null',
+            Date.now(),
+            CONSUMER_GROUP,
+            'inline-parent-test',
+            undefined,
+            parentInfo,
+          );
+        }
+
+        expect(await cleanupClient.exists([keys.job(parentId)])).toBe(0);
+      } finally {
+        await flow.close();
+        await flushQueue(cleanupClient, queueName);
+      }
+    },
+  );
 
   it('reconciles a removed nested cross-queue child', async () => {
     const parentQ = Q + '-removed-parent';

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -588,13 +588,6 @@ describeEachMode('FlowProducer', (CONNECTION) => {
     const parentQ = Q + '-tab-parent\tqueue';
     const childQ = Q + '-tab-child\tqueue';
     const flow = new FlowProducer({ connection: CONNECTION });
-    const childWorker = new Worker(childQ, async () => ({ ok: true }), {
-      connection: CONNECTION,
-      blockTimeout: 200,
-      stalledInterval: 60000,
-    });
-    childWorker.on('error', () => {});
-    await childWorker.waitUntilReady();
 
     try {
       const node = await flow.add({
@@ -608,12 +601,11 @@ describeEachMode('FlowProducer', (CONNECTION) => {
       const pending = JSON.stringify([parentQ, node.job.id, `glide:{${childQ}}:${childId}`]);
       await cleanupClient.sadd(childKeys.xqPending, [pending]);
 
-      await (childWorker as any).scheduler.flushCrossQueueParentNotifies();
+      await new Scheduler(cleanupClient, childKeys).flushCrossQueueParentNotifies();
 
       expect(String(await cleanupClient.hget(buildKeys(parentQ).job(node.job.id), 'state'))).toBe('waiting');
       expect(await cleanupClient.sismember(childKeys.xqPending, pending)).toBe(false);
     } finally {
-      await childWorker.close(true);
       await flow.close();
       await flushQueue(cleanupClient, parentQ);
       await flushQueue(cleanupClient, childQ);

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -3,7 +3,7 @@
  * Runs against both standalone (:6379) and cluster (:7000).
  */
 import { readFileSync } from 'node:fs';
-import { it, expect, beforeAll, afterAll, describe } from 'vitest';
+import { it, expect, beforeAll, afterAll, describe, vi } from 'vitest';
 import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
 
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
@@ -23,6 +23,43 @@ describe('DAG wiring source invariants', () => {
     const start = source.indexOf("redis.register_function('glidemq_completeChild'");
     const end = source.indexOf("redis.register_function('glidemq_registerParent'", start);
     expect(source.slice(start, end)).toMatch(/redis\.call\('EXISTS', parentJobKey\) == 0/);
+  });
+});
+
+describe('Scheduler cross-queue notification parsing', () => {
+  it('handles JSON, legacy, malformed, stale, and failed notifications', async () => {
+    const jsonMember = JSON.stringify(['parent', 'p1', 'glide:{child}:c1']);
+    const legacyMember = 'parent\tp2\tglide:{child}:c2';
+    const malformedMember = '{"not":"a notification"}';
+    const failedMember = JSON.stringify(['parent', 'p3', 'glide:{child}:c3']);
+    const errors: Error[] = [];
+    const client = {
+      smembers: vi.fn().mockResolvedValue(new Set([jsonMember, legacyMember, malformedMember, failedMember])),
+      fcall: vi.fn(async (_name: string, _keys: string[], args: string[]) => {
+        if (args[1] === 'p2') return -1;
+        if (args[1] === 'p3') throw new Error('temporary connection failure');
+        return 0;
+      }),
+      srem: vi.fn().mockResolvedValue(1),
+    } as any;
+
+    await new Scheduler(client, buildKeys('child'), {
+      onError: (err: Error) => errors.push(err),
+    }).flushCrossQueueParentNotifies();
+
+    expect(client.fcall).toHaveBeenCalledTimes(3);
+    expect(client.srem).toHaveBeenCalledTimes(2);
+    expect(errors.map((error) => error.message)).toEqual(['temporary connection failure']);
+  });
+
+  it('reports malformed queue key metadata without attempting completion', async () => {
+    const client = { smembers: vi.fn().mockResolvedValue(new Set(['ignored'])) } as any;
+    const errors: Error[] = [];
+    const keys = { ...buildKeys('child'), id: 'glide:child:id' };
+
+    await new Scheduler(client, keys, { onError: (err: Error) => errors.push(err) }).flushCrossQueueParentNotifies();
+
+    expect(errors[0]?.message).toMatch(/Invalid queue id key/);
   });
 });
 
@@ -431,13 +468,7 @@ describeEachMode('FlowProducer', (CONNECTION) => {
   it('reconciles a child deleted between the existence check and parent wiring', async () => {
     const queueName = Q + '-toctou';
     const flow = new FlowProducer({ connection: CONNECTION });
-    const worker = new Worker(queueName, async () => ({ ok: true }), {
-      connection: CONNECTION,
-      blockTimeout: 200,
-      stalledInterval: 60000,
-    });
-    worker.on('error', () => {});
-    await worker.waitUntilReady();
+    let worker: any;
 
     const client = await (flow as any).getClient();
     const originalExists = client.exists.bind(client);
@@ -472,13 +503,21 @@ describeEachMode('FlowProducer', (CONNECTION) => {
       const keys = buildKeys(queueName);
       expect(await cleanupClient.exists([keys.job(nestedId)])).toBe(0);
       expect(await cleanupClient.exists([keys.parents(nestedId)])).toBe(0);
+      worker = new Worker(queueName, async () => ({ ok: true }), {
+        connection: CONNECTION,
+        blockTimeout: 200,
+        stalledInterval: 60000,
+        promotionInterval: 100,
+      });
+      worker.on('error', () => {});
+      await worker.waitUntilReady();
       await waitFor(
         async () => String(await cleanupClient.hget(keys.job(node.job.id), 'state')) === 'completed',
         10000,
       );
     } finally {
       client.exists = originalExists;
-      await worker.close(true);
+      if (worker) await worker.close(true);
       await flow.close();
       await flushQueue(cleanupClient, queueName);
     }

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -375,6 +375,7 @@ describeEachMode('FlowProducer', (CONNECTION) => {
         async () => String(await cleanupClient.hget(parentKeys.job(node.job.id), 'state')) === 'completed',
         10000,
       );
+      expect(String(await cleanupClient.hget(parentKeys.job(node.job.id), 'state'))).toBe('completed');
     } finally {
       releaseMiddle();
       await parentWorker.close(true);
@@ -523,6 +524,7 @@ describeEachMode('FlowProducer', (CONNECTION) => {
         async () => String(await cleanupClient.hget(parentKeys.job(node.job.id), 'state')) === 'completed',
         10000,
       );
+      expect(String(await cleanupClient.hget(parentKeys.job(node.job.id), 'state'))).toBe('completed');
     } finally {
       await parentWorker.close(true);
       await flow.close();

--- a/tests/flow.test.ts
+++ b/tests/flow.test.ts
@@ -2,12 +2,29 @@
  * Flow (parent-child job trees) integration tests.
  * Runs against both standalone (:6379) and cluster (:7000).
  */
-import { it, expect, beforeAll, afterAll } from 'vitest';
-import { describeEachMode, createCleanupClient, flushQueue } from './helpers/fixture';
+import { readFileSync } from 'node:fs';
+import { it, expect, beforeAll, afterAll, describe } from 'vitest';
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
 
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
 const { FlowProducer } = require('../dist/flow-producer') as typeof import('../src/flow-producer');
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { Scheduler } = require('../dist/scheduler') as typeof import('../src/scheduler');
 const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+
+describe('DAG wiring source invariants', () => {
+  it('does not FCALL registerParent from the cross-queue Phase B batch', () => {
+    const source = readFileSync('src/flow-producer.ts', 'utf8');
+    expect(source).not.toMatch(/batchB\.fcall\(\s*['"]glidemq_registerParent/);
+  });
+
+  it('guards completeChild against recreating deleted parent hashes', () => {
+    const source = readFileSync('src/functions/glidemq.lua', 'utf8');
+    const start = source.indexOf("redis.register_function('glidemq_completeChild'");
+    const end = source.indexOf("redis.register_function('glidemq_registerParent'", start);
+    expect(source.slice(start, end)).toMatch(/redis\.call\('EXISTS', parentJobKey\) == 0/);
+  });
+});
 
 describeEachMode('FlowProducer', (CONNECTION) => {
   let cleanupClient: any;
@@ -244,6 +261,367 @@ describeEachMode('FlowProducer', (CONNECTION) => {
     await flow.close();
     await flushQueue(cleanupClient, qName);
   }, 60000);
+
+  it('nested cross-queue flow completes when workers are already running', async () => {
+    const parentQ = Q + '-xq-parent';
+    const childQ = Q + '-xq-child';
+    const flow = new FlowProducer({ connection: CONNECTION });
+    let middleStarted = false;
+    let releaseMiddle = () => {};
+    const middleGate = new Promise<void>((resolve) => {
+      releaseMiddle = resolve;
+    });
+    const parentWorker = new Worker(parentQ, async () => ({ ok: true }), {
+      connection: CONNECTION,
+      concurrency: 4,
+      blockTimeout: 200,
+      stalledInterval: 60000,
+    });
+    const childWorker = new Worker(
+      childQ,
+      async (job: any) => {
+        if (job.data.level === 1) {
+          middleStarted = true;
+          await middleGate;
+        }
+        return { ok: true };
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 4,
+        blockTimeout: 200,
+        stalledInterval: 60000,
+      },
+    );
+    parentWorker.on('error', () => {});
+    childWorker.on('error', () => {});
+    await parentWorker.waitUntilReady();
+    await childWorker.waitUntilReady();
+
+    // Hold the recursive child flow after its middle job is active. The outer
+    // parent is then created and wired while that worker still has a stale job
+    // snapshot with no parentId/parentQueue fields.
+    const originalAddFlowRecursive = (flow as any).addFlowRecursive;
+    let nesting = 0;
+    (flow as any).addFlowRecursive = async function (...args: any[]) {
+      nesting++;
+      try {
+        const result = await originalAddFlowRecursive.apply(this, args);
+        if (nesting === 2) await waitFor(() => middleStarted, 5000);
+        return result;
+      } finally {
+        nesting--;
+      }
+    };
+
+    try {
+      const node = await flow.add({
+        name: 'grandparent',
+        queueName: parentQ,
+        data: { level: 0 },
+        children: [
+          {
+            name: 'parent-child',
+            queueName: childQ,
+            data: { level: 1 },
+            children: [{ name: 'grandchild', queueName: childQ, data: { level: 2 } }],
+          },
+        ],
+      });
+
+      releaseMiddle();
+      const parentKeys = buildKeys(parentQ);
+      await waitFor(
+        async () => String(await cleanupClient.hget(parentKeys.job(node.job.id), 'state')) === 'completed',
+        10000,
+      );
+    } finally {
+      releaseMiddle();
+      await parentWorker.close(true);
+      await childWorker.close(true);
+      await flow.close();
+      await flushQueue(cleanupClient, parentQ);
+      await flushQueue(cleanupClient, childQ);
+    }
+  }, 20000);
+
+  it('completeChild does not recreate a removed parent hash', async () => {
+    const parentQ = Q + '-removed-parent';
+    const flow = new FlowProducer({ connection: CONNECTION });
+    try {
+      const node = await flow.add({
+        name: 'removed-parent',
+        queueName: parentQ,
+        data: {},
+        children: [{ name: 'child', queueName: parentQ, data: {} }],
+      });
+      const parentKeys = buildKeys(parentQ);
+      const parentJobKey = parentKeys.job(node.job.id);
+      await cleanupClient.del([parentJobKey]);
+
+      await cleanupClient.fcall(
+        'glidemq_completeChild',
+        [parentKeys.deps(node.job.id), parentJobKey, parentKeys.stream, parentKeys.events],
+        [`${parentKeys.name}:${node.children![0].job.id}`, node.job.id],
+      );
+
+      expect(await cleanupClient.exists([parentJobKey])).toBe(0);
+    } finally {
+      await flow.close();
+      await flushQueue(cleanupClient, parentQ);
+    }
+  });
+
+  it('reconciles a removed nested cross-queue child', async () => {
+    const parentQ = Q + '-removed-parent';
+    const childQ = Q + '-removed-child';
+    const flow = new FlowProducer({ connection: CONNECTION });
+    const parentWorker = new Worker(parentQ, async () => ({ ok: true }), {
+      connection: CONNECTION,
+      blockTimeout: 200,
+      stalledInterval: 60000,
+    });
+    parentWorker.on('error', () => {});
+    await parentWorker.waitUntilReady();
+
+    let nesting = 0;
+    const originalAddFlowRecursive = (flow as any).addFlowRecursive;
+    (flow as any).addFlowRecursive = async function (...args: any[]) {
+      nesting++;
+      try {
+        const result = await originalAddFlowRecursive.apply(this, args);
+        if (nesting === 2) {
+          const childKeys = buildKeys(args[1].queueName);
+          await cleanupClient.del([childKeys.job(result.job.id)]);
+        }
+        return result;
+      } finally {
+        nesting--;
+      }
+    };
+
+    try {
+      const node = await flow.add({
+        name: 'outer-parent',
+        queueName: parentQ,
+        data: {},
+        children: [
+          {
+            name: 'nested-parent',
+            queueName: childQ,
+            data: {},
+            children: [{ name: 'nested-child', queueName: childQ, data: {} }],
+          },
+        ],
+      });
+
+      const parentKeys = buildKeys(parentQ);
+      await waitFor(
+        async () => String(await cleanupClient.hget(parentKeys.job(node.job.id), 'state')) === 'completed',
+        10000,
+      );
+    } finally {
+      await parentWorker.close(true);
+      await flow.close();
+      await flushQueue(cleanupClient, parentQ);
+      await flushQueue(cleanupClient, childQ);
+    }
+  }, 20000);
+
+  it('reconciles a child deleted between the existence check and parent wiring', async () => {
+    const queueName = Q + '-toctou';
+    const flow = new FlowProducer({ connection: CONNECTION });
+    const worker = new Worker(queueName, async () => ({ ok: true }), {
+      connection: CONNECTION,
+      blockTimeout: 200,
+      stalledInterval: 60000,
+    });
+    worker.on('error', () => {});
+    await worker.waitUntilReady();
+
+    const client = await (flow as any).getClient();
+    const originalExists = client.exists.bind(client);
+    let deleted = false;
+    client.exists = async (keys: string[]) => {
+      const result = await originalExists(keys);
+      const key = String(keys[0] ?? '');
+      if (!deleted && result === 1 && key.includes(`{${queueName}}:job:`)) {
+        deleted = true;
+        await cleanupClient.del([key]);
+      }
+      return result;
+    };
+
+    try {
+      const node = await flow.add({
+        name: 'toctou-parent',
+        queueName,
+        data: {},
+        children: [
+          {
+            name: 'toctou-nested-parent',
+            queueName,
+            data: {},
+            children: [{ name: 'toctou-leaf', queueName, data: {} }],
+          },
+        ],
+      });
+
+      expect(deleted).toBe(true);
+      const nestedId = node.children![0].job.id;
+      const keys = buildKeys(queueName);
+      expect(await cleanupClient.exists([keys.job(nestedId)])).toBe(0);
+      expect(await cleanupClient.exists([keys.parents(nestedId)])).toBe(0);
+      await waitFor(
+        async () => String(await cleanupClient.hget(keys.job(node.job.id), 'state')) === 'completed',
+        10000,
+      );
+    } finally {
+      client.exists = originalExists;
+      await worker.close(true);
+      await flow.close();
+      await flushQueue(cleanupClient, queueName);
+    }
+  }, 20000);
+
+  it('reconciles a cross-queue child deleted between the existence check and parent wiring', async () => {
+    const parentQ = Q + '-toctou-parent';
+    const childQ = Q + '-toctou-child';
+    const flow = new FlowProducer({ connection: CONNECTION });
+    const client = await (flow as any).getClient();
+    const originalExists = client.exists.bind(client);
+    let deleted = false;
+    client.exists = async (keys: string[]) => {
+      const result = await originalExists(keys);
+      const key = String(keys[0] ?? '');
+      if (!deleted && result === 1 && key.includes(`{${childQ}}:job:`)) {
+        deleted = true;
+        await cleanupClient.del([key]);
+      }
+      return result;
+    };
+
+    let worker: any;
+    try {
+      const node = await flow.add({
+        name: 'cross-toctou-parent',
+        queueName: parentQ,
+        data: {},
+        children: [
+          {
+            name: 'cross-toctou-nested-parent',
+            queueName: childQ,
+            data: {},
+            children: [{ name: 'cross-toctou-leaf', queueName: childQ, data: {} }],
+          },
+        ],
+      });
+
+      expect(deleted).toBe(true);
+      const childKeys = buildKeys(childQ);
+      const nestedId = node.children![0].job.id;
+      expect(await cleanupClient.exists([childKeys.job(nestedId)])).toBe(0);
+      expect(await cleanupClient.exists([childKeys.parents(nestedId)])).toBe(0);
+
+      worker = new Worker(parentQ, async () => ({ ok: true }), {
+        connection: CONNECTION,
+        blockTimeout: 200,
+        stalledInterval: 60000,
+        promotionInterval: 100,
+      });
+      worker.on('error', () => {});
+      await worker.waitUntilReady();
+      const parentKeys = buildKeys(parentQ);
+      await waitFor(
+        async () => String(await cleanupClient.hget(parentKeys.job(node.job.id), 'state')) === 'completed',
+        10000,
+      );
+    } finally {
+      client.exists = originalExists;
+      await worker?.close(true);
+      await flow.close();
+      await flushQueue(cleanupClient, parentQ);
+      await flushQueue(cleanupClient, childQ);
+    }
+  }, 20000);
+
+  it('flushes JSON pending notifications for queue names containing tabs', async () => {
+    const parentQ = Q + '-tab-parent\tqueue';
+    const childQ = Q + '-tab-child\tqueue';
+    const flow = new FlowProducer({ connection: CONNECTION });
+    const childWorker = new Worker(childQ, async () => ({ ok: true }), {
+      connection: CONNECTION,
+      blockTimeout: 200,
+      stalledInterval: 60000,
+    });
+    childWorker.on('error', () => {});
+    await childWorker.waitUntilReady();
+
+    try {
+      const node = await flow.add({
+        name: 'tab-parent',
+        queueName: parentQ,
+        data: {},
+        children: [{ name: 'tab-child', queueName: childQ, data: {} }],
+      });
+      const childId = node.children![0].job.id;
+      const childKeys = buildKeys(childQ);
+      const pending = JSON.stringify([parentQ, node.job.id, `glide:{${childQ}}:${childId}`]);
+      await cleanupClient.sadd(childKeys.xqPending, [pending]);
+
+      await (childWorker as any).scheduler.flushCrossQueueParentNotifies();
+
+      expect(String(await cleanupClient.hget(buildKeys(parentQ).job(node.job.id), 'state'))).toBe('waiting');
+      expect(await cleanupClient.sismember(childKeys.xqPending, pending)).toBe(false);
+    } finally {
+      await childWorker.close(true);
+      await flow.close();
+      await flushQueue(cleanupClient, parentQ);
+      await flushQueue(cleanupClient, childQ);
+    }
+  }, 20000);
+
+  it('flushes pending notifications with a custom prefix containing braces', async () => {
+    const prefix = 'test-flow:{tenant}';
+    const parentQ = Q + '-prefix-parent';
+    const childQ = Q + '-prefix-child';
+    const flow = new FlowProducer({ connection: CONNECTION, prefix });
+
+    try {
+      const node = await flow.add({
+        name: 'prefix-parent',
+        queueName: parentQ,
+        data: {},
+        children: [{ name: 'prefix-child', queueName: childQ, data: {} }],
+      });
+      const childId = node.children![0].job.id;
+      const childKeys = buildKeys(childQ, prefix);
+      const pending = JSON.stringify([parentQ, node.job.id, `${prefix}:{${childQ}}:${childId}`]);
+      await cleanupClient.sadd(childKeys.xqPending, [pending]);
+
+      await new Scheduler(cleanupClient, childKeys).flushCrossQueueParentNotifies();
+
+      expect(String(await cleanupClient.hget(buildKeys(parentQ, prefix).job(node.job.id), 'state'))).toBe('waiting');
+      expect(await cleanupClient.sismember(childKeys.xqPending, pending)).toBe(false);
+    } finally {
+      await flow.close();
+      await flushQueue(cleanupClient, parentQ, prefix);
+      await flushQueue(cleanupClient, childQ, prefix);
+    }
+  });
+
+  it('obliterate removes cross-queue pending notifications', async () => {
+    const queueName = Q + '-obliterate-xq';
+    const queue = new Queue(queueName, { connection: CONNECTION });
+    const keys = buildKeys(queueName);
+    try {
+      await cleanupClient.sadd(keys.xqPending, ['pending']);
+      await queue.obliterate({ force: true });
+      expect(await cleanupClient.exists([keys.xqPending])).toBe(0);
+    } finally {
+      await queue.close();
+    }
+  });
 
   it('parent getChildrenValues returns all child results', async () => {
     const qName = Q + '-values';

--- a/tests/helpers/fixture.ts
+++ b/tests/helpers/fixture.ts
@@ -108,6 +108,7 @@ export async function flushQueue(client: any, queueName: string, prefix = 'glide
     k.schedulers,
     k.ordering,
     k.ratelimited,
+    k.xqPending,
     k.metricsCompleted,
     k.metricsFailed,
     k.lifo,

--- a/tests/lua-instrument.test.ts
+++ b/tests/lua-instrument.test.ts
@@ -67,7 +67,6 @@ describe('Lua coverage instrumenter', () => {
     expect(lua).toContain("return '__LIBRARY_VERSION__'");
     expect(lua).toContain("__reg('glidemq_addJob'");
     expect(lua).not.toContain("redis.register_function('glidemq_");
-    expect(lua).not.toContain('__cov[1108]=1;');
     expect(executable.length).toBeGreaterThan(500);
   });
 

--- a/tests/shutdown.test.ts
+++ b/tests/shutdown.test.ts
@@ -34,6 +34,7 @@ function makeMockClient(overrides: Record<string, unknown> = {}) {
     xread: vi.fn().mockResolvedValue(null),
     hgetall: vi.fn().mockResolvedValue([]),
     hget: vi.fn().mockResolvedValue(null),
+    smembers: vi.fn().mockResolvedValue(new Set()),
     close: vi.fn(),
     ...overrides,
   };

--- a/tests/worker-saturation.test.ts
+++ b/tests/worker-saturation.test.ts
@@ -52,6 +52,7 @@ function makeMockClient(overrides: Record<string, unknown> = {}) {
     hgetall: vi.fn().mockResolvedValue([]),
     hget: vi.fn().mockResolvedValue(null),
     hset: vi.fn().mockResolvedValue(1),
+    smembers: vi.fn().mockResolvedValue(new Set()),
     close: vi.fn(),
     ...overrides,
   };

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -45,6 +45,7 @@ function makeMockClient(overrides: Record<string, unknown> = {}) {
     hget: vi.fn().mockResolvedValue(null),
     hmget: vi.fn().mockResolvedValue([null, null]),
     hset: vi.fn().mockResolvedValue(1),
+    smembers: vi.fn().mockResolvedValue(new Set()),
     close: vi.fn(),
     ...overrides,
   };

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -300,6 +300,7 @@ describe('Worker', () => {
     expect(completeAndFetchNextCall).toBeDefined();
     const completionArgs = completeAndFetchNextCall[2] as string[];
     expect(completionArgs.slice(-8, -5)).toEqual(['tenant-a', '1', 'group-1']);
+    expect(mockCommandClient.hmget).not.toHaveBeenCalledWith(keys.job('1'), ['parentId', 'parentQueue']);
 
     // Event should have been emitted
     expect(completedJobs).toHaveLength(1);


### PR DESCRIPTION
## Summary
- Completes nested and cross-queue parents without cross-slot FCALL keys.
- Persists retryable parent notifications and reconciles removed or deleted flow/DAG children.
- Preserves custom prefixes, removes ghost parent sets, and clears pending notifications during obliterate.
- Uses JSON-safe pending payloads and a versioned server-function library.

## Regression-first history
The first commit is `15a89cc test: cover nested cross-queue parent completion`. It fails on upstream before the implementation commits.

## Validation
- `npm run build`
- `SKIP_CLUSTER=1 npx vitest run tests/flow.test.ts tests/dag.test.ts` - 33/33
- Custom-prefix cross-queue recovery reproduced and fixed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

The branch is independent and based directly on `upstream/main`.

## Known CI dependency

The upstream `codecov/patch` check is blocked by the base-workflow issue fixed in [#272](https://github.com/avifenesh/glide-mq/pull/272): the unquoted fuzzer glob changes the integration coverage selection, and the coverage uploads need the corrected authentication. The identical head passes every test and 92.76% patch coverage in companion fork PR [#7](https://github.com/jonathanong/glide-mq/pull/7). Merge #272, allow the resulting `main` coverage run to complete, then rebase this branch onto updated `main` and rerun CI. This is CI plumbing, not missing integration-test coverage.

### Coverage comparison

| Context | Patch coverage |
|---|---:|
| Current upstream run | 73.74% |
| [Identical-head fork PR #7](https://github.com/jonathanong/glide-mq/pull/7) | 92.76% |