### PR TITLE
fix: do not claim the next job while closing

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- **In flight**: `fix/close-fetch-next` (fork #18 / upstream #282) — rebased onto v0.15.5. close() must not strand CAF or poll claims; grouped CAF undo skips `retainedSlot` active rewind. Lua library 124. Sonar new-code duplication and performClose complexity are being cleaned on this branch.
+- **In flight**: `fix/close-fetch-next` (fork #18 / upstream #282) — rebased onto v0.15.5. close() must not strand CAF or poll claims; grouped CAF undo skips `retainedSlot` active rewind. Lua library 124. Close-fetch tests share helpers so Sonar new-code duplication stays under the 3% gate.
 - **Audit fix**: `fix/repeat-after-stalled` atomically advances repeat-after-complete schedulers during terminal stalled recovery.
 - **Branch**: `automation/cover-open-fixes-20260825` consolidates the reviewed correctness queue.
 - **Revoke/timeout safety**: revoked active jobs cannot complete; each batch job owns its abort signal, and timeouts remain retryable.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- **In flight**: `fix/close-fetch-next` (fork #18 / upstream #282) — rebased onto v0.15.5. close() must not strand CAF or poll claims; grouped CAF undo skips `retainedSlot` active rewind. Lua library 124.
+- **In flight**: `fix/close-fetch-next` (fork #18 / upstream #282) — rebased onto v0.15.5. close() must not strand CAF or poll claims; grouped CAF undo skips `retainedSlot` active rewind. Lua library 124. Sonar new-code duplication and performClose complexity are being cleaned on this branch.
 - **Audit fix**: `fix/repeat-after-stalled` atomically advances repeat-after-complete schedulers during terminal stalled recovery.
 - **Branch**: `automation/cover-open-fixes-20260825` consolidates the reviewed correctness queue.
 - **Revoke/timeout safety**: revoked active jobs cannot complete; each batch job owns its abort signal, and timeouts remain retryable.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- **In flight**: `fix/close-fetch-next` (fork #18 / upstream #282) — rebased onto v0.15.5. close() must not strand CAF or poll claims; grouped CAF undo skips `retainedSlot` active rewind. Lua library 124. Close-fetch tests share helpers so Sonar new-code duplication stays under the 3% gate.
+- **In flight**: `fix/close-fetch-next` (fork #18 / upstream #282) — rebased onto v0.15.5. close() must not strand CAF or poll claims; grouped CAF undo skips `retainedSlot` active rewind. Lua library 124. Close-fetch tests share helpers so Sonar new-code duplication stays under the 3% gate. tb-idle-refill now uses a 250ms promotion interval and 12s waitFor so the default 5s promotion ceiling cannot starve the second job.
 - **Audit fix**: `fix/repeat-after-stalled` atomically advances repeat-after-complete schedulers during terminal stalled recovery.
 - **Branch**: `automation/cover-open-fixes-20260825` consolidates the reviewed correctness queue.
 - **Revoke/timeout safety**: revoked active jobs cannot complete; each batch job owns its abort signal, and timeouts remain retryable.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- **In flight**: rate-limited token-bucket promotion skips bounded tombstones and advances both ordered frontiers without stranding successors.
+- **In flight**: `fix/close-fetch-next` (fork #18 / upstream #282) — close() must not strand CAF or poll claims; grouped CAF undo is covered by a `'completed'`-handler race test. Lua library 121 on this branch (clash with #281/#285).
 - **Audit fix**: `fix/repeat-after-stalled` atomically advances repeat-after-complete schedulers during terminal stalled recovery.
 - **Branch**: `automation/cover-open-fixes-20260825` consolidates the reviewed correctness queue.
 - **Revoke/timeout safety**: revoked active jobs cannot complete; each batch job owns its abort signal, and timeouts remain retryable.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- **In flight**: `fix/close-fetch-next` (fork #18 / upstream #282) — close() must not strand CAF or poll claims; grouped CAF undo is covered by a `'completed'`-handler race test. Lua library 121 on this branch (clash with #281/#285).
+- **In flight**: `fix/close-fetch-next` (fork #18 / upstream #282) — close() must not strand CAF or poll claims; grouped CAF undo skips `retainedSlot` active rewind. Lua library 122 on this branch (clash with #281/#285 at 121).
 - **Audit fix**: `fix/repeat-after-stalled` atomically advances repeat-after-complete schedulers during terminal stalled recovery.
 - **Branch**: `automation/cover-open-fixes-20260825` consolidates the reviewed correctness queue.
 - **Revoke/timeout safety**: revoked active jobs cannot complete; each batch job owns its abort signal, and timeouts remain retryable.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- **In flight**: `fix/close-fetch-next` (fork #18 / upstream #282) — close() must not strand CAF or poll claims; grouped CAF undo skips `retainedSlot` active rewind. Lua library 122 on this branch (clash with #281/#285 at 121).
+- **In flight**: `fix/close-fetch-next` (fork #18 / upstream #282) — rebased onto v0.15.5. close() must not strand CAF or poll claims; grouped CAF undo skips `retainedSlot` active rewind. Lua library 124.
 - **Audit fix**: `fix/repeat-after-stalled` atomically advances repeat-after-complete schedulers during terminal stalled recovery.
 - **Branch**: `automation/cover-open-fixes-20260825` consolidates the reviewed correctness queue.
 - **Revoke/timeout safety**: revoked active jobs cannot complete; each batch job owns its abort signal, and timeouts remain retryable.

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -46,6 +46,7 @@ import {
   completeJob,
   isCompleteJobRevoked,
   completeAndFetchNext,
+  type CompleteAndFetchResult,
   completeChild,
   failJob,
   addJob,
@@ -104,6 +105,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
   protected paused = false;
   protected closing = false;
   protected closed = false;
+  private closePromise: Promise<void> | null = null;
   protected queueKeys: ReturnType<typeof buildKeys>;
   protected consumerId: string;
   protected activeCount = 0;
@@ -1544,28 +1546,47 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         }
       }
       const now = Date.now();
-      const fetchResult = await completeAndFetchNext(
-        this.commandClient,
-        this.queueKeys,
-        currentJobId,
-        currentEntryId,
-        returnvalue,
-        now,
-        this.consumerGroup,
-        this.consumerId,
-        job.opts.removeOnComplete,
-        undefined,
-        completionHints,
-        this.broadcastMode ? true : undefined,
-        job.processedOn,
-        !!job.parentIds,
-        this.skipEvents,
-        this.skipMetrics,
-      );
+      // close() sets closing before waitForActiveJobs. Completing without
+      // fetch-next avoids claiming a job that this worker will not process.
+      let fetchResult: CompleteAndFetchResult;
+      if (this.closing) {
+        const notifications = await completeJob(
+          this.commandClient,
+          this.queueKeys,
+          currentJobId,
+          currentEntryId,
+          returnvalue,
+          now,
+          this.consumerGroup,
+          job.opts.removeOnComplete,
+          undefined,
+          this.broadcastMode ? true : undefined,
+        );
+        fetchResult = { completed: currentJobId, next: false as const, parentNotifications: notifications };
+      } else {
+        fetchResult = await completeAndFetchNext(
+          this.commandClient,
+          this.queueKeys,
+          currentJobId,
+          currentEntryId,
+          returnvalue,
+          now,
+          this.consumerGroup,
+          this.consumerId,
+          job.opts.removeOnComplete,
+          undefined,
+          completionHints,
+          this.broadcastMode ? true : undefined,
+          job.processedOn,
+          !!job.parentIds,
+          this.skipEvents,
+          this.skipMetrics,
+        );
 
-      if (fetchResult.next === 'CURRENT_REVOKED') {
-        await this.handleJobFailure(job, currentJobId, currentEntryId, new UnrecoverableError('revoked'));
-        return;
+        if (fetchResult.next === 'CURRENT_REVOKED') {
+          await this.handleJobFailure(job, currentJobId, currentEntryId, new UnrecoverableError('revoked'));
+          return;
+        }
       }
       await this.notifyCrossQueueParents(fetchResult.parentNotifications);
       job.returnvalue = processResult;
@@ -1617,6 +1638,21 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
 
       if (job.schedulerName) {
         await this.updateSchedulerAfterComplete(job.schedulerName, now);
+      }
+
+      // CAF raced with close(): the next job is already claimed. Defer it
+      // so another worker can take it without waiting for stall reclaim.
+      if (
+        this.closing &&
+        typeof fetchResult.next === 'object' &&
+        fetchResult.nextJobId &&
+        fetchResult.nextEntryId != null
+      ) {
+        await this.deferPausedActivation({
+          jobId: fetchResult.nextJobId,
+          entryId: fetchResult.nextEntryId,
+        });
+        return;
       }
 
       // No next job - return to poll loop
@@ -2014,12 +2050,12 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
    */
   async close(force?: boolean): Promise<void> {
     if (this.closed) return;
-    if (this.closing) {
-      // Already closing - wait for init to settle, then return
-      await this.initPromise.catch(() => {});
-      return;
-    }
+    if (this.closePromise) return this.closePromise;
+    this.closePromise = this.performClose(force);
+    return this.closePromise;
+  }
 
+  private async performClose(force?: boolean): Promise<void> {
     this.closing = true;
     this.running = false;
     this.emit('closing');

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -1562,6 +1562,10 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           undefined,
           this.broadcastMode ? true : undefined,
         );
+        if (isCompleteJobRevoked(notifications)) {
+          await this.handleJobFailure(job, currentJobId, currentEntryId, new UnrecoverableError('revoked'));
+          return;
+        }
         fetchResult = { completed: currentJobId, next: false as const, parentNotifications: notifications };
       } else {
         fetchResult = await completeAndFetchNext(
@@ -2051,15 +2055,14 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
   async close(force?: boolean): Promise<void> {
     if (this.closed) return;
     if (this.closePromise) return this.closePromise;
-    this.closePromise = this.performClose(force);
+    this.closing = true;
+    this.running = false;
+    this.closePromise = Promise.resolve().then(() => this.performClose(force));
+    this.emit('closing');
     return this.closePromise;
   }
 
   private async performClose(force?: boolean): Promise<void> {
-    this.closing = true;
-    this.running = false;
-    this.emit('closing');
-
     // Wait for init to complete so clients are available for cleanup
     await this.initPromise.catch(() => {});
 

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -63,15 +63,7 @@ import {
 import { Scheduler } from './scheduler';
 
 export type WorkerEvent =
-  | 'completed'
-  | 'failed'
-  | 'error'
-  | 'stalled'
-  | 'closing'
-  | 'closed'
-  | 'active'
-  | 'drained'
-  | 'budget-exceeded';
+  'completed' | 'failed' | 'error' | 'stalled' | 'closing' | 'closed' | 'active' | 'drained' | 'budget-exceeded';
 
 /**
  * Configuration that differs between Worker and BroadcastWorker.
@@ -963,8 +955,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         entry.entryId,
         this.consumerGroup,
         this.broadcastMode ? true : undefined,
-        true,
-        entry.undoGroupClaim,
+        { pausedRestore: true, undoGroupClaim: entry.undoGroupClaim },
       );
       if (this.broadcastMode && entry.entryId !== '') {
         this.pausedBroadcastEntries.add(entry.entryId);
@@ -2084,23 +2075,37 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     return this.closePromise;
   }
 
+  private async stopSchedulerOnClose(force?: boolean): Promise<void> {
+    if (!this.scheduler) return;
+    this.scheduler.stop();
+    if (!force) {
+      await this.scheduler.waitForIdle();
+    }
+    this.scheduler = null;
+  }
+
+  private async deregisterWorker(): Promise<void> {
+    if (this.workerHeartbeatTimer) {
+      clearInterval(this.workerHeartbeatTimer);
+      this.workerHeartbeatTimer = null;
+    }
+    if (!this.commandClient) return;
+    try {
+      await this.commandClient.del([this.queueKeys.worker(this.consumerId)]);
+    } catch {
+      // Ignore - TTL will clean up
+    }
+  }
+
   private async performClose(force?: boolean): Promise<void> {
     // Wait for init to complete so clients are available for cleanup
     await this.initPromise.catch(() => {});
-
-    if (this.scheduler) {
-      this.scheduler.stop();
-      if (!force) {
-        await this.scheduler.waitForIdle();
-      }
-      this.scheduler = null;
-    }
+    await this.stopSchedulerOnClose(force);
 
     if (!force) {
       await this.waitForActiveJobs();
     }
 
-    // Shut down sandbox worker pool
     if (this.sandboxClose) {
       try {
         await this.sandboxClose(force);
@@ -2109,21 +2114,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
       }
     }
 
-    // Clear worker registration heartbeat
-    if (this.workerHeartbeatTimer) {
-      clearInterval(this.workerHeartbeatTimer);
-      this.workerHeartbeatTimer = null;
-    }
-    // Best-effort deregistration
-    if (this.commandClient) {
-      try {
-        await this.commandClient.del([this.queueKeys.worker(this.consumerId)]);
-      } catch {
-        // Ignore - TTL will clean up
-      }
-    }
+    await this.deregisterWorker();
 
-    // Clear all active heartbeats
     for (const [, timer] of this.heartbeatIntervals) {
       clearInterval(timer);
     }

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -63,7 +63,15 @@ import {
 import { Scheduler } from './scheduler';
 
 export type WorkerEvent =
-  'completed' | 'failed' | 'error' | 'stalled' | 'closing' | 'closed' | 'active' | 'drained' | 'budget-exceeded';
+  | 'completed'
+  | 'failed'
+  | 'error'
+  | 'stalled'
+  | 'closing'
+  | 'closed'
+  | 'active'
+  | 'drained'
+  | 'budget-exceeded';
 
 /**
  * Configuration that differs between Worker and BroadcastWorker.

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -750,6 +750,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           entry.job.opts.removeOnComplete,
           undefined,
           this.broadcastMode ? true : undefined,
+          this.skipEvents,
+          this.skipMetrics,
         );
         if (isCompleteJobRevoked(completeResult)) {
           await this.handleJobFailure(entry.job, entry.jobId, entry.entryId, new UnrecoverableError('revoked'));
@@ -816,6 +818,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
             entry.job.opts.removeOnComplete,
             undefined,
             this.broadcastMode ? true : undefined,
+            this.skipEvents,
+            this.skipMetrics,
           );
           if (isCompleteJobRevoked(completeResult)) {
             await this.handleJobFailure(entry.job, entry.jobId, entry.entryId, new UnrecoverableError('revoked'));
@@ -883,6 +887,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           undefined,
           undefined,
           this.broadcastMode ? true : undefined,
+          this.skipEvents,
+          this.skipMetrics,
         );
       } catch (err) {
         this.emit('error', err);
@@ -943,7 +949,11 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
     return false;
   }
 
-  private async deferPausedActivation(entry: { jobId: string; entryId: string }): Promise<void> {
+  private async deferPausedActivation(entry: {
+    jobId: string;
+    entryId: string;
+    undoGroupClaim?: boolean;
+  }): Promise<void> {
     if (!this.commandClient) return;
     try {
       await deferActive(
@@ -954,6 +964,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         this.consumerGroup,
         this.broadcastMode ? true : undefined,
         true,
+        entry.undoGroupClaim,
       );
       if (this.broadcastMode && entry.entryId !== '') {
         this.pausedBroadcastEntries.add(entry.entryId);
@@ -1561,6 +1572,8 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
           job.opts.removeOnComplete,
           undefined,
           this.broadcastMode ? true : undefined,
+          this.skipEvents,
+          this.skipMetrics,
         );
         if (isCompleteJobRevoked(notifications)) {
           await this.handleJobFailure(job, currentJobId, currentEntryId, new UnrecoverableError('revoked'));
@@ -1655,6 +1668,7 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
         await this.deferPausedActivation({
           jobId: fetchResult.nextJobId,
           entryId: fetchResult.nextEntryId,
+          undoGroupClaim: true,
         });
         return;
       }

--- a/src/base-worker.ts
+++ b/src/base-worker.ts
@@ -1295,6 +1295,14 @@ export abstract class BaseWorker<D = any, R = any> extends EventEmitter {
   protected async processJob(jobId: string, entryId: string): Promise<void> {
     if (!this.commandClient) return;
 
+    // close() can land while XREADGROUP/list-pop is in flight. The poll loop
+    // still delivers that claim, but the while-guard below would otherwise
+    // drop it in this consumer's PEL until stall reclaim.
+    if (this.closing) {
+      await this.deferPausedActivation({ jobId, entryId });
+      return;
+    }
+
     let currentJobId = jobId;
     let currentEntryId = entryId;
     let currentHash: Record<string, string> | null = null;

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -1070,6 +1070,8 @@ redis.register_function('glidemq_complete', function(keys, args)
   local depsMember = args[9] or ''
   local parentId = args[10] or ''
   local broadcastMode = args[11] or '0'
+  local skipEvents = args[12] or '0'
+  local skipMetrics = args[13] or '0'
   local processedOn = tonumber(redis.call('HGET', jobKey, 'processedOn')) or timestamp
   if redis.call('HGET', jobKey, 'revoked') == '1' then
     return 'REVOKED'
@@ -1084,8 +1086,8 @@ redis.register_function('glidemq_complete', function(keys, args)
   )
   markOrderingDone(jobKey, jobId)
   releaseGroupSlotAndPromote(jobKey, jobId, timestamp)
-  emitEvent(eventsKey, 'completed', jobId, {'returnvalue', returnvalue})
-  recordMetrics(metricsKey, timestamp, timestamp - processedOn)
+  if skipEvents ~= '1' then emitEvent(eventsKey, 'completed', jobId, {'returnvalue', returnvalue}) end
+  if skipMetrics ~= '1' then recordMetrics(metricsKey, timestamp, timestamp - processedOn) end
   local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
   local storedParentQueue = redis.call('HGET', jobKey, 'parentQueue')
   local storedParentId = redis.call('HGET', jobKey, 'parentId')
@@ -2772,6 +2774,32 @@ redis.register_function('glidemq_deferActive', function(keys, args)
     xaddJob(streamKey, jobId, redis.call('HGET', jobKey, 'name'))
   end
   redis.call('HSET', jobKey, 'state', 'waiting')
+  local undoGroupClaim = args[6] or '0'
+  if undoGroupClaim == '1' then
+    local gk = redis.call('HGET', jobKey, 'groupKey')
+    if gk and gk ~= '' then
+      local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
+      local ghk = prefix .. 'group:' .. gk
+      local seq = tonumber(redis.call('HGET', jobKey, 'orderingSeq')) or 0
+      local nextSeq = tonumber(redis.call('HGET', ghk, 'nextSeq')) or 0
+      local returning = seq > 0 and nextSeq > 0 and seq < nextSeq and nextSeq ~= seq + 1
+      if not returning then
+        local active = tonumber(redis.call('HGET', ghk, 'active')) or 0
+        if active > 0 then redis.call('HSET', ghk, 'active', tostring(active - 1)) end
+        if seq > 0 and nextSeq == seq + 1 then
+          redis.call('HSET', ghk, 'nextSeq', tostring(seq))
+        end
+      end
+      local tbCap = tonumber(redis.call('HGET', ghk, 'tbCapacity')) or 0
+      if tbCap > 0 then
+        local cost = tonumber(redis.call('HGET', jobKey, 'cost')) or 1000
+        local tokens = tonumber(redis.call('HGET', ghk, 'tbTokens')) or 0
+        redis.call('HSET', ghk, 'tbTokens', tostring(math.min(tbCap, tokens + cost)))
+      end
+      local rateCount = tonumber(redis.call('HGET', ghk, 'rateCount')) or 0
+      if rateCount > 0 then redis.call('HSET', ghk, 'rateCount', tostring(rateCount - 1)) end
+    end
+  end
   return 1
 end)
 

--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -2783,7 +2783,9 @@ redis.register_function('glidemq_deferActive', function(keys, args)
       local seq = tonumber(redis.call('HGET', jobKey, 'orderingSeq')) or 0
       local nextSeq = tonumber(redis.call('HGET', ghk, 'nextSeq')) or 0
       local returning = seq > 0 and nextSeq > 0 and seq < nextSeq and nextSeq ~= seq + 1
-      if not returning then
+      -- retainedSlot jobs already hold the group slot; CAF skipped the increment.
+      local retainedSlot = redis.call('HGET', jobKey, 'retainedSlot') == '1'
+      if not returning and not retainedSlot then
         local active = tonumber(redis.call('HGET', ghk, 'active')) or 0
         if active > 0 then redis.call('HSET', ghk, 'active', tostring(active - 1)) end
         if seq > 0 and nextSeq == seq + 1 then

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -409,9 +409,7 @@ export async function completeJob(
     args.push('', '');
   }
 
-  args.push(broadcastMode ? '1' : '0');
-  args.push(skipEvents ? '1' : '0');
-  args.push(skipMetrics ? '1' : '0');
+  args.push(broadcastMode ? '1' : '0', skipEvents ? '1' : '0', skipMetrics ? '1' : '0');
 
   const raw = await client.fcall('glidemq_complete', keys, args);
   return String(raw) === 'REVOKED' ? [COMPLETE_REVOKED_MARKER] : parseParentNotifications(raw);
@@ -898,14 +896,20 @@ export async function deferActive(
   entryId: string,
   group: string = CONSUMER_GROUP,
   broadcastMode?: boolean,
-  pausedRestore?: boolean,
-  undoGroupClaim?: boolean,
+  opts?: { pausedRestore?: boolean; undoGroupClaim?: boolean },
 ): Promise<void> {
-  const args = [jobId, entryId, group];
-  args.push(broadcastMode ? '1' : '0');
-  args.push(pausedRestore ? '1' : '0');
-  args.push(undoGroupClaim ? '1' : '0');
-  await client.fcall('glidemq_deferActive', [k.stream, k.job(jobId), k.listActive], args);
+  await client.fcall(
+    'glidemq_deferActive',
+    [k.stream, k.job(jobId), k.listActive],
+    [
+      jobId,
+      entryId,
+      group,
+      broadcastMode ? '1' : '0',
+      opts?.pausedRestore ? '1' : '0',
+      opts?.undoGroupClaim ? '1' : '0',
+    ],
+  );
 }
 
 /**

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -88,9 +88,11 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 110: dedupe overlapping tree and DAG parent notifications per completion.
 // Version 119: integrate the reviewed correctness queue and preserve Queue.pause in the reservation-aware list pop.
 // Version 120: removeJob acknowledges a claimed FIFO entry in every stream consumer group before deleting it.
+<<<<<<< HEAD
 // Version 121: tbRefill uses Redis server time and stamps capacity so idle-full time is not later granted as extra tokens.
 // Version 122: moveToWaitingChildren unparks immediately when no child deps exist.
-export const LIBRARY_VERSION = '122';
+// Version 123: glidemq_complete honors skipEvents/skipMetrics; deferActive can undo a CAF group reservation.
+export const LIBRARY_VERSION = '123';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';
@@ -382,6 +384,8 @@ export async function completeJob(
   removeOnComplete?: boolean | number | { age: number; count: number },
   parentInfo?: { depsMember: string; parentId: string; parentKeys: QueueKeys },
   broadcastMode?: boolean,
+  skipEvents?: boolean,
+  skipMetrics?: boolean,
 ): Promise<string[]> {
   const { mode, count, age } = encodeRetention(removeOnComplete);
 
@@ -405,7 +409,9 @@ export async function completeJob(
     args.push('', '');
   }
 
-  if (broadcastMode) args.push('1');
+  args.push(broadcastMode ? '1' : '0');
+  args.push(skipEvents ? '1' : '0');
+  args.push(skipMetrics ? '1' : '0');
 
   const raw = await client.fcall('glidemq_complete', keys, args);
   return String(raw) === 'REVOKED' ? [COMPLETE_REVOKED_MARKER] : parseParentNotifications(raw);
@@ -893,10 +899,12 @@ export async function deferActive(
   group: string = CONSUMER_GROUP,
   broadcastMode?: boolean,
   pausedRestore?: boolean,
+  undoGroupClaim?: boolean,
 ): Promise<void> {
   const args = [jobId, entryId, group];
   args.push(broadcastMode ? '1' : '0');
-  if (pausedRestore) args.push('1');
+  args.push(pausedRestore ? '1' : '0');
+  args.push(undoGroupClaim ? '1' : '0');
   await client.fcall('glidemq_deferActive', [k.stream, k.job(jobId), k.listActive], args);
 }
 

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -88,11 +88,11 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 110: dedupe overlapping tree and DAG parent notifications per completion.
 // Version 119: integrate the reviewed correctness queue and preserve Queue.pause in the reservation-aware list pop.
 // Version 120: removeJob acknowledges a claimed FIFO entry in every stream consumer group before deleting it.
-<<<<<<< HEAD
 // Version 121: tbRefill uses Redis server time and stamps capacity so idle-full time is not later granted as extra tokens.
 // Version 122: moveToWaitingChildren unparks immediately when no child deps exist.
 // Version 123: glidemq_complete honors skipEvents/skipMetrics; deferActive can undo a CAF group reservation.
-export const LIBRARY_VERSION = '123';
+// Version 124: undoGroupClaim skips active/nextSeq rewind when the job holds retainedSlot.
+export const LIBRARY_VERSION = '124';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/tests/close-fetch-next.test.ts
+++ b/tests/close-fetch-next.test.ts
@@ -10,9 +10,9 @@
 import { afterAll, beforeAll, expect, it } from 'vitest';
 import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './helpers/fixture';
 
-const { Queue } = require('../dist/queue') as typeof import('../src/queue');
-const { Worker } = require('../dist/worker') as typeof import('../src/worker');
-const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
+import { Queue } from '../src/queue';
+import { Worker } from '../src/worker';
+import { buildKeys } from '../src/utils';
 
 describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
   let cleanupClient: any;

--- a/tests/close-fetch-next.test.ts
+++ b/tests/close-fetch-next.test.ts
@@ -101,7 +101,7 @@ describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
     }
   }, 15000);
 
-  it('releases a grouped CAF claim so close(false) does not park the next job', async () => {
+  it('completes the current grouped job without fetching next when already closing', async () => {
     const Q = uniqueQueue('close-caf-group');
     const queue = new Queue(Q, { connection: CONNECTION });
     const group = { key: 'g', concurrency: 1 };
@@ -141,6 +141,84 @@ describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
     expect(await jobA.getState()).toBe('completed');
     expect(await jobB.getState()).not.toBe('group-waiting');
     expect(await jobB.getState()).not.toBe('active');
+
+    const recovered: number[] = [];
+    const worker2 = new Worker(
+      Q,
+      async (job: { data: { n: number } }) => {
+        recovered.push(job.data.n);
+        return 'ok';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 50,
+        stalledInterval: 60_000,
+      },
+    );
+    worker2.on('error', () => {});
+
+    try {
+      await waitFor(() => recovered.includes(2), 4000, 50);
+      expect(await jobB.getState()).toBe('completed');
+    } finally {
+      await worker2.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
+  it('undoes a grouped CAF claim when close races with completeAndFetchNext', async () => {
+    const Q = uniqueQueue('close-caf-undo');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const group = {
+      key: 'g',
+      concurrency: 1,
+      tokenBucket: { capacity: 10, refillRate: 0.001 },
+      rateLimit: { max: 10, duration: 60_000 },
+    };
+
+    const jobA = await queue.add('task', { n: 1 }, { ordering: group, cost: 1 });
+    const jobB = await queue.add('task', { n: 2 }, { ordering: group, cost: 1 });
+
+    const processed: number[] = [];
+    const worker = new Worker(
+      Q,
+      async (job: { data: { n: number } }) => {
+        processed.push(job.data.n);
+        return 'ok';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 50,
+        stalledInterval: 60_000,
+      },
+    );
+    worker.on('error', () => {});
+    // 'completed' fires after CAF has claimed job B and before the close-defer.
+    worker.once('completed', () => {
+      void worker.close(false);
+    });
+
+    await waitFor(() => processed.includes(1), 4000, 50);
+    await worker.close(false);
+
+    expect(processed).toEqual([1]);
+    expect(await jobA.getState()).toBe('completed');
+    expect(await jobB.getState()).not.toBe('active');
+    expect(await jobB.getState()).not.toBe('group-waiting');
+
+    const keys = buildKeys(Q);
+    const grpFields = await cleanupClient.hgetall(keys.group('g'));
+    const grp: Record<string, string> = {};
+    if (grpFields) {
+      for (const f of grpFields) grp[String(f.field)] = String(f.value);
+    }
+    const bSeq = Number(await cleanupClient.hget(keys.job(jobB.id), 'orderingSeq'));
+    expect(Number(grp.active ?? 0)).toBe(0);
+    expect(Number(grp.nextSeq)).toBe(bSeq);
+    expect(Number(grp.tbTokens)).toBeGreaterThanOrEqual(9000);
+    expect(Number(grp.rateCount ?? 0)).toBe(1);
 
     const recovered: number[] = [];
     const worker2 = new Worker(

--- a/tests/close-fetch-next.test.ts
+++ b/tests/close-fetch-next.test.ts
@@ -8,168 +8,150 @@
  * Run: npx vitest run tests/close-fetch-next.test.ts
  */
 import { afterAll, beforeAll, expect, it } from 'vitest';
-import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './helpers/fixture';
+import { createCleanupClient, describeEachMode, flushQueue, waitFor, type ConnectionConfig } from './helpers/fixture';
 
 import { Queue } from '../src/queue';
 import { Worker } from '../src/worker';
 import { deferActive } from '../src/functions';
 import { buildKeys } from '../src/utils';
+import type { Job } from '../src/job';
+import type { Processor } from '../src/types';
 
-describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
-  let cleanupClient: any;
+type TaskData = { n: number };
+
+function useQueueCleanup(connection: ConnectionConfig) {
+  let cleanupClient: Awaited<ReturnType<typeof createCleanupClient>>;
   const queues: string[] = [];
-
-  function uniqueQueue(prefix: string): string {
-    const name = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-    queues.push(name);
-    return name;
-  }
-
   beforeAll(async () => {
-    cleanupClient = await createCleanupClient(CONNECTION);
+    cleanupClient = await createCleanupClient(connection);
   });
-
   afterAll(async () => {
     await Promise.all(queues.map((q) => flushQueue(cleanupClient, q).catch(() => {})));
     cleanupClient.close();
   });
+  return {
+    get client() {
+      return cleanupClient;
+    },
+    uniqueQueue(prefix: string): string {
+      const name = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      queues.push(name);
+      return name;
+    },
+  };
+}
+
+function hashFromFields(fields: { field: unknown; value: unknown }[] | null | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!fields) return out;
+  for (const f of fields) out[String(f.field)] = String(f.value);
+  return out;
+}
+
+function closeTestWorker(
+  name: string,
+  connection: ConnectionConfig,
+  processor: Processor<TaskData, string>,
+  extra?: { events?: false },
+): Worker<TaskData, string> {
+  const worker = new Worker<TaskData, string>(name, processor, {
+    connection,
+    concurrency: 1,
+    blockTimeout: 50,
+    stalledInterval: 60_000,
+    ...extra,
+  });
+  worker.on('error', () => {});
+  return worker;
+}
+
+function heldFirstJob(): {
+  processor: Processor<TaskData, string>;
+  started: () => boolean;
+  release: () => void;
+} {
+  let release!: () => void;
+  const hold = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let started = false;
+  return {
+    processor: async (job) => {
+      if (job.data.n === 1) {
+        started = true;
+        await hold;
+      }
+      return 'ok';
+    },
+    started: () => started,
+    release: () => release(),
+  };
+}
+
+async function recoverSecondJob(name: string, connection: ConnectionConfig, queue: Queue, jobB: Job): Promise<void> {
+  const recovered: number[] = [];
+  const worker = closeTestWorker(name, connection, async (job) => {
+    recovered.push(job.data.n);
+    return 'ok';
+  });
+  try {
+    await waitFor(() => recovered.includes(2), 4000, 50);
+    expect(await jobB.getState()).toBe('completed');
+  } finally {
+    await worker.close(true);
+    await queue.close();
+  }
+}
+
+describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
+  const ctx = useQueueCleanup(CONNECTION);
 
   it('does not leave the chained next job active after close(false)', async () => {
-    const Q = uniqueQueue('close-caf');
+    const Q = ctx.uniqueQueue('close-caf');
     const queue = new Queue(Q, { connection: CONNECTION });
-
     const jobA = await queue.add('task', { n: 1 });
     const jobB = await queue.add('task', { n: 2 });
-
-    let releaseA!: () => void;
-    const holdA = new Promise<void>((resolve) => {
-      releaseA = resolve;
-    });
-    let aStarted = false;
     const processed: number[] = [];
+    const hold = heldFirstJob();
+    const worker = closeTestWorker(Q, CONNECTION, async (job) => {
+      const result = await hold.processor(job);
+      processed.push(job.data.n);
+      return result;
+    });
 
-    const worker = new Worker(
-      Q,
-      async (job: { data: { n: number } }) => {
-        if (job.data.n === 1) {
-          aStarted = true;
-          await holdA;
-        }
-        processed.push(job.data.n);
-        return 'ok';
-      },
-      {
-        connection: CONNECTION,
-        concurrency: 1,
-        blockTimeout: 50,
-        stalledInterval: 60_000,
-      },
-    );
-    worker.on('error', () => {});
-
-    await waitFor(() => aStarted);
-
+    await waitFor(() => hold.started());
     const closePromise = worker.close(false);
-    releaseA();
+    hold.release();
     await closePromise;
 
     expect(processed).toEqual([1]);
     expect(await jobA.getState()).toBe('completed');
     expect(await jobB.getState()).not.toBe('active');
-
-    const recovered: number[] = [];
-    const worker2 = new Worker(
-      Q,
-      async (job: { data: { n: number } }) => {
-        recovered.push(job.data.n);
-        return 'ok';
-      },
-      {
-        connection: CONNECTION,
-        concurrency: 1,
-        blockTimeout: 50,
-        stalledInterval: 60_000,
-      },
-    );
-    worker2.on('error', () => {});
-
-    try {
-      await waitFor(() => recovered.includes(2), 4000, 50);
-      expect(await jobB.getState()).toBe('completed');
-    } finally {
-      await worker2.close(true);
-      await queue.close();
-    }
+    await recoverSecondJob(Q, CONNECTION, queue, jobB);
   }, 15000);
 
   it('completes the current grouped job without fetching next when already closing', async () => {
-    const Q = uniqueQueue('close-caf-group');
+    const Q = ctx.uniqueQueue('close-caf-group');
     const queue = new Queue(Q, { connection: CONNECTION });
     const group = { key: 'g', concurrency: 1 };
-
     const jobA = await queue.add('task', { n: 1 }, { ordering: group });
     const jobB = await queue.add('task', { n: 2 }, { ordering: group });
+    const hold = heldFirstJob();
+    const worker = closeTestWorker(Q, CONNECTION, hold.processor);
 
-    let releaseA!: () => void;
-    const holdA = new Promise<void>((resolve) => {
-      releaseA = resolve;
-    });
-    let aStarted = false;
-
-    const worker = new Worker(
-      Q,
-      async (job: { data: { n: number } }) => {
-        if (job.data.n === 1) {
-          aStarted = true;
-          await holdA;
-        }
-        return 'ok';
-      },
-      {
-        connection: CONNECTION,
-        concurrency: 1,
-        blockTimeout: 50,
-        stalledInterval: 60_000,
-      },
-    );
-    worker.on('error', () => {});
-
-    await waitFor(() => aStarted);
+    await waitFor(() => hold.started());
     const closePromise = worker.close(false);
-    releaseA();
+    hold.release();
     await closePromise;
 
     expect(await jobA.getState()).toBe('completed');
     expect(await jobB.getState()).not.toBe('group-waiting');
     expect(await jobB.getState()).not.toBe('active');
-
-    const recovered: number[] = [];
-    const worker2 = new Worker(
-      Q,
-      async (job: { data: { n: number } }) => {
-        recovered.push(job.data.n);
-        return 'ok';
-      },
-      {
-        connection: CONNECTION,
-        concurrency: 1,
-        blockTimeout: 50,
-        stalledInterval: 60_000,
-      },
-    );
-    worker2.on('error', () => {});
-
-    try {
-      await waitFor(() => recovered.includes(2), 4000, 50);
-      expect(await jobB.getState()).toBe('completed');
-    } finally {
-      await worker2.close(true);
-      await queue.close();
-    }
+    await recoverSecondJob(Q, CONNECTION, queue, jobB);
   }, 15000);
 
   it('undoes a grouped CAF claim when close races with completeAndFetchNext', async () => {
-    const Q = uniqueQueue('close-caf-undo');
+    const Q = ctx.uniqueQueue('close-caf-undo');
     const queue = new Queue(Q, { connection: CONNECTION });
     const group = {
       key: 'g',
@@ -177,25 +159,13 @@ describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
       tokenBucket: { capacity: 10, refillRate: 0.001 },
       rateLimit: { max: 10, duration: 60_000 },
     };
-
     const jobA = await queue.add('task', { n: 1 }, { ordering: group, cost: 1 });
     const jobB = await queue.add('task', { n: 2 }, { ordering: group, cost: 1 });
-
     const processed: number[] = [];
-    const worker = new Worker(
-      Q,
-      async (job: { data: { n: number } }) => {
-        processed.push(job.data.n);
-        return 'ok';
-      },
-      {
-        connection: CONNECTION,
-        concurrency: 1,
-        blockTimeout: 50,
-        stalledInterval: 60_000,
-      },
-    );
-    worker.on('error', () => {});
+    const worker = closeTestWorker(Q, CONNECTION, async (job) => {
+      processed.push(job.data.n);
+      return 'ok';
+    });
     // 'completed' fires after CAF has claimed job B and before the close-defer.
     worker.once('completed', () => {
       void worker.close(false);
@@ -210,80 +180,30 @@ describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
     expect(await jobB.getState()).not.toBe('group-waiting');
 
     const keys = buildKeys(Q);
-    const grpFields = await cleanupClient.hgetall(keys.group('g'));
-    const grp: Record<string, string> = {};
-    if (grpFields) {
-      for (const f of grpFields) grp[String(f.field)] = String(f.value);
-    }
-    const bSeq = Number(await cleanupClient.hget(keys.job(jobB.id), 'orderingSeq'));
+    const grp = hashFromFields(await ctx.client.hgetall(keys.group('g')));
+    const bSeq = Number(await ctx.client.hget(keys.job(jobB.id), 'orderingSeq'));
     expect(Number(grp.active ?? 0)).toBe(0);
     expect(Number(grp.nextSeq)).toBe(bSeq);
     expect(Number(grp.tbTokens)).toBeGreaterThanOrEqual(9000);
     expect(Number(grp.rateCount ?? 0)).toBe(1);
-
-    const recovered: number[] = [];
-    const worker2 = new Worker(
-      Q,
-      async (job: { data: { n: number } }) => {
-        recovered.push(job.data.n);
-        return 'ok';
-      },
-      {
-        connection: CONNECTION,
-        concurrency: 1,
-        blockTimeout: 50,
-        stalledInterval: 60_000,
-      },
-    );
-    worker2.on('error', () => {});
-
-    try {
-      await waitFor(() => recovered.includes(2), 4000, 50);
-      expect(await jobB.getState()).toBe('completed');
-    } finally {
-      await worker2.close(true);
-      await queue.close();
-    }
+    await recoverSecondJob(Q, CONNECTION, queue, jobB);
   }, 15000);
 
   it('does not write completion events when events are disabled during close', async () => {
-    const Q = uniqueQueue('close-caf-events');
+    const Q = ctx.uniqueQueue('close-caf-events');
     const queue = new Queue(Q, { connection: CONNECTION, events: false });
     const jobA = await queue.add('task', { n: 1 });
     await queue.add('task', { n: 2 });
+    const hold = heldFirstJob();
+    const worker = closeTestWorker(Q, CONNECTION, hold.processor, { events: false });
 
-    let releaseA!: () => void;
-    const holdA = new Promise<void>((resolve) => {
-      releaseA = resolve;
-    });
-    let aStarted = false;
-
-    const worker = new Worker(
-      Q,
-      async (job: { data: { n: number } }) => {
-        if (job.data.n === 1) {
-          aStarted = true;
-          await holdA;
-        }
-        return 'ok';
-      },
-      {
-        connection: CONNECTION,
-        concurrency: 1,
-        blockTimeout: 50,
-        stalledInterval: 60_000,
-        events: false,
-      },
-    );
-    worker.on('error', () => {});
-
-    await waitFor(() => aStarted);
+    await waitFor(() => hold.started());
     const closePromise = worker.close(false);
-    releaseA();
+    hold.release();
     await closePromise;
 
     const keys = buildKeys(Q);
-    const entries = (await cleanupClient.xrange(keys.events, '-', '+')) as Record<string, [string, string][]>;
+    const entries = (await ctx.client.xrange(keys.events, '-', '+')) as Record<string, [string, string][]>;
     const types: string[] = [];
     for (const fields of Object.values(entries ?? {})) {
       for (const [f, v] of fields) {
@@ -296,10 +216,10 @@ describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
   }, 15000);
 
   it('does not decrement group.active when undoing a retained-slot returning claim', async () => {
-    const Q = uniqueQueue('close-caf-retained');
+    const Q = ctx.uniqueQueue('close-caf-retained');
     const keys = buildKeys(Q);
     const jobId = '1';
-    await cleanupClient.hset(keys.job(jobId), {
+    await ctx.client.hset(keys.job(jobId), {
       state: 'active',
       name: 'task',
       groupKey: 'g',
@@ -307,7 +227,7 @@ describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
       retainedSlot: '1',
       cost: '1000',
     });
-    await cleanupClient.hset(keys.group('g'), {
+    await ctx.client.hset(keys.group('g'), {
       active: '1',
       nextSeq: '2',
       tbCapacity: '10000',
@@ -315,20 +235,18 @@ describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
       rateCount: '1',
     });
     const entryId = String(
-      await cleanupClient.xadd(keys.stream, [
+      await ctx.client.xadd(keys.stream, [
         ['jobId', jobId],
         ['name', 'task'],
       ]),
     );
-    await cleanupClient.xgroupCreate(keys.stream, 'workers', '0');
+    await ctx.client.xgroupCreate(keys.stream, 'workers', '0');
+    await deferActive(ctx.client, keys, jobId, entryId, 'workers', false, {
+      pausedRestore: true,
+      undoGroupClaim: true,
+    });
 
-    await deferActive(cleanupClient, keys, jobId, entryId, 'workers', false, true, true);
-
-    const grpFields = await cleanupClient.hgetall(keys.group('g'));
-    const grp: Record<string, string> = {};
-    if (grpFields) {
-      for (const f of grpFields) grp[String(f.field)] = String(f.value);
-    }
+    const grp = hashFromFields(await ctx.client.hgetall(keys.group('g')));
     expect(Number(grp.active)).toBe(1);
     expect(Number(grp.nextSeq)).toBe(2);
     expect(Number(grp.tbTokens)).toBe(9000);

--- a/tests/close-fetch-next.test.ts
+++ b/tests/close-fetch-next.test.ts
@@ -12,6 +12,7 @@ import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './he
 
 const { Queue } = require('../dist/queue') as typeof import('../src/queue');
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
 
 describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
   let cleanupClient: any;
@@ -98,5 +99,120 @@ describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
       await worker2.close(true);
       await queue.close();
     }
+  }, 15000);
+
+  it('releases a grouped CAF claim so close(false) does not park the next job', async () => {
+    const Q = uniqueQueue('close-caf-group');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const group = { key: 'g', concurrency: 1 };
+
+    const jobA = await queue.add('task', { n: 1 }, { ordering: group });
+    const jobB = await queue.add('task', { n: 2 }, { ordering: group });
+
+    let releaseA!: () => void;
+    const holdA = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    let aStarted = false;
+
+    const worker = new Worker(
+      Q,
+      async (job: { data: { n: number } }) => {
+        if (job.data.n === 1) {
+          aStarted = true;
+          await holdA;
+        }
+        return 'ok';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 50,
+        stalledInterval: 60_000,
+      },
+    );
+    worker.on('error', () => {});
+
+    await waitFor(() => aStarted);
+    const closePromise = worker.close(false);
+    releaseA();
+    await closePromise;
+
+    expect(await jobA.getState()).toBe('completed');
+    expect(await jobB.getState()).not.toBe('group-waiting');
+    expect(await jobB.getState()).not.toBe('active');
+
+    const recovered: number[] = [];
+    const worker2 = new Worker(
+      Q,
+      async (job: { data: { n: number } }) => {
+        recovered.push(job.data.n);
+        return 'ok';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 50,
+        stalledInterval: 60_000,
+      },
+    );
+    worker2.on('error', () => {});
+
+    try {
+      await waitFor(() => recovered.includes(2), 4000, 50);
+      expect(await jobB.getState()).toBe('completed');
+    } finally {
+      await worker2.close(true);
+      await queue.close();
+    }
+  }, 15000);
+
+  it('does not write completion events when events are disabled during close', async () => {
+    const Q = uniqueQueue('close-caf-events');
+    const queue = new Queue(Q, { connection: CONNECTION, events: false });
+    const jobA = await queue.add('task', { n: 1 });
+    await queue.add('task', { n: 2 });
+
+    let releaseA!: () => void;
+    const holdA = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    let aStarted = false;
+
+    const worker = new Worker(
+      Q,
+      async (job: { data: { n: number } }) => {
+        if (job.data.n === 1) {
+          aStarted = true;
+          await holdA;
+        }
+        return 'ok';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 50,
+        stalledInterval: 60_000,
+        events: false,
+      },
+    );
+    worker.on('error', () => {});
+
+    await waitFor(() => aStarted);
+    const closePromise = worker.close(false);
+    releaseA();
+    await closePromise;
+
+    const keys = buildKeys(Q);
+    const entries = (await cleanupClient.xrange(keys.events, '-', '+')) as Record<string, [string, string][]>;
+    const types: string[] = [];
+    for (const fields of Object.values(entries ?? {})) {
+      for (const [f, v] of fields) {
+        if (String(f) === 'event') types.push(String(v));
+      }
+    }
+    expect(types).not.toContain('completed');
+    expect(await jobA.getState()).toBe('completed');
+    await queue.close();
   }, 15000);
 });

--- a/tests/close-fetch-next.test.ts
+++ b/tests/close-fetch-next.test.ts
@@ -12,6 +12,7 @@ import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './he
 
 import { Queue } from '../src/queue';
 import { Worker } from '../src/worker';
+import { deferActive } from '../src/functions';
 import { buildKeys } from '../src/utils';
 
 describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
@@ -293,4 +294,44 @@ describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
     expect(await jobA.getState()).toBe('completed');
     await queue.close();
   }, 15000);
+
+  it('does not decrement group.active when undoing a retained-slot returning claim', async () => {
+    const Q = uniqueQueue('close-caf-retained');
+    const keys = buildKeys(Q);
+    const jobId = '1';
+    await cleanupClient.hset(keys.job(jobId), {
+      state: 'active',
+      name: 'task',
+      groupKey: 'g',
+      orderingSeq: '1',
+      retainedSlot: '1',
+      cost: '1000',
+    });
+    await cleanupClient.hset(keys.group('g'), {
+      active: '1',
+      nextSeq: '2',
+      tbCapacity: '10000',
+      tbTokens: '8000',
+      rateCount: '1',
+    });
+    const entryId = String(
+      await cleanupClient.xadd(keys.stream, [
+        ['jobId', jobId],
+        ['name', 'task'],
+      ]),
+    );
+    await cleanupClient.xgroupCreate(keys.stream, 'workers', '0');
+
+    await deferActive(cleanupClient, keys, jobId, entryId, 'workers', false, true, true);
+
+    const grpFields = await cleanupClient.hgetall(keys.group('g'));
+    const grp: Record<string, string> = {};
+    if (grpFields) {
+      for (const f of grpFields) grp[String(f.field)] = String(f.value);
+    }
+    expect(Number(grp.active)).toBe(1);
+    expect(Number(grp.nextSeq)).toBe(2);
+    expect(Number(grp.tbTokens)).toBe(9000);
+    expect(Number(grp.rateCount)).toBe(0);
+  });
 });

--- a/tests/close-fetch-next.test.ts
+++ b/tests/close-fetch-next.test.ts
@@ -1,0 +1,102 @@
+/**
+ * close(false) must not leave the next job claimed by completeAndFetchNext.
+ *
+ * concurrency=1 chains via completeAndFetchNext. If close() sets closing while
+ * job A is running, CAF still claims job B, then the loop exits and drops B
+ * in state=active with no processor.
+ *
+ * Run: npx vitest run tests/close-fetch-next.test.ts
+ */
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './helpers/fixture';
+
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+
+describeEachMode('close(false) vs completeAndFetchNext', (CONNECTION) => {
+  let cleanupClient: any;
+  const queues: string[] = [];
+
+  function uniqueQueue(prefix: string): string {
+    const name = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    queues.push(name);
+    return name;
+  }
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    await Promise.all(queues.map((q) => flushQueue(cleanupClient, q).catch(() => {})));
+    cleanupClient.close();
+  });
+
+  it('does not leave the chained next job active after close(false)', async () => {
+    const Q = uniqueQueue('close-caf');
+    const queue = new Queue(Q, { connection: CONNECTION });
+
+    const jobA = await queue.add('task', { n: 1 });
+    const jobB = await queue.add('task', { n: 2 });
+
+    let releaseA!: () => void;
+    const holdA = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    let aStarted = false;
+    const processed: number[] = [];
+
+    const worker = new Worker(
+      Q,
+      async (job: { data: { n: number } }) => {
+        if (job.data.n === 1) {
+          aStarted = true;
+          await holdA;
+        }
+        processed.push(job.data.n);
+        return 'ok';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 50,
+        stalledInterval: 60_000,
+      },
+    );
+    worker.on('error', () => {});
+
+    await waitFor(() => aStarted);
+
+    const closePromise = worker.close(false);
+    releaseA();
+    await closePromise;
+
+    expect(processed).toEqual([1]);
+    expect(await jobA.getState()).toBe('completed');
+    expect(await jobB.getState()).not.toBe('active');
+
+    const recovered: number[] = [];
+    const worker2 = new Worker(
+      Q,
+      async (job: { data: { n: number } }) => {
+        recovered.push(job.data.n);
+        return 'ok';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 50,
+        stalledInterval: 60_000,
+      },
+    );
+    worker2.on('error', () => {});
+
+    try {
+      await waitFor(() => recovered.includes(2), 4000, 50);
+      expect(await jobB.getState()).toBe('completed');
+    } finally {
+      await worker2.close(true);
+      await queue.close();
+    }
+  }, 15000);
+});

--- a/tests/pause-worker-internals.test.ts
+++ b/tests/pause-worker-internals.test.ts
@@ -81,6 +81,23 @@ describe('pause worker internals', () => {
     const completeArgs = fcall.mock.calls.at(-1)[2] as string[];
     expect(fcall.mock.calls.at(-1)[0]).toBe('glidemq_complete');
     expect(completeArgs.slice(-3)).toEqual(['0', '1', '1']);
+
+    const closingWorker = {
+      commandClient: { fcall },
+      queueKeys: keys,
+      consumerGroup: 'workers',
+      broadcastMode: false,
+      closing: true,
+      emit: vi.fn(),
+    };
+    (closingWorker as any).deferPausedActivation = (entry: { jobId: string; entryId: string }) =>
+      (BaseWorker.prototype as any).deferPausedActivation.call(closingWorker, entry);
+    await (BaseWorker.prototype as any).processJob.call(closingWorker, 'job-poll', '9-0');
+    expect(fcall).toHaveBeenLastCalledWith(
+      'glidemq_deferActive',
+      [keys.stream, keys.job('job-poll'), keys.listActive],
+      ['job-poll', '9-0', 'workers', '0', '1', '0'],
+    );
   });
 
   it('waits while paused without rewinding broadcast pending reads after resume', async () => {

--- a/tests/pause-worker-internals.test.ts
+++ b/tests/pause-worker-internals.test.ts
@@ -38,7 +38,7 @@ describe('pause worker internals', () => {
     expect(fcall).toHaveBeenCalledWith(
       'glidemq_deferActive',
       [keys.stream, keys.job('job-1'), keys.listActive],
-      ['job-1', '', 'workers', '0', '1'],
+      ['job-1', '', 'workers', '0', '1', '0'],
     );
 
     const pausedClient = { fcall: vi.fn().mockResolvedValue('PAUSED') } as any;
@@ -50,7 +50,7 @@ describe('pause worker internals', () => {
     expect(fcall).toHaveBeenLastCalledWith(
       'glidemq_deferActive',
       [keys.stream, keys.job('job-3'), keys.listActive],
-      ['job-3', '1-0', 'workers', '1', '1'],
+      ['job-3', '1-0', 'workers', '1', '1', '0'],
     );
   });
 

--- a/tests/pause-worker-internals.test.ts
+++ b/tests/pause-worker-internals.test.ts
@@ -46,7 +46,7 @@ describe('pause worker internals', () => {
       'PAUSED',
     );
 
-    await deferActive({ fcall } as any, keys, 'job-3', '1-0', 'workers', true, true);
+    await deferActive({ fcall } as any, keys, 'job-3', '1-0', 'workers', true, { pausedRestore: true });
     expect(fcall).toHaveBeenLastCalledWith(
       'glidemq_deferActive',
       [keys.stream, keys.job('job-3'), keys.listActive],

--- a/tests/pause-worker-internals.test.ts
+++ b/tests/pause-worker-internals.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { BaseWorker } from '../src/base-worker';
 import { BroadcastWorker } from '../src/broadcast-worker';
-import { deferActive, moveToActive } from '../src/functions';
+import { deferActive, moveToActive, completeJob } from '../src/functions';
 import { buildKeys } from '../src/utils';
 import { Worker } from '../src/worker';
 
@@ -52,6 +52,35 @@ describe('pause worker internals', () => {
       [keys.stream, keys.job('job-3'), keys.listActive],
       ['job-3', '1-0', 'workers', '1', '1', '0'],
     );
+
+    await (BaseWorker.prototype as any).deferPausedActivation.call(worker, {
+      jobId: 'job-4',
+      entryId: '2-0',
+      undoGroupClaim: true,
+    });
+    expect(fcall).toHaveBeenLastCalledWith(
+      'glidemq_deferActive',
+      [keys.stream, keys.job('job-4'), keys.listActive],
+      ['job-4', '2-0', 'workers', '0', '1', '1'],
+    );
+
+    await completeJob(
+      { fcall } as any,
+      keys,
+      'job-5',
+      '3-0',
+      'null',
+      1,
+      'workers',
+      undefined,
+      undefined,
+      false,
+      true,
+      true,
+    );
+    const completeArgs = fcall.mock.calls.at(-1)[2] as string[];
+    expect(fcall.mock.calls.at(-1)[0]).toBe('glidemq_complete');
+    expect(completeArgs.slice(-3)).toEqual(['0', '1', '1']);
   });
 
   it('waits while paused without rewinding broadcast pending reads after resume', async () => {

--- a/tests/tb-idle-refill.test.ts
+++ b/tests/tb-idle-refill.test.ts
@@ -51,19 +51,19 @@ describeEachMode('token bucket idle-at-capacity refill', (CONNECTION) => {
       async () => {
         completed.push(Date.now());
       },
-      { connection: CONNECTION, concurrency: 4, blockTimeout: 50 },
+      { connection: CONNECTION, concurrency: 4, blockTimeout: 50, promotionInterval: 250 },
     );
     worker.on('error', () => {});
 
     try {
-      await waitFor(() => completed.length === 2, 5000, 50);
+      await waitFor(() => completed.length === 2, 12000, 50);
       completed.sort((a, b) => a - b);
       expect(completed[1]! - completed[0]!).toBeGreaterThanOrEqual(700);
     } finally {
       await worker.close(true);
       await queue.close();
     }
-  }, 15000);
+  }, 20000);
 
   it('does not persist an ahead caller clock as tbLastRefill at capacity', async () => {
     const Q = uniqueQueue('tb-idle-clock');


### PR DESCRIPTION
Companion review PR for the close vs completeAndFetchNext claim drop.

## Summary
- `close(false)` sets `closing` while concurrency=1 `processJob` is still in the completeAndFetchNext chain
- that FCALL claims the next waiting job, then the loop exits and leaves it `active` with no processor
- complete the current job without fetch-next when already closing; defer a next job if CAF already claimed it
- close-time `completeJob` treats COMPLETE_REVOKED as already-acked; `closePromise` is assigned before `closing` is emitted

## Red-first proof
The first commit is test-only. Against its parent, `close(false)` left job B `state=active` and a second worker with a long stalled interval could not recover it.

## Test plan
- [x] `npx vitest run tests/close-fetch-next.test.ts` (standalone + cluster)
- [x] `npx vitest run tests/shutdown.test.ts`


Made with [Cursor](https://cursor.com)