### PR TITLE
fix: stop token bucket over-refill after sitting at capacity

### DIFF
--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -109,6 +109,11 @@ end
 -- Refill token bucket using remainder accumulator for precision.
 -- tbRefillRate is in millitokens/second. Returns current millitokens after refill.
 -- Side effect: updates tbTokens, tbLastRefill, tbRefillRemainder on the group hash.
+local function redisNowMs()
+  local t = redis.call('TIME')
+  return tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
+end
+
 local function tbRefill(groupHashKey, g, now)
   local tbCapacity = tonumber(g.tbCapacity) or 0
   if tbCapacity <= 0 then return 0 end
@@ -116,10 +121,14 @@ local function tbRefill(groupHashKey, g, now)
   if tbTokens >= tbCapacity then
     -- Sitting at capacity must not accumulate idle time as later refill credit.
     -- Keep lastRefill monotonic so a slow-clock replica cannot rewind it.
+    -- Cap the stamp to server time so an ahead worker cannot stall refill.
     local tbLastRefill = tonumber(g.tbLastRefill) or 0
-    if now > tbLastRefill then
-      redis.call('HSET', groupHashKey, 'tbLastRefill', tostring(now))
-      g.tbLastRefill = tostring(now)
+    local stamp = now
+    local serverNow = redisNowMs()
+    if serverNow < stamp then stamp = serverNow end
+    if stamp > tbLastRefill then
+      redis.call('HSET', groupHashKey, 'tbLastRefill', tostring(stamp))
+      g.tbLastRefill = tostring(stamp)
     end
     return tbCapacity
   end

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -113,7 +113,12 @@ local function tbRefill(groupHashKey, g, now)
   local tbCapacity = tonumber(g.tbCapacity) or 0
   if tbCapacity <= 0 then return 0 end
   local tbTokens = tonumber(g.tbTokens) or tbCapacity
-  if tbTokens >= tbCapacity then return tbCapacity end
+  if tbTokens >= tbCapacity then
+    -- Sitting at capacity must not accumulate idle time as later refill credit.
+    redis.call('HSET', groupHashKey, 'tbLastRefill', tostring(now))
+    g.tbLastRefill = tostring(now)
+    return tbCapacity
+  end
   local tbRefillRate = tonumber(g.tbRefillRate) or 0
   local tbLastRefill = tonumber(g.tbLastRefill) or now
   local tbRefillRemainder = tonumber(g.tbRefillRemainder) or 0

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -118,24 +118,26 @@ local function tbRefill(groupHashKey, g, now)
   local tbCapacity = tonumber(g.tbCapacity) or 0
   if tbCapacity <= 0 then return 0 end
   local tbTokens = tonumber(g.tbTokens) or tbCapacity
+  local refillNow = redisNowMs()
   if tbTokens >= tbCapacity then
     -- Sitting at capacity must not accumulate idle time as later refill credit.
-    -- Keep lastRefill monotonic so a slow-clock replica cannot rewind it.
-    -- Cap the stamp to server time so an ahead worker cannot stall refill.
+    -- Keep the refill timeline entirely in Redis server-clock domain.
     local tbLastRefill = tonumber(g.tbLastRefill) or 0
-    local stamp = now
-    local serverNow = redisNowMs()
-    if serverNow < stamp then stamp = serverNow end
-    if stamp > tbLastRefill then
-      redis.call('HSET', groupHashKey, 'tbLastRefill', tostring(stamp))
-      g.tbLastRefill = tostring(stamp)
+    if refillNow > tbLastRefill then
+      redis.call('HSET', groupHashKey, 'tbLastRefill', tostring(refillNow))
+      g.tbLastRefill = tostring(refillNow)
     end
     return tbCapacity
   end
   local tbRefillRate = tonumber(g.tbRefillRate) or 0
