### PR TITLE
fix: flush TestWorker partial batches on timeout

### DIFF
--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1648,22 +1648,15 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
   // ---- Batch processing ----
 
   private processAvailableBatch(): void {
-    // Respect concurrency: don't start a new batch if at capacity
     if (this.activeCount >= this.concurrency * this.batchSize) return;
 
-    // Collect up to batchSize waiting jobs from the waitingQueue
-    const records: TestJobRecord<D, R>[] = [];
-    while (this.queue.waitingQueue.length > 0 && records.length < this.batchSize) {
-      const record = this.queue.waitingQueue[0];
-      if (record.state !== 'waiting') {
-        this.queue.waitingQueue.shift();
-        continue;
-      }
-      this.queue.waitingQueue.shift();
-      records.push(record);
+    while (this.queue.waitingQueue.length > 0 && this.pendingBatch.length < this.batchSize) {
+      const record = this.queue.waitingQueue.shift()!;
+      if (record.state !== 'waiting') continue;
+      this.pendingBatch.push(record);
     }
 
-    if (records.length === 0) {
+    if (this.pendingBatch.length === 0) {
       if (this.activeCount === 0 && !this.isDrained) {
         this.isDrained = true;
         this.emit('drained');
@@ -1671,54 +1664,52 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
       return;
     }
 
-    // Batch is full - process immediately even if timer is running
-    if (records.length >= this.batchSize) {
-      if (this.batchTimer) {
-        clearTimeout(this.batchTimer);
-        this.batchTimer = null;
-      }
-      this.executeBatch(records);
+    if (this.pendingBatch.length >= this.batchSize) {
+      this.clearBatchTimer();
+      this.executeBatch(this.pendingBatch.splice(0, this.batchSize));
+      if (this.pendingBatch.length > 0) this.scheduleBatchFlush();
+      else if (this.queue.waitingQueue.length > 0) queueMicrotask(() => this.processAvailableBatch());
       return;
     }
 
     if (this.batchTimeout > 0) {
-      this.pendingBatch.push(...records);
-      if (this.pendingBatch.length >= this.batchSize) {
-        if (this.batchTimer) {
-          clearTimeout(this.batchTimer);
-          this.batchTimer = null;
-        }
-        this.executeBatch(this.pendingBatch.splice(0, this.batchSize));
-        return;
-      }
-      if (!this.batchTimer) {
-        this.batchTimer = setTimeout(() => {
-          this.batchTimer = null;
-          this.flushBatch();
-        }, this.batchTimeout);
-      }
+      this.scheduleBatchFlush();
       return;
     }
 
-    // No timeout - process partial batch immediately
-    this.executeBatch(records);
+    this.executeBatch(this.pendingBatch.splice(0, this.pendingBatch.length));
+  }
+
+  private clearBatchTimer(): void {
+    if (this.batchTimer) {
+      clearTimeout(this.batchTimer);
+      this.batchTimer = null;
+    }
+  }
+
+  private scheduleBatchFlush(): void {
+    if (this.batchTimer || this.batchTimeout <= 0 || this.pendingBatch.length === 0) return;
+    this.batchTimer = setTimeout(() => {
+      this.batchTimer = null;
+      this.flushBatch();
+    }, this.batchTimeout);
   }
 
   private flushBatch(): void {
     if (!this.running) return;
-    const records = this.pendingBatch.splice(0, this.batchSize);
-    while (this.queue.waitingQueue.length > 0 && records.length < this.batchSize) {
+    this.pendingBatch = this.pendingBatch.filter((r) => this.queue.jobs.has(r.id) && r.state === 'waiting');
+    while (this.queue.waitingQueue.length > 0 && this.pendingBatch.length < this.batchSize) {
       const record = this.queue.waitingQueue[0];
       if (record.state !== 'waiting') {
         this.queue.waitingQueue.shift();
         continue;
       }
       this.queue.waitingQueue.shift();
-      records.push(record);
+      this.pendingBatch.push(record);
     }
-    if (records.length > 0) {
-      this.executeBatch(records);
-    }
+    if (this.pendingBatch.length === 0) return;
+    this.executeBatch(this.pendingBatch.splice(0, this.batchSize));
+    if (this.pendingBatch.length > 0) this.scheduleBatchFlush();
   }
 
   private executeBatch(records: TestJobRecord<D, R>[]): void {
@@ -1876,16 +1867,16 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
   /** Stop processing and detach from the queue. */
   async close(): Promise<void> {
     this.running = false;
-    if (this.batchTimer) {
-      clearTimeout(this.batchTimer);
-      this.batchTimer = null;
-    }
+    this.clearBatchTimer();
     if (this.pendingBatch.length > 0) {
       this.queue.waitingQueue.unshift(...this.pendingBatch);
       this.pendingBatch = [];
     }
     this.queue.workers.delete(this);
     this.queue.onWorkerDetached();
+    for (const peer of this.queue.workers) {
+      peer.onJobAdded();
+    }
     this.removeAllListeners();
   }
 }

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1380,6 +1380,7 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
   private readonly batchTimeout: number;
   private readonly batchProcessor: ((jobs: TestJob<D, R>[]) => Promise<R[]>) | null;
   private batchTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingBatch: TestJobRecord<D, R>[] = [];
   private readonly tokenLimiter: TestWorkerOptions['tokenLimiter'];
   private tpmLocalCounter = 0;
   private tpmWindowStart = 0;
@@ -1681,7 +1682,15 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
     }
 
     if (this.batchTimeout > 0) {
-      // Start a timer to flush the partial batch after timeout
+      this.pendingBatch.push(...records);
+      if (this.pendingBatch.length >= this.batchSize) {
+        if (this.batchTimer) {
+          clearTimeout(this.batchTimer);
+          this.batchTimer = null;
+        }
+        this.executeBatch(this.pendingBatch.splice(0, this.batchSize));
+        return;
+      }
       if (!this.batchTimer) {
         this.batchTimer = setTimeout(() => {
           this.batchTimer = null;
@@ -1697,8 +1706,7 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
 
   private flushBatch(): void {
     if (!this.running) return;
-    // Re-collect from waitingQueue, skipping stale entries
-    const records: TestJobRecord<D, R>[] = [];
+    const records = this.pendingBatch.splice(0, this.batchSize);
     while (this.queue.waitingQueue.length > 0 && records.length < this.batchSize) {
       const record = this.queue.waitingQueue[0];
       if (record.state !== 'waiting') {
@@ -1871,6 +1879,10 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
     if (this.batchTimer) {
       clearTimeout(this.batchTimer);
       this.batchTimer = null;
+    }
+    if (this.pendingBatch.length > 0) {
+      this.queue.waitingQueue.unshift(...this.pendingBatch);
+      this.pendingBatch = [];
     }
     this.queue.workers.delete(this);
     this.queue.onWorkerDetached();

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1650,9 +1650,10 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
   private processAvailableBatch(): void {
     if (this.activeCount >= this.concurrency * this.batchSize) return;
 
-    while (this.queue.waitingQueue.length > 0 && this.pendingBatch.length < this.batchSize) {
-      const record = this.queue.waitingQueue.shift()!;
-      if (record.state !== 'waiting') continue;
+    this.pendingBatch = this.pendingBatch.filter((r) => this.queue.jobs.has(r.id) && r.state === 'waiting');
+    while (this.pendingBatch.length < this.batchSize) {
+      const record = this.takeWaitingRecord();
+      if (!record) break;
       this.pendingBatch.push(record);
     }
 
@@ -1668,7 +1669,7 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
       this.clearBatchTimer();
       this.executeBatch(this.pendingBatch.splice(0, this.batchSize));
       if (this.pendingBatch.length > 0) this.scheduleBatchFlush();
-      else if (this.queue.waitingQueue.length > 0) queueMicrotask(() => this.processAvailableBatch());
+      else if (this.queue.waitingQueue.length > 0) queueMicrotask(() => this.processAvailable());
       return;
     }
 
@@ -1695,17 +1696,25 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
     }, this.batchTimeout);
   }
 
+  private takeWaitingRecord(): TestJobRecord<D, R> | undefined {
+    while (this.queue.waitingQueue.length > 0) {
+      const record = this.queue.waitingQueue.shift()!;
+      if (record.state !== 'waiting') continue;
+      if (!this.queue.jobs.has(record.id)) continue;
+      return record;
+    }
+    return undefined;
+  }
+
   private flushBatch(): void {
     if (!this.running) return;
     this.pendingBatch = this.pendingBatch.filter((r) => this.queue.jobs.has(r.id) && r.state === 'waiting');
-    while (this.queue.waitingQueue.length > 0 && this.pendingBatch.length < this.batchSize) {
-      const record = this.queue.waitingQueue[0];
-      if (record.state !== 'waiting') {
-        this.queue.waitingQueue.shift();
-        continue;
+    if (!this.queue.isPaused()) {
+      while (this.pendingBatch.length < this.batchSize) {
+        const record = this.takeWaitingRecord();
+        if (!record) break;
+        this.pendingBatch.push(record);
       }
-      this.queue.waitingQueue.shift();
-      this.pendingBatch.push(record);
     }
     if (this.pendingBatch.length === 0) return;
     this.executeBatch(this.pendingBatch.splice(0, this.batchSize));
@@ -1869,8 +1878,9 @@ export class TestWorker<D = any, R = any> extends EventEmitter {
     this.running = false;
     this.clearBatchTimer();
     if (this.pendingBatch.length > 0) {
-      this.queue.waitingQueue.unshift(...this.pendingBatch);
+      const handoff = this.pendingBatch.filter((r) => this.queue.jobs.has(r.id) && r.state === 'waiting');
       this.pendingBatch = [];
+      if (handoff.length > 0) this.queue.waitingQueue.unshift(...handoff);
     }
     this.queue.workers.delete(this);
     this.queue.onWorkerDetached();

--- a/tests/testing-mode.test.ts
+++ b/tests/testing-mode.test.ts
@@ -1253,6 +1253,94 @@ describe('TestWorker batch mode', () => {
     expect((await queue.getJobs('waiting')).length).toBe(0);
   });
 
+  it('flushes leftover pending jobs after a full batch takes only part of them', async () => {
+    queue = new TestQueue('batch-remainder');
+    const batchSizes: number[] = [];
+
+    await queue.addBulk([
+      { name: 'a', data: { i: 1 } },
+      { name: 'b', data: { i: 2 } },
+      { name: 'c', data: { i: 3 } },
+      { name: 'd', data: { i: 4 } },
+    ]);
+
+    worker = new TestWorker(
+      queue,
+      async (jobs: TestJob[]) => {
+        batchSizes.push(jobs.length);
+        return jobs.map(() => 'ok');
+      },
+      { batch: { size: 5, timeout: 50 } },
+    );
+
+    await waitFor(async () => (await queue.getJobCounts()).waiting === 4, 500, 10);
+    await queue.addBulk([
+      { name: 'e', data: { i: 5 } },
+      { name: 'f', data: { i: 6 } },
+      { name: 'g', data: { i: 7 } },
+      { name: 'h', data: { i: 8 } },
+    ]);
+
+    await waitFor(async () => (await queue.getJobCounts()).completed === 8, 2000, 20);
+    expect(batchSizes).toEqual([5, 3]);
+  });
+
+  it('does not process a pending batch after drain()', async () => {
+    queue = new TestQueue('batch-drain');
+    const batchSizes: number[] = [];
+
+    await queue.add('a', { i: 1 });
+    await queue.add('b', { i: 2 });
+
+    worker = new TestWorker(
+      queue,
+      async (jobs: TestJob[]) => {
+        batchSizes.push(jobs.length);
+        return jobs.map(() => 'ok');
+      },
+      { batch: { size: 5, timeout: 80 } },
+    );
+
+    await waitFor(async () => (await queue.getJobCounts()).waiting === 2, 500, 10);
+    await queue.drain();
+    await new Promise((r) => setTimeout(r, 150));
+    expect(batchSizes).toEqual([]);
+    expect((await queue.getJobCounts()).completed).toBe(0);
+  });
+
+  it('hands a closing worker pending batch to remaining workers', async () => {
+    queue = new TestQueue('batch-close-handoff');
+    const batchSizes: number[] = [];
+
+    await queue.add('a', { i: 1 });
+    await queue.add('b', { i: 2 });
+
+    worker = new TestWorker(
+      queue,
+      async () => {
+        throw new Error('closing worker should not flush');
+      },
+      { batch: { size: 5, timeout: 5000 } },
+    );
+
+    await waitFor(async () => (await queue.getJobCounts()).waiting === 2, 500, 10);
+
+    const peer = new TestWorker(
+      queue,
+      async (jobs: TestJob[]) => {
+        batchSizes.push(jobs.length);
+        return jobs.map(() => 'ok');
+      },
+      { batch: { size: 5, timeout: 50 } },
+    );
+
+    await worker.close();
+    worker = peer;
+
+    await waitFor(async () => (await queue.getJobCounts()).completed === 2, 2000, 20);
+    expect(batchSizes).toEqual([2]);
+  });
+
   it('emits active and completed events per job', async () => {
     queue = new TestQueue('batch-events');
     const activeIds: string[] = [];

--- a/tests/testing-mode.test.ts
+++ b/tests/testing-mode.test.ts
@@ -1232,6 +1232,27 @@ describe('TestWorker batch mode', () => {
     expect(returnValues).toEqual([2, 4, 6]);
   });
 
+  it('flushes a partial batch after batch.timeout', async () => {
+    queue = new TestQueue('batch-timeout');
+    const batchSizes: number[] = [];
+
+    await queue.add('a', { i: 1 });
+    await queue.add('b', { i: 2 });
+
+    worker = new TestWorker(
+      queue,
+      async (jobs: TestJob[]) => {
+        batchSizes.push(jobs.length);
+        return jobs.map(() => 'ok');
+      },
+      { batch: { size: 5, timeout: 50 } },
+    );
+
+    await waitFor(async () => (await queue.getJobCounts()).completed === 2, 2000, 20);
+    expect(batchSizes).toEqual([2]);
+    expect((await queue.getJobs('waiting')).length).toBe(0);
+  });
+
   it('emits active and completed events per job', async () => {
     queue = new TestQueue('batch-events');
     const activeIds: string[] = [];

--- a/tests/testworker-batch-flush.test.ts
+++ b/tests/testworker-batch-flush.test.ts
@@ -1,0 +1,127 @@
+/**
+ * TestWorker batch.timeout leftover/drain/close paths.
+ * Lives outside tests/testing-mode.test.ts so integration coverage collects it.
+ *
+ * Run: npx vitest run tests/testworker-batch-flush.test.ts
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { TestQueue, TestWorker, TestJob } from '../src/testing';
+import { waitFor } from './helpers/fixture';
+
+describe('TestWorker pending batch flush', () => {
+  let queue: TestQueue;
+  let worker: TestWorker;
+
+  afterEach(async () => {
+    if (worker) await worker.close();
+    if (queue) await queue.close();
+  });
+
+  it('flushes a partial batch after batch.timeout', async () => {
+    queue = new TestQueue('cov-batch-timeout');
+    const batchSizes: number[] = [];
+
+    await queue.add('a', { i: 1 });
+    await queue.add('b', { i: 2 });
+
+    worker = new TestWorker(
+      queue,
+      async (jobs: TestJob[]) => {
+        batchSizes.push(jobs.length);
+        return jobs.map(() => 'ok');
+      },
+      { batch: { size: 5, timeout: 50 } },
+    );
+
+    await waitFor(async () => (await queue.getJobCounts()).completed === 2, 2000, 20);
+    expect(batchSizes).toEqual([2]);
+  });
+
+  it('flushes leftover pending jobs after a full batch takes only part of them', async () => {
+    queue = new TestQueue('cov-batch-remainder');
+    const batchSizes: number[] = [];
+
+    await queue.addBulk([
+      { name: 'a', data: { i: 1 } },
+      { name: 'b', data: { i: 2 } },
+      { name: 'c', data: { i: 3 } },
+      { name: 'd', data: { i: 4 } },
+    ]);
+
+    worker = new TestWorker(
+      queue,
+      async (jobs: TestJob[]) => {
+        batchSizes.push(jobs.length);
+        return jobs.map(() => 'ok');
+      },
+      { batch: { size: 5, timeout: 50 } },
+    );
+
+    await waitFor(async () => (await queue.getJobCounts()).waiting === 4, 500, 10);
+    await queue.addBulk([
+      { name: 'e', data: { i: 5 } },
+      { name: 'f', data: { i: 6 } },
+      { name: 'g', data: { i: 7 } },
+      { name: 'h', data: { i: 8 } },
+    ]);
+
+    await waitFor(async () => (await queue.getJobCounts()).completed === 8, 2000, 20);
+    expect(batchSizes).toEqual([5, 3]);
+  });
+
+  it('does not process a pending batch after drain()', async () => {
+    queue = new TestQueue('cov-batch-drain');
+    const batchSizes: number[] = [];
+
+    await queue.add('a', { i: 1 });
+    await queue.add('b', { i: 2 });
+
+    worker = new TestWorker(
+      queue,
+      async (jobs: TestJob[]) => {
+        batchSizes.push(jobs.length);
+        return jobs.map(() => 'ok');
+      },
+      { batch: { size: 5, timeout: 80 } },
+    );
+
+    await waitFor(async () => (await queue.getJobCounts()).waiting === 2, 500, 10);
+    await queue.drain();
+    await new Promise((r) => setTimeout(r, 150));
+    expect(batchSizes).toEqual([]);
+    expect((await queue.getJobCounts()).completed).toBe(0);
+  });
+
+  it('hands a closing worker pending batch to remaining workers', async () => {
+    queue = new TestQueue('cov-batch-close-handoff');
+    const batchSizes: number[] = [];
+
+    await queue.add('a', { i: 1 });
+    await queue.add('b', { i: 2 });
+
+    worker = new TestWorker(
+      queue,
+      async () => {
+        throw new Error('closing worker should not flush');
+      },
+      { batch: { size: 5, timeout: 5000 } },
+    );
+
+    await waitFor(async () => (await queue.getJobCounts()).waiting === 2, 500, 10);
+
+    const peer = new TestWorker(
+      queue,
+      async (jobs: TestJob[]) => {
+        batchSizes.push(jobs.length);
+        return jobs.map(() => 'ok');
+      },
+      { batch: { size: 5, timeout: 50 } },
+    );
+
+    await worker.close();
+    worker = peer;
+
+    await waitFor(async () => (await queue.getJobCounts()).completed === 2, 2000, 20);
+    expect(batchSizes).toEqual([2]);
+  });
+});

--- a/tests/testworker-batch-flush.test.ts
+++ b/tests/testworker-batch-flush.test.ts
@@ -124,4 +124,92 @@ describe('TestWorker pending batch flush', () => {
     await waitFor(async () => (await queue.getJobCounts()).completed === 2, 2000, 20);
     expect(batchSizes).toEqual([2]);
   });
+
+  it('does not execute drained jobs when later adds fill the batch', async () => {
+    queue = new TestQueue('cov-batch-drain-fill');
+    const processed: number[] = [];
+
+    await queue.add('a', { i: 1 });
+    await queue.add('b', { i: 2 });
+
+    worker = new TestWorker(
+      queue,
+      async (jobs: TestJob[]) => {
+        processed.push(...jobs.map((j) => (j.data as { i: number }).i));
+        return jobs.map(() => 'ok');
+      },
+      { batch: { size: 5, timeout: 5000 } },
+    );
+
+    await waitFor(async () => (await queue.getJobCounts()).waiting === 2, 500, 10);
+    await queue.drain();
+    await queue.addBulk([
+      { name: 'c', data: { i: 3 } },
+      { name: 'd', data: { i: 4 } },
+      { name: 'e', data: { i: 5 } },
+      { name: 'f', data: { i: 6 } },
+      { name: 'g', data: { i: 7 } },
+    ]);
+
+    await waitFor(async () => (await queue.getJobCounts()).completed === 5, 2000, 20);
+    expect(processed.sort((a, b) => a - b)).toEqual([3, 4, 5, 6, 7]);
+  });
+
+  it('does not hand drained pending jobs to a peer on close', async () => {
+    queue = new TestQueue('cov-batch-drain-close');
+    const processed: number[] = [];
+
+    await queue.add('a', { i: 1 });
+    await queue.add('b', { i: 2 });
+
+    worker = new TestWorker(
+      queue,
+      async () => {
+        throw new Error('closing worker should not flush');
+      },
+      { batch: { size: 5, timeout: 5000 } },
+    );
+
+    await waitFor(async () => (await queue.getJobCounts()).waiting === 2, 500, 10);
+    await queue.drain();
+
+    const peer = new TestWorker(
+      queue,
+      async (jobs: TestJob[]) => {
+        processed.push(...jobs.map((j) => (j.data as { i: number }).i));
+        return jobs.map(() => 'ok');
+      },
+      { batch: { size: 5, timeout: 50 } },
+    );
+
+    await worker.close();
+    worker = peer;
+    await new Promise((r) => setTimeout(r, 150));
+    expect(processed).toEqual([]);
+    expect((await queue.getJobCounts()).completed).toBe(0);
+  });
+
+  it('flushes reserved jobs on timeout but does not claim more while paused', async () => {
+    queue = new TestQueue('cov-batch-pause-fill');
+    const processed: number[] = [];
+
+    await queue.add('a', { i: 1 });
+    await queue.add('b', { i: 2 });
+
+    worker = new TestWorker(
+      queue,
+      async (jobs: TestJob[]) => {
+        processed.push(...jobs.map((j) => (j.data as { i: number }).i));
+        return jobs.map(() => 'ok');
+      },
+      { batch: { size: 5, timeout: 50 } },
+    );
+
+    await waitFor(async () => (await queue.getJobCounts()).waiting === 2, 500, 10);
+    await queue.pause();
+    await queue.add('c', { i: 3 });
+    await waitFor(async () => (await queue.getJobCounts()).completed === 2, 2000, 20);
+    expect(processed.sort((a, b) => a - b)).toEqual([1, 2]);
+    expect((await queue.getJobCounts()).waiting).toBe(1);
+  });
 });


### PR DESCRIPTION
Companion review PR for TestWorker batch.timeout dropping shifted jobs.

## Summary
- `processAvailableBatch` shifts waiting jobs into a local array, starts `batch.timeout`, then returns
- `flushBatch()` re-read `waitingQueue`, which no longer held those jobs, so the partial batch never ran
- keep shifted jobs in `pendingBatch` and flush that array on timeout (or when it later fills)
- leftover jobs after a full flush get another timeout; drain drops records no longer in the queue; `close()` requeues pending work

## Red-first proof
The first commit is test-only. Against its parent, two jobs with `{ batch: { size: 5, timeout: 50 } }` never completed (`waitFor` timed out at 2000ms).

## Test plan
- [x] `npx vitest run tests/testing-mode.test.ts -t "flushes a partial batch"`
- [x] `npx vitest run tests/testing-mode.test.ts`
- [x] `npx vitest run tests/testworker-batch-flush.test.ts`


Made with [Cursor](https://cursor.com)