### PR TITLE
fix: allow list jobs to moveToDelayed and suspend

### DIFF
--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -1383,6 +1383,11 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           this.stopHeartbeat(currentJobId);
           this.activeAbortControllers.delete(currentJobId);
         }
+        if (continuation.job.movedToFailed) {
+          job.movedToFailed = true;
+          job.movedToFailedResult = continuation.job.movedToFailedResult;
+          job.failedReason = continuation.job.failedReason;
+        }
         aborted = ac.signal.aborted;
       } else {
         this.suspendContinuations.delete(currentJobId);

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -1389,6 +1389,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           job.movedToFailedResult = continuation.job.movedToFailedResult;
           job.failedReason = continuation.job.failedReason;
         }
+        if (continuation.job.discarded) job.discarded = true;
         const resumedDelayedRequest = continuation.job.consumeMoveToDelayedRequest();
         if (resumedDelayedRequest) job.moveToDelayedRequest = resumedDelayedRequest;
         if (continuation.job.consumeMoveToWaitingChildrenRequest()) job.moveToWaitingChildrenRequest = true;

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -561,6 +561,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       const hash = moveResult as Record<string, string>;
       const job = Job.fromHash<D, R>(this.commandClient, this.queueKeys, entry.jobId, hash, this.serializer);
       job.entryId = entry.entryId;
+      job.failContext = { group: this.consumerGroup, broadcastMode: this.broadcastMode ? true : undefined };
 
       // Check ordering - if not ready, defer and skip
       const orderingReady = await this.isOrderingTurn(job);
@@ -688,6 +689,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         const len = Array.isArray(results) ? results.length : 'non-array';
         const err = new Error(`Batch processor returned ${len} results but batch had ${batch.length} jobs`);
         for (const entry of batch) {
+          if (await this.skipMovedToFailed(entry.job)) continue;
           await this.handleJobFailure(entry.job, entry.jobId, entry.entryId, err);
         }
         return;