-  local tbLastRefill = tonumber(g.tbLastRefill) or now
+  local tbLastRefill = tonumber(g.tbLastRefill) or refillNow
+  if tbLastRefill > refillNow then
+    -- Normalize timestamps written by older caller-clock implementations.
+    tbLastRefill = refillNow
+    redis.call('HSET', groupHashKey, 'tbLastRefill', tostring(refillNow))
+  end
   local tbRefillRemainder = tonumber(g.tbRefillRemainder) or 0
-  local elapsed = now - tbLastRefill
+  local elapsed = refillNow - tbLastRefill
   if elapsed <= 0 or tbRefillRate <= 0 then return tbTokens end
   -- Cap elapsed to prevent overflow in long-idle buckets
   local maxElapsed = math.ceil(tbCapacity * 1000 / tbRefillRate)
@@ -146,7 +148,7 @@ local function tbRefill(groupHashKey, g, now)
   local newTokens = math.min(tbCapacity, tbTokens + added)
   redis.call('HSET', groupHashKey,
     'tbTokens', tostring(newTokens),
-    'tbLastRefill', tostring(now),
+    'tbLastRefill', tostring(refillNow),
     'tbRefillRemainder', tostring(newRemainder))
   return newTokens
 end

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -115,8 +115,12 @@ local function tbRefill(groupHashKey, g, now)
   local tbTokens = tonumber(g.tbTokens) or tbCapacity
   if tbTokens >= tbCapacity then
     -- Sitting at capacity must not accumulate idle time as later refill credit.
-    redis.call('HSET', groupHashKey, 'tbLastRefill', tostring(now))
-    g.tbLastRefill = tostring(now)
+    -- Keep lastRefill monotonic so a slow-clock replica cannot rewind it.
+    local tbLastRefill = tonumber(g.tbLastRefill) or 0
+    if now > tbLastRefill then
+      redis.call('HSET', groupHashKey, 'tbLastRefill', tostring(now))
+      g.tbLastRefill = tostring(now)
+    end
     return tbCapacity
   end
   local tbRefillRate = tonumber(g.tbRefillRate) or 0

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -88,7 +88,7 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 110: dedupe overlapping tree and DAG parent notifications per completion.
 // Version 119: integrate the reviewed correctness queue and preserve Queue.pause in the reservation-aware list pop.
 // Version 120: removeJob acknowledges a claimed FIFO entry in every stream consumer group before deleting it.
-// Version 121: tbRefill stamps tbLastRefill when already at capacity so idle-full time is not later granted as extra tokens.
+// Version 121: tbRefill uses Redis server time and stamps capacity so idle-full time is not later granted as extra tokens.
 export const LIBRARY_VERSION = '121';
 
 // Consumer group name used by workers

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -88,7 +88,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 110: dedupe overlapping tree and DAG parent notifications per completion.
 // Version 119: integrate the reviewed correctness queue and preserve Queue.pause in the reservation-aware list pop.
 // Version 120: removeJob acknowledges a claimed FIFO entry in every stream consumer group before deleting it.
