### PR TITLE
fix: keep command client alive during in-flight reconnect

### DIFF
--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -411,10 +411,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
               await this.commandClient.ping();
               await ensureFunctionLibrary(this.commandClient, undefined, this.opts.connection!.clusterMode ?? false);
             } catch (err) {
-              this.emit(
-                'error',
-                new ConnectionError('Command client is unreachable while jobs are in flight.'),
-              );
+              this.emit('error', new ConnectionError('Command client is unreachable while jobs are in flight.'));
               throw err;
             }
           }

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -390,18 +390,34 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         }
 
         if (this.commandClientOwned) {
-          // Close and recreate owned command client
-          if (this.commandClient) {
-            try {
-              this.commandClient.close();
-            } catch {
-              /* ignore */
+          const jobsInFlight = this.activePromises.size > 0;
+          if (!jobsInFlight) {
+            if (this.commandClient) {
+              try {
+                this.commandClient.close();
+              } catch {
+                /* ignore */
+              }
+              this.commandClient = null;
             }
-            this.commandClient = null;
+            const client = await createClient(this.opts.connection!);
+            await ensureFunctionLibrary(client, undefined, this.opts.connection!.clusterMode ?? false);
+            this.commandClient = client;
+          } else if (this.commandClient) {
+            // Keep the live command client so in-flight completions and
+            // heartbeats continue. Closing it here freezes lastActive and
+            // lets stalled reclaim double-run the processor.
+            try {
+              await this.commandClient.ping();
+              await ensureFunctionLibrary(this.commandClient, undefined, this.opts.connection!.clusterMode ?? false);
+            } catch (err) {
+              this.emit(
+                'error',
+                new ConnectionError('Command client is unreachable while jobs are in flight.'),
+              );
+              throw err;
+            }
           }
-          const client = await createClient(this.opts.connection!);
-          await ensureFunctionLibrary(client, undefined, this.opts.connection!.clusterMode ?? false);
-          this.commandClient = client;
         } else {
           // Injected command client - verify liveness and re-ensure library
           try {

--- a/tests/reconnect-live-client.test.ts
+++ b/tests/reconnect-live-client.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Reconnect must not destroy the command client under in-flight jobs.
+ *
+ * concurrency>1 dispatches processJob then keeps polling. A later pollOnce throw
+ * runs reconnectAndResume, which closes the owned command client. Heartbeats
+ * captured that client and fail silently, so lastActive freezes and stalled
+ * reclaim redelivers the job while the original processor is still running.
+ *
+ * Run: npx vitest run tests/reconnect-live-client.test.ts
+ */
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './helpers/fixture';
+
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+
+describeEachMode('reconnect with in-flight jobs', (CONNECTION) => {
+  let cleanupClient: any;
+  const queues: string[] = [];
+
+  function uniqueQueue(prefix: string): string {
+    const name = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    queues.push(name);
+    return name;
+  }
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    await Promise.all(queues.map((q) => flushQueue(cleanupClient, q).catch(() => {})));
+    cleanupClient.close();
+  });
+
+  it('does not redeliver an in-flight job after poll reconnect', async () => {
+    const Q = uniqueQueue('reconnect-live');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    await queue.add('task', { n: 1 });
+
+    let release!: () => void;
+    const hold = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let started = 0;
+
+    const worker = new Worker(
+      Q,
+      async () => {
+        started++;
+        await hold;
+        return 'ok';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 2,
+        blockTimeout: 50,
+        lockDuration: 1000,
+        stalledInterval: 400,
+      },
+    );
+    worker.on('error', () => {});
+
+    await waitFor(() => started === 1);
+
+    const origPollOnce = (worker as any).pollOnce.bind(worker);
+    let failNext = true;
+    (worker as any).pollOnce = async () => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('Connection lost');
+      }
+      return origPollOnce();
+    };
+
+    await waitFor(() => !failNext, 4000, 20);
+    await new Promise((r) => setTimeout(r, 2500));
+
+    expect(started).toBe(1);
+
+    release();
+    await waitFor(() => started >= 1 && (worker as any).activeCount === 0, 4000, 50);
+    expect(started).toBe(1);
+
+    await worker.close(true);
+    await queue.close();
+  }, 15000);
+});


### PR DESCRIPTION
Companion review PR for reconnect destroying the command client under live jobs.

## Summary
- a pollOnce throw on concurrency>1 reconnects and closes the owned command client
- in-flight heartbeats captured that client and fail silently
- lastActive freezes, stalled reclaim redelivers, and the processor runs twice
- skip recreating the command client while activePromises is non-empty; still replace the blocking client

## Red-first proof
The first commit is test-only. Against its parent, triggering reconnect during an in-flight job made the processor start a second time within lockDuration.

## Test plan
- [x] `npx vitest run tests/reconnect-live-client.test.ts`
- [x] `npx vitest run tests/recovery.test.ts`


Made with [Cursor](https://cursor.com)