@@ -696,7 +698,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       for (let i = 0; i < batch.length; i++) {
         const entry = batch[i];
         const result = results[i];
-        if (entry.job.movedToFailed) continue;
+        if (await this.skipMovedToFailed(entry.job)) continue;
 
         let returnvalue: string;
         try {
@@ -758,6 +760,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       for (let i = 0; i < batch.length; i++) {
         const entry = batch[i];
         const result = i < batchResults.length ? batchResults[i] : new Error('No result in BatchError');
+        if (await this.skipMovedToFailed(entry.job)) continue;
 
         if (result instanceof Error) {
           const failure = (await this.isJobRevoked(entry.jobId)) ? new UnrecoverableError('revoked') : result;
@@ -822,6 +825,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       // A timeout is retryable. Revocation is terminal only when completion or
       // an explicit state check positively identifies the revoked job.
       for (const entry of batch) {
+        if (await this.skipMovedToFailed(entry.job)) continue;
         const failure = (await this.isJobRevoked(entry.jobId)) ? new UnrecoverableError('revoked') : thrownError;
         await this.handleJobFailure(entry.job, entry.jobId, entry.entryId, failure);
       }
@@ -1101,6 +1105,29 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
   }
 
   /**
+   * Job.moveToFailed already ran failJob. Finish DLQ, failed events, and
+   * repeatAfterComplete scheduling without transitioning the job again.
+   */
+  protected async finalizeMovedToFailed(job: Job<D, R>, error: Error): Promise<void> {
+    if (job.movedToFailedFinalized) return;
+    job.movedToFailedFinalized = true;
+    const terminal = job.movedToFailedResult === 'failed';
+    if (terminal && this.opts.deadLetterQueue && this.commandClient) {
+      await this.moveToDLQ(job, error);
+    }
+    if (this.hasFailedListeners) this.emit('failed', job, error);
+    if (terminal && job.schedulerName) {
+      await this.updateSchedulerAfterComplete(job.schedulerName, Date.now());
+    }
+  }
+
+  protected async skipMovedToFailed(job: Job<D, R>): Promise<boolean> {
+    if (!job.movedToFailed) return false;
+    await this.finalizeMovedToFailed(job, new Error(job.failedReason || 'failed'));
+    return true;
+  }
+
+  /**
    * Move an active job back into delayed state after the processor requests a pause.
    */
   protected async handleMoveToDelayed(
@@ -1267,6 +1294,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
 
       const job = Job.fromHash<D, R>(this.commandClient, this.queueKeys, currentJobId, currentHash, this.serializer);
       job.entryId = currentEntryId;
+      job.failContext = { group: this.consumerGroup, broadcastMode: this.broadcastMode ? true : undefined };
 
       // Fast path: skip async isOrderingTurn when no ordering configured
       if (this.orderingMetaField(job)) {
@@ -1443,6 +1471,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       }
 
       if (processError || aborted) {
+        if (await this.skipMovedToFailed(job)) return;
         const confirmedRevoked = aborted && (await this.isJobRevoked(currentJobId));
         await this.handleJobFailure(
           job,
@@ -1453,7 +1482,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         return;
       }
 
-      if (job.movedToFailed) return;
+      if (await this.skipMovedToFailed(job)) return;
 
       if (!this.commandClient) return;
 

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -696,6 +696,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       for (let i = 0; i < batch.length; i++) {
         const entry = batch[i];
         const result = results[i];
+        if (entry.job.movedToFailed) continue;
 
         let returnvalue: string;
         try {
@@ -1451,6 +1452,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         );
         return;
       }
+
+      if (job.movedToFailed) return;
 
       if (!this.commandClient) return;
 

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -1389,11 +1389,18 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           job.movedToFailedResult = continuation.job.movedToFailedResult;
           job.failedReason = continuation.job.failedReason;
         }
+        const resumedDelayedRequest = continuation.job.consumeMoveToDelayedRequest();
+        if (resumedDelayedRequest) job.moveToDelayedRequest = resumedDelayedRequest;
+        if (continuation.job.consumeMoveToWaitingChildrenRequest()) job.moveToWaitingChildrenRequest = true;
+        const resumedSuspendRequest = continuation.job.consumeSuspendRequest();
+        if (resumedSuspendRequest) job.suspendRequest = resumedSuspendRequest;
         aborted = ac.signal.aborted;
       } else {
         this.suspendContinuations.delete(currentJobId);
         ({ result: processResult, error: processError, aborted } = await this.runProcessor(job, currentJobId));
       }
+
+      if (await this.skipMovedToFailed(job)) return;
 
       const delayedRequest = job.consumeMoveToDelayedRequest();
       const delayedError = processError instanceof DelayedError ? processError : undefined;

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -1365,9 +1365,11 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       let processResult: R | undefined;
       let processError: Error | undefined;
       let aborted: boolean;
+      let continuationJob = job;
       const hasContinuation = job.signals.length > 0 && this.suspendContinuations.has(currentJobId);
       if (hasContinuation) {
         const continuation = this.suspendContinuations.get(currentJobId)!;
+        continuationJob = continuation.job;
         this.suspendContinuations.delete(currentJobId);
         const ac = new AbortController();
         this.activeAbortControllers.set(currentJobId, ac);
@@ -1474,7 +1476,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         if (!this.commandClient) return;
         try {
           if (suspendReq?.onResume) {
-            this.suspendContinuations.set(currentJobId, { job, onResume: suspendReq.onResume });
+            this.suspendContinuations.set(currentJobId, { job: continuationJob, onResume: suspendReq.onResume });
           }
           const suspResult = await suspendJob(
             this.commandClient,

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -1373,6 +1373,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         this.activeAbortControllers.set(currentJobId, ac);
         job.abortSignal = ac.signal;
         continuation.job.abortSignal = ac.signal;
+        continuation.job.entryId = currentEntryId;
         this.startHeartbeat(currentJobId, job.opts.lockDuration);
         try {
           processResult = await continuation.onResume(job.signals);

--- a/src/job.ts
+++ b/src/job.ts
@@ -198,6 +198,13 @@ export class Job<D = any, R = any> {
    */
   discarded = false;
 
+  /**
+   * When true, moveToFailed already transitioned the job. The worker must not
+   * completeAndFetchNext / completeJob afterward.
+   * @internal
+   */
+  movedToFailed = false;
+
   /** @internal Request captured by moveToDelayed() while inside the worker. */
   moveToDelayedRequest?: { delayedUntil: number; serializedData?: string; nextData?: D };
 
@@ -647,6 +654,7 @@ export class Job<D = any, R = any> {
       backoffDelay,
     );
     this.failedReason = err.message;
+    this.movedToFailed = true;
     if (result === 'retrying') {
       this.attemptsMade += 1;
     }

--- a/src/job.ts
+++ b/src/job.ts
@@ -482,7 +482,7 @@ export class Job<D = any, R = any> {
    * This method must be called from inside a Worker processor.
    */
   async moveToWaitingChildren(): Promise<never> {
-    if (!this.entryId) {
+    if (this.entryId == null) {
       throw new Error('moveToWaitingChildren() can only be used while the job is active in a Worker');
     }
     this.moveToWaitingChildrenRequest = true;
@@ -508,7 +508,7 @@ export class Job<D = any, R = any> {
    * This method must be called from inside a Worker processor.
    */
   async suspend(opts?: SuspendOptions & { onResume?: (signals: SignalEntry[]) => Promise<any> }): Promise<never> {
-    if (!this.entryId) {
+    if (this.entryId == null) {
       throw new Error('suspend() can only be used while the job is active in a Worker');
     }
     this.suspendRequest = {
@@ -632,7 +632,7 @@ export class Job<D = any, R = any> {
         this.opts.backoff.jitter,
       );
     }
-    if (!this.entryId) {
+    if (this.entryId == null) {
       throw new GlideMQError('moveToFailed can only be called while job is active in a Worker');
     }
     const entryId = this.entryId;
@@ -724,7 +724,7 @@ export class Job<D = any, R = any> {
     if (!Number.isFinite(timestamp) || timestamp < 0) {
       throw new Error('Timestamp must be a finite Unix millisecond value >= 0');
     }
-    if (!this.entryId) {
+    if (this.entryId == null) {
       throw new Error('moveToDelayed() can only be used while the job is active in a Worker');
     }
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -205,6 +205,15 @@ export class Job<D = any, R = any> {
    */
   movedToFailed = false;
 
+  /** @internal `failed` or `retrying` from the moveToFailed Lua call. */
+  movedToFailedResult?: string;
+
+  /** @internal Set while a worker is processing so failJob can pass group/broadcast. */
+  failContext?: { group: string; broadcastMode?: boolean };
+
+  /** @internal Worker already ran DLQ / failed-event / scheduler bookkeeping. */
+  movedToFailedFinalized = false;
+
   /** @internal Request captured by moveToDelayed() while inside the worker. */
   moveToDelayedRequest?: { delayedUntil: number; serializedData?: string; nextData?: D };
 
@@ -652,9 +661,13 @@ export class Job<D = any, R = any> {
       Date.now(),
       maxAttempts,
       backoffDelay,
+      this.failContext?.group,
+      this.opts.removeOnFail,
+      this.failContext?.broadcastMode,
     );
     this.failedReason = err.message;
     this.movedToFailed = true;
+    this.movedToFailedResult = result;
     if (result === 'retrying') {
       this.attemptsMade += 1;
     }

--- a/src/job.ts
+++ b/src/job.ts
@@ -5,7 +5,14 @@ import type { JobOptions, JobUsage, Client, Serializer, SuspendOptions, SignalEn
 import { JSON_SERIALIZER } from './types';
 import type { QueueKeys } from './functions/index';
 import { changeDelay, changePriority, failJob, promoteJob, removeJob, tryLock, unlock } from './functions/index';
-import { GlideMQError, DelayedError, WaitingChildrenError, GroupRateLimitError, SuspendError } from './errors';
+import {
+  GlideMQError,
+  DelayedError,
+  WaitingChildrenError,
+  GroupRateLimitError,
+  SuspendError,
+  UnrecoverableError,
+} from './errors';
 import type { GroupRateLimitOptions } from './errors';
 import {
   calculateBackoff,
@@ -638,7 +645,7 @@ export class Job<D = any, R = any> {
    * Requires entryId to be set (set by Worker when processing).
    */
   async moveToFailed(err: Error): Promise<void> {
-    const maxAttempts = this.opts.attempts ?? 0;
+    const maxAttempts = this.discarded || err instanceof UnrecoverableError ? 0 : (this.opts.attempts ?? 0);
     let backoffDelay = 0;
     if (this.opts.backoff) {
       backoffDelay = calculateBackoff(

--- a/src/sandbox/pool.ts
+++ b/src/sandbox/pool.ts
@@ -269,7 +269,7 @@ export class SandboxPool {
           if (!Number.isFinite(timestamp) || timestamp < 0) {
             throw new Error('Timestamp must be a finite Unix millisecond value >= 0');
           }
-          if (!job.entryId) {
+          if (job.entryId == null) {
             throw new Error('moveToDelayed() can only be used while the job is active in a Worker');
           }
           const nextStep = msg.args[1];

--- a/tests/fixtures/processors/move-to-delayed-future.js
+++ b/tests/fixtures/processors/move-to-delayed-future.js
@@ -1,0 +1,3 @@
+module.exports = async function moveToDelayedFuture(job) {
+  await job.moveToDelayed(Date.now() + 60_000);
+};

--- a/tests/list-entryid-guard.test.ts
+++ b/tests/list-entryid-guard.test.ts
@@ -227,6 +227,40 @@ describeEachMode('list-job worker methods', (CONNECTION) => {
     }
   }, 15000);
 
+  it('keeps a resumed priority job failed when onResume calls moveToFailed', async () => {
+    const Q = uniqueQueue('list-entryid-resume-fail');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('task', { n: 1 }, { priority: 1 });
+    let captured: any;
+
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        if (active.signals.length === 0) {
+          captured = active;
+          await active.suspend({
+            onResume: async () => {
+              await captured.moveToFailed(new Error('resume-failed'));
+            },
+          });
+        }
+        return 'completed';
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 60_000 },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await waitFor(async () => (await queue.getSuspendInfo(job.id)) !== null, 4000, 50);
+      await queue.signal(job.id, 'resume');
+      await waitFor(async () => ['failed', 'completed'].includes(await job.getState()), 4000, 50);
+      expect(await job.getState()).toBe('failed');
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
   it('does not complete a batch job that already called moveToFailed', async () => {
     const Q = uniqueQueue('list-entryid-fail-batch');
     const queue = new Queue(Q, { connection: CONNECTION });

--- a/tests/list-entryid-guard.test.ts
+++ b/tests/list-entryid-guard.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Priority/LIFO jobs are dispatched with entryId ''. Job.moveToDelayed,
+ * suspend, and moveToWaitingChildren currently treat that as "not in a worker".
+ *
+ * Run: npx vitest run tests/list-entryid-guard.test.ts
+ */
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './helpers/fixture';
+
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+
+describeEachMode('list-job worker methods', (CONNECTION) => {
+  let cleanupClient: any;
+  const queues: string[] = [];
+
+  function uniqueQueue(prefix: string): string {
+    const name = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    queues.push(name);
+    return name;
+  }
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    await Promise.all(queues.map((q) => flushQueue(cleanupClient, q).catch(() => {})));
+    cleanupClient.close();
+  });
+
+  it('lets a priority job call moveToDelayed from the processor', async () => {
+    const Q = uniqueQueue('list-entryid-delay');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('task', { n: 1 }, { priority: 1 });
+
+    const errors: Error[] = [];
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        await active.moveToDelayed(Date.now() + 60_000);
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 60_000 },
+    );
+    worker.on('error', () => {});
+    worker.on('failed', (_job: unknown, err: Error) => errors.push(err));
+
+    try {
+      await waitFor(async () => {
+        const state = await job.getState();
+        return state === 'delayed' || state === 'failed';
+      }, 4000, 50);
+      expect(await job.getState()).toBe('delayed');
+      expect(errors).toEqual([]);
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
+  it('lets a priority job call suspend from the processor', async () => {
+    const Q = uniqueQueue('list-entryid-suspend');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('task', { n: 1 }, { priority: 1 });
+
+    const errors: Error[] = [];
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        await active.suspend({ reason: 'wait' });
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 60_000 },
+    );
+    worker.on('error', () => {});
+    worker.on('failed', (_job: unknown, err: Error) => errors.push(err));
+
+    try {
+      await waitFor(async () => {
+        const state = await job.getState();
+        return state === 'suspended' || state === 'failed';
+      }, 4000, 50);
+      expect(await job.getState()).toBe('suspended');
+      expect(errors).toEqual([]);
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+});

--- a/tests/list-entryid-guard.test.ts
+++ b/tests/list-entryid-guard.test.ts
@@ -336,6 +336,44 @@ describeEachMode('list-job worker methods', (CONNECTION) => {
     }
   }, 15000);
 
+  it('preserves discard requested from onResume', async () => {
+    const Q = uniqueQueue('list-entryid-resume-discard');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('task', { n: 1 }, { priority: 1, attempts: 3, backoff: 10 });
+    let captured: any;
+    let processorCalls = 0;
+
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        processorCalls++;
+        if (active.signals.length === 0) {
+          captured = active;
+          await active.suspend({
+            onResume: async () => {
+              captured.discard();
+              throw new Error('discarded-resume');
+            },
+          });
+        }
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 100, lockDuration: 100 },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await waitFor(async () => (await queue.getSuspendInfo(job.id)) !== null, 4000, 50);
+      await queue.signal(job.id, 'resume');
+      await waitFor(async () => (await job.getState()) === 'failed', 4000, 50);
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(await job.getState()).toBe('failed');
+      expect(processorCalls).toBe(1);
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
   it('does not complete a batch job that already called moveToFailed', async () => {
     const Q = uniqueQueue('list-entryid-fail-batch');
     const queue = new Queue(Q, { connection: CONNECTION });

--- a/tests/list-entryid-guard.test.ts
+++ b/tests/list-entryid-guard.test.ts
@@ -10,6 +10,7 @@ import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './he
 
 const { Queue } = require('../dist/queue') as typeof import('../src/queue');
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+const { BatchError } = require('../dist/errors') as typeof import('../src/errors');
 
 const DELAY_PROCESSOR = path.resolve(__dirname, 'fixtures/processors/move-to-delayed-future.js');
 
@@ -122,6 +123,144 @@ describeEachMode('list-job worker methods', (CONNECTION) => {
         50,
       );
       expect(await job.getState()).toBe('failed');
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
+  it('emits failed and does not complete after moveToFailed plus a later throw', async () => {
+    const Q = uniqueQueue('list-entryid-fail-throw');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('task', { n: 1 }, { priority: 1 });
+    const failed: Error[] = [];
+
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        await active.moveToFailed(new Error('nope'));
+        throw new Error('cleanup');
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 60_000 },
+    );
+    worker.on('error', () => {});
+    worker.on('failed', (_job: unknown, err: Error) => failed.push(err));
+    worker.on('completed', () => {
+      throw new Error('should not complete');
+    });
+
+    try {
+      await waitFor(async () => (await job.getState()) === 'failed', 4000, 50);
+      expect(await job.getState()).toBe('failed');
+      expect(failed.map((e) => e.message)).toEqual(['nope']);
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
+  it('routes a terminal moveToFailed job to the dead-letter queue', async () => {
+    const Q = uniqueQueue('list-entryid-fail-dlq');
+    const DLQ = `${Q}-dead`;
+    const queue = new Queue(Q, { connection: CONNECTION, deadLetterQueue: { name: DLQ } });
+    const job = await queue.add('task', { n: 1 }, { priority: 1 });
+
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        await active.moveToFailed(new Error('nope'));
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 50,
+        stalledInterval: 60_000,
+        deadLetterQueue: { name: DLQ },
+      },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await waitFor(async () => (await queue.getDeadLetterJobs()).length > 0, 4000, 50);
+      const dlqJobs = await queue.getDeadLetterJobs();
+      expect(dlqJobs[0]?.data?.originalJobId).toBe(job.id);
+      expect(dlqJobs[0]?.data?.failedReason).toBe('nope');
+    } finally {
+      await worker.close(true);
+      await queue.close();
+      await flushQueue(cleanupClient, DLQ);
+    }
+  }, 15000);
+
+  it('advances repeatAfterComplete after an explicit moveToFailed', async () => {
+    const Q = uniqueQueue('list-entryid-fail-rac');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    await queue.upsertJobScheduler('rac-mtf', { repeatAfterComplete: 200 }, { name: 'task', data: { n: 1 } });
+
+    let jobCount = 0;
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        jobCount++;
+        if (jobCount === 1) {
+          await active.moveToFailed(new Error('nope'));
+          return;
+        }
+        return 'ok';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 50,
+        stalledInterval: 60_000,
+        promotionInterval: 100,
+      },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await waitFor(() => jobCount >= 2, 6000, 50);
+      expect(jobCount).toBeGreaterThanOrEqual(2);
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
+  it('does not complete a batch job that already called moveToFailed', async () => {
+    const Q = uniqueQueue('list-entryid-fail-batch');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const [a, b] = await queue.addBulk([
+      { name: 'task', data: { n: 1 }, opts: { priority: 1 } },
+      { name: 'task', data: { n: 2 }, opts: { priority: 1 } },
+    ]);
+    const failedIds: string[] = [];
+    const completedIds: string[] = [];
+
+    const worker = new Worker(
+      Q,
+      async (jobs: Array<{ id: string; moveToFailed: (err: Error) => Promise<void> }>) => {
+        await jobs[0].moveToFailed(new Error('nope'));
+        throw new BatchError([new Error('other'), 'should-not-complete-first']);
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 50,
+        stalledInterval: 60_000,
+        batch: { size: 2 },
+      },
+    );
+    worker.on('error', () => {});
+    worker.on('failed', (job: { id: string }) => failedIds.push(job.id));
+    worker.on('completed', (job: { id: string }) => completedIds.push(job.id));
+
+    try {
+      await waitFor(async () => (await a.getState()) === 'failed', 4000, 50);
+      expect(await a.getState()).toBe('failed');
+      expect(failedIds).toContain(a.id);
+      expect(completedIds).not.toContain(a.id);
+      expect(completedIds.concat(failedIds)).toContain(b.id);
     } finally {
       await worker.close(true);
       await queue.close();

--- a/tests/list-entryid-guard.test.ts
+++ b/tests/list-entryid-guard.test.ts
@@ -10,7 +10,7 @@ import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './he
 
 const { Queue } = require('../dist/queue') as typeof import('../src/queue');
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
-const { BatchError } = require('../dist/errors') as typeof import('../src/errors');
+const { BatchError, UnrecoverableError } = require('../dist/errors') as typeof import('../src/errors');
 
 const DELAY_PROCESSOR = path.resolve(__dirname, 'fixtures/processors/move-to-delayed-future.js');
 
@@ -153,6 +153,45 @@ describeEachMode('list-job worker methods', (CONNECTION) => {
       await waitFor(async () => (await job.getState()) === 'failed', 4000, 50);
       expect(await job.getState()).toBe('failed');
       expect(failed.map((e) => e.message)).toEqual(['nope']);
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
+  it('does not retry explicit discarded or unrecoverable failures', async () => {
+    const Q = uniqueQueue('list-entryid-no-retry');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const [discarded, unrecoverable] = await queue.addBulk([
+      { name: 'task', data: { mode: 'discard' }, opts: { priority: 1, attempts: 3, backoff: 10 } },
+      { name: 'task', data: { mode: 'unrecoverable' }, opts: { priority: 1, attempts: 3, backoff: 10 } },
+    ]);
+    const calls = new Map<string, number>();
+
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        calls.set(active.id, (calls.get(active.id) ?? 0) + 1);
+        if (active.data.mode === 'discard') {
+          active.discard();
+          await active.moveToFailed(new Error('discarded'));
+        } else {
+          await active.moveToFailed(new UnrecoverableError('unrecoverable'));
+        }
+      },
+      { connection: CONNECTION, concurrency: 2, blockTimeout: 50, stalledInterval: 100, lockDuration: 100 },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await waitFor(
+        async () => (await discarded.getState()) === 'failed' && (await unrecoverable.getState()) === 'failed',
+        4000,
+        50,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(calls.get(discarded.id)).toBe(1);
+      expect(calls.get(unrecoverable.id)).toBe(1);
     } finally {
       await worker.close(true);
       await queue.close();

--- a/tests/list-entryid-guard.test.ts
+++ b/tests/list-entryid-guard.test.ts
@@ -262,6 +262,80 @@ describeEachMode('list-job worker methods', (CONNECTION) => {
     }
   }, 15000);
 
+  it('preserves delayed data requested from onResume', async () => {
+    const Q = uniqueQueue('list-entryid-resume-delay');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('task', { step: 'start' }, { priority: 1 });
+    let captured: any;
+
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        if (active.signals.length === 0) {
+          captured = active;
+          await active.suspend({
+            onResume: async () => captured.moveToDelayed(Date.now() + 60_000, 'next'),
+          });
+        }
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 60_000 },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await waitFor(async () => (await queue.getSuspendInfo(job.id)) !== null, 4000, 50);
+      await queue.signal(job.id, 'resume');
+      await waitFor(async () => (await job.getState()) === 'delayed', 4000, 50);
+      const refreshed = await queue.getJob(job.id);
+      expect(refreshed?.data.step).toBe('next');
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
+  it('preserves a second suspend callback requested from onResume', async () => {
+    const Q = uniqueQueue('list-entryid-resume-suspend');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('task', { n: 1 }, { priority: 1 });
+    let captured: any;
+    let secondResumeCalled = false;
+
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        if (active.signals.length === 0) {
+          captured = active;
+          await active.suspend({
+            onResume: async () =>
+              captured.suspend({
+                reason: 'second',
+                onResume: async () => {
+                  secondResumeCalled = true;
+                  return 'done';
+                },
+              }),
+          });
+        }
+        return 'processor';
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 60_000 },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await waitFor(async () => (await queue.getSuspendInfo(job.id)) !== null, 4000, 50);
+      await queue.signal(job.id, 'first');
+      await waitFor(async () => (await queue.getSuspendInfo(job.id))?.reason === 'second', 4000, 50);
+      await queue.signal(job.id, 'second');
+      await waitFor(async () => (await job.getState()) === 'completed', 4000, 50);
+      expect(secondResumeCalled).toBe(true);
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
   it('does not complete a batch job that already called moveToFailed', async () => {
     const Q = uniqueQueue('list-entryid-fail-batch');
     const queue = new Queue(Q, { connection: CONNECTION });

--- a/tests/list-entryid-guard.test.ts
+++ b/tests/list-entryid-guard.test.ts
@@ -4,11 +4,14 @@
  *
  * Run: npx vitest run tests/list-entryid-guard.test.ts
  */
+import path from 'path';
 import { afterAll, beforeAll, expect, it } from 'vitest';
 import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './helpers/fixture';
 
 const { Queue } = require('../dist/queue') as typeof import('../src/queue');
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+
+const DELAY_PROCESSOR = path.resolve(__dirname, 'fixtures/processors/move-to-delayed-future.js');
 
 describeEachMode('list-job worker methods', (CONNECTION) => {
   let cleanupClient: any;
@@ -94,4 +97,66 @@ describeEachMode('list-job worker methods', (CONNECTION) => {
       await queue.close();
     }
   }, 15000);
+
+  it('keeps a priority job failed after moveToFailed returns normally', async () => {
+    const Q = uniqueQueue('list-entryid-fail');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('task', { n: 1 }, { priority: 1 });
+
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        await active.moveToFailed(new Error('nope'));
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 60_000 },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await waitFor(
+        async () => {
+          const state = await job.getState();
+          return state === 'failed' || state === 'completed';
+        },
+        4000,
+        50,
+      );
+      expect(await job.getState()).toBe('failed');
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
+  it('lets a sandboxed priority job call moveToDelayed', async () => {
+    const Q = uniqueQueue('list-entryid-sandbox-delay');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('task', { n: 1 }, { priority: 1 });
+
+    const errors: Error[] = [];
+    const worker = new Worker(Q, DELAY_PROCESSOR, {
+      connection: CONNECTION,
+      concurrency: 1,
+      blockTimeout: 50,
+      stalledInterval: 60_000,
+    });
+    worker.on('error', () => {});
+    worker.on('failed', (_job: unknown, err: Error) => errors.push(err));
+
+    try {
+      await waitFor(
+        async () => {
+          const state = await job.getState();
+          return state === 'delayed' || state === 'failed';
+        },
+        8000,
+        50,
+      );
+      expect(await job.getState()).toBe('delayed');
+      expect(errors).toEqual([]);
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 20000);
 });

--- a/tests/list-entryid-guard.test.ts
+++ b/tests/list-entryid-guard.test.ts
@@ -46,10 +46,14 @@ describeEachMode('list-job worker methods', (CONNECTION) => {
     worker.on('failed', (_job: unknown, err: Error) => errors.push(err));
 
     try {
-      await waitFor(async () => {
-        const state = await job.getState();
-        return state === 'delayed' || state === 'failed';
-      }, 4000, 50);
+      await waitFor(
+        async () => {
+          const state = await job.getState();
+          return state === 'delayed' || state === 'failed';
+        },
+        4000,
+        50,
+      );
       expect(await job.getState()).toBe('delayed');
       expect(errors).toEqual([]);
     } finally {
@@ -75,10 +79,14 @@ describeEachMode('list-job worker methods', (CONNECTION) => {
     worker.on('failed', (_job: unknown, err: Error) => errors.push(err));
 
     try {
-      await waitFor(async () => {
-        const state = await job.getState();
-        return state === 'suspended' || state === 'failed';
-      }, 4000, 50);
+      await waitFor(
+        async () => {
+          const state = await job.getState();
+          return state === 'suspended' || state === 'failed';
+        },
+        4000,
+        50,
+      );
       expect(await job.getState()).toBe('suspended');
       expect(errors).toEqual([]);
     } finally {

--- a/tests/list-entryid-guard.test.ts
+++ b/tests/list-entryid-guard.test.ts
@@ -246,7 +246,7 @@ describeEachMode('list-job worker methods', (CONNECTION) => {
         }
         return 'completed';
       },
-      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 60_000 },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 100, lockDuration: 100 },
     );
     worker.on('error', () => {});
 
@@ -254,6 +254,7 @@ describeEachMode('list-job worker methods', (CONNECTION) => {
       await waitFor(async () => (await queue.getSuspendInfo(job.id)) !== null, 4000, 50);
       await queue.signal(job.id, 'resume');
       await waitFor(async () => ['failed', 'completed'].includes(await job.getState()), 4000, 50);
+      await new Promise((resolve) => setTimeout(resolve, 500));
       expect(await job.getState()).toBe('failed');
     } finally {
       await worker.close(true);

--- a/tests/list-entryid-guard.test.ts
+++ b/tests/list-entryid-guard.test.ts
@@ -374,6 +374,46 @@ describeEachMode('list-job worker methods', (CONNECTION) => {
     }
   }, 15000);
 
+  it('preserves explicit failure from a second chained onResume', async () => {
+    const Q = uniqueQueue('list-entryid-resume-chain-fail');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('task', { n: 1 }, { priority: 1 });
+    let captured: any;
+
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        if (active.signals.length === 0) {
+          captured = active;
+          await active.suspend({
+            onResume: async () =>
+              captured.suspend({
+                reason: 'second',
+                onResume: async () => {
+                  await captured.moveToFailed(new Error('second-resume-failed'));
+                },
+              }),
+          });
+        }
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 100, lockDuration: 100 },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await waitFor(async () => (await queue.getSuspendInfo(job.id)) !== null, 4000, 50);
+      await queue.signal(job.id, 'first');
+      await waitFor(async () => (await queue.getSuspendInfo(job.id))?.reason === 'second', 4000, 50);
+      await queue.signal(job.id, 'second');
+      await waitFor(async () => ['failed', 'completed'].includes(await job.getState()), 4000, 50);
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(await job.getState()).toBe('failed');
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
   it('does not complete a batch job that already called moveToFailed', async () => {
     const Q = uniqueQueue('list-entryid-fail-batch');
     const queue = new Queue(Q, { connection: CONNECTION });

--- a/tests/sandbox.test.ts
+++ b/tests/sandbox.test.ts
@@ -315,6 +315,32 @@ describe('SandboxPool', () => {
     await pool.close();
   });
 
+  it('should proxy moveToDelayed for list jobs with empty entryId', async () => {
+    const pool = new SandboxPool(MOVE_TO_DELAYED_PROCESSOR, true, 1, RUNNER_PATH);
+
+    const fakeJob: any = {
+      id: 'job-delay-list',
+      name: 'test',
+      data: { step: 'send' },
+      opts: {},
+      attemptsMade: 0,
+      timestamp: Date.now(),
+      progress: 0,
+      entryId: '',
+      log: vi.fn(),
+      updateProgress: vi.fn(),
+      requestMoveToDelayed: vi.fn(),
+    };
+    fakeJob.updateData = vi.fn().mockImplementation(async (data: any) => {
+      fakeJob.data = data;
+    });
+
+    await expect(pool.run(fakeJob as Job)).rejects.toBeInstanceOf(DelayedError);
+    expect(fakeJob.requestMoveToDelayed).toHaveBeenCalledWith(123456, { step: 'next' });
+
+    await pool.close();
+  });
+
   it('should preserve DelayedError metadata from sandboxed processors', async () => {
     const pool = new SandboxPool(THROW_DELAYED_ERROR_PROCESSOR, true, 1, RUNNER_PATH);
 


### PR DESCRIPTION
Companion review PR for priority/LIFO jobs rejected by worker-only Job methods.

## Summary
- list-backed jobs are dispatched with `entryId: ''`
- `moveToDelayed` / `suspend` / `moveToWaitingChildren` / `moveToFailed` treated that as missing
- Lua already treats empty entryId as list-sourced; the TypeScript guard now only rejects null/undefined
- `moveToFailed` returning normally no longer lets completeAndFetchNext overwrite failed as completed
- sandbox `moveToDelayed` accepts the empty list sentinel

## Red-first proof
The first commit is test-only. Against its parent, a priority job calling `moveToDelayed` or `suspend` failed instead of changing state.

## Test plan
- [x] `npx vitest run tests/list-entryid-guard.test.ts`
- [x] `npx vitest run tests/job.test.ts`
- [x] `npx vitest run tests/sandbox.test.ts`


Made with [Cursor](https://cursor.com)