-export const LIBRARY_VERSION = '120';
+// Version 121: tbRefill stamps tbLastRefill when already at capacity so idle-full time is not later granted as extra tokens.
+export const LIBRARY_VERSION = '121';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/tests/tb-idle-refill.test.ts
+++ b/tests/tb-idle-refill.test.ts
@@ -12,6 +12,8 @@ import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './he
 
 const { Queue } = require('../dist/queue') as typeof import('../src/queue');
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+const { moveToActive } = require('../dist/functions/index') as typeof import('../src/functions/index');
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
 
 describeEachMode('token bucket idle-at-capacity refill', (CONNECTION) => {
   let cleanupClient: any;
@@ -61,5 +63,25 @@ describeEachMode('token bucket idle-at-capacity refill', (CONNECTION) => {
       await worker.close(true);
       await queue.close();
     }
+  }, 15000);
+
+  it('does not persist an ahead caller clock as tbLastRefill at capacity', async () => {
+    const Q = uniqueQueue('tb-idle-clock');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const tb = { key: 'clock-group', concurrency: 10, tokenBucket: { capacity: 1, refillRate: 1 } };
+    const job = await queue.add('a', { n: 1 }, { ordering: tb, cost: 1 });
+    const keys = buildKeys(Q);
+    const streamEntries = (await cleanupClient.xrange(keys.stream, '-', '+')) as Record<string, [string, string][]>;
+    const entryId = Object.keys(streamEntries)[0];
+    expect(entryId).toBeTruthy();
+    await cleanupClient.xgroupCreate(keys.stream, 'workers', '0', { mkStream: true }).catch(() => {});
+
+    const future = Date.now() + 3_600_000;
+    await moveToActive(cleanupClient, keys, job.id, future, keys.stream, entryId, 'workers');
+    const last = Number(await cleanupClient.hget(keys.group(tb.key), 'tbLastRefill'));
+    expect(last).toBeGreaterThan(0);
+    expect(last).toBeLessThan(Date.now() + 5_000);
+
+    await queue.close();
   }, 15000);
 });

--- a/tests/tb-idle-refill.test.ts
+++ b/tests/tb-idle-refill.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Token bucket must not treat idle-at-capacity time as refill credit.
+ *
+ * tbRefill returns early when full without updating tbLastRefill. The next
+ * consume then refills using the whole idle interval, so two cost=capacity
+ * jobs run back-to-back after a pause.
+ *
+ * Run: npx vitest run tests/tb-idle-refill.test.ts
+ */
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './helpers/fixture';
+
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+
+describeEachMode('token bucket idle-at-capacity refill', (CONNECTION) => {
+  let cleanupClient: any;
+  const queues: string[] = [];
+
+  function uniqueQueue(prefix: string): string {
+    const name = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    queues.push(name);
+    return name;
+  }
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    await Promise.all(queues.map((q) => flushQueue(cleanupClient, q).catch(() => {})));
+    cleanupClient.close();
+  });
+
+  it('does not let a second full-cost job through immediately after an idle-full bucket', async () => {
+    const Q = uniqueQueue('tb-idle');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const tb = { key: 'idle-group', concurrency: 10, tokenBucket: { capacity: 1, refillRate: 1 } };
+
+    // Creating the group fills the bucket and stamps tbLastRefill. Idle with
+    // jobs waiting so activation sees tokens >= capacity and skips the stamp.
+    await queue.add('a', { n: 1 }, { ordering: tb, cost: 1 });
+    await queue.add('b', { n: 2 }, { ordering: tb, cost: 1 });
+    await new Promise((r) => setTimeout(r, 2000));
+
+    const completed: number[] = [];
+    const worker = new Worker(
+      Q,
+      async () => {
+        completed.push(Date.now());
+      },
+      { connection: CONNECTION, concurrency: 4, blockTimeout: 50 },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await waitFor(() => completed.length === 2, 5000, 50);
+      completed.sort((a, b) => a - b);
+      expect(completed[1]! - completed[0]!).toBeGreaterThanOrEqual(700);
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+});


### PR DESCRIPTION
Companion review PR for idle-at-capacity token bucket over-refill.

## Summary
- `tbRefill` returned immediately when `tbTokens >= tbCapacity` without updating `tbLastRefill`
- consume then treated the idle interval as refill credit, so two full-cost jobs ran in the same millisecond
- stamp `tbLastRefill` when already at capacity (`LIBRARY_VERSION` 121)
- only advance `tbLastRefill` when `now > tbLastRefill` so clock skew cannot rewind it

## Red-first proof
The first commit is test-only. Against its parent, two cost=capacity jobs enqueued onto an idle-full bucket both completed immediately.

## Test plan
- [x] `npx vitest run tests/tb-idle-refill.test.ts`
- [x] `npx vitest run tests/token-bucket.test.ts`


Made with [Cursor](https://cursor.com)