### PR TITLE
fix: do not park moveToWaitingChildren with zero deps

### DIFF
--- a/src/functions/glidemq.lua
+++ b/src/functions/glidemq.lua
@@ -3570,15 +3570,14 @@ redis.register_function('glidemq_moveToWaitingChildren', function(keys, args)
   local prefix = string.sub(jobKey, 1, #jobKey - #('job:' .. jobId))
   local depsKey = prefix .. 'deps:' .. jobId
   local totalDeps = redis.call('SCARD', depsKey)
-  if totalDeps > 0 then
-    local depsCompleted = tonumber(redis.call('HGET', jobKey, 'depsCompleted')) or 0
-    if depsCompleted >= totalDeps then
-      redis.call('HSET', jobKey, 'state', 'waiting')
-      xaddJob(streamKey, jobId, redis.call('HGET', jobKey, 'name'))
-      emitEvent(eventsKey, 'active', jobId, nil)
-      if entryId == '' then decrListActive(prefix .. 'list-active') end
-      return 'completed'
-    end
+  local depsCompleted = tonumber(redis.call('HGET', jobKey, 'depsCompleted')) or 0
+  -- totalDeps == 0 is already complete: do not park with no children to wait on.
+  if depsCompleted >= totalDeps then
+    redis.call('HSET', jobKey, 'state', 'waiting')
+    xaddJob(streamKey, jobId, redis.call('HGET', jobKey, 'name'))
+    emitEvent(eventsKey, 'active', jobId, nil)
+    if entryId == '' then decrListActive(prefix .. 'list-active') end
+    return 'completed'
   end
 
   if entryId == '' then decrListActive(prefix .. 'list-active') end

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -88,7 +88,8 @@ export const LIBRARY_NAME = 'glidemq';
 // Version 110: dedupe overlapping tree and DAG parent notifications per completion.
 // Version 119: integrate the reviewed correctness queue and preserve Queue.pause in the reservation-aware list pop.
 // Version 120: removeJob acknowledges a claimed FIFO entry in every stream consumer group before deleting it.
-export const LIBRARY_VERSION = '120';
+// Version 121: moveToWaitingChildren unparks immediately when no child deps exist.
+export const LIBRARY_VERSION = '121';
 
 // Consumer group name used by workers
 export const CONSUMER_GROUP = 'workers';

--- a/tests/waiting-children-empty.test.ts
+++ b/tests/waiting-children-empty.test.ts
@@ -1,0 +1,64 @@
+/**
+ * moveToWaitingChildren() with an empty deps set must not park forever.
+ *
+ * Lua ACK/XDELs, sets waiting-children, then only self-unblocks when
+ * SCARD(deps) > 0. Zero deps never XADD back, so the job is stuck.
+ *
+ * Run: npx vitest run tests/waiting-children-empty.test.ts
+ */
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import { createCleanupClient, describeEachMode, flushQueue, waitFor } from './helpers/fixture';
+
+const { Queue } = require('../dist/queue') as typeof import('../src/queue');
+const { Worker } = require('../dist/worker') as typeof import('../src/worker');
+
+describeEachMode('moveToWaitingChildren with zero deps', (CONNECTION) => {
+  let cleanupClient: any;
+  const queues: string[] = [];
+
+  function uniqueQueue(prefix: string): string {
+    const name = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    queues.push(name);
+    return name;
+  }
+
+  beforeAll(async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+  });
+
+  afterAll(async () => {
+    await Promise.all(queues.map((q) => flushQueue(cleanupClient, q).catch(() => {})));
+    cleanupClient.close();
+  });
+
+  it('requeues a job that waits on children before any child exists', async () => {
+    const Q = uniqueQueue('wtc-empty');
+    const queue = new Queue(Q, { connection: CONNECTION });
+    const job = await queue.add('parent', { n: 1 });
+
+    const parked = new Set<string>();
+    const worker = new Worker(
+      Q,
+      async (active) => {
+        if (!parked.has(active.id)) {
+          parked.add(active.id);
+          await active.moveToWaitingChildren();
+        }
+        return 'ok';
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 50, stalledInterval: 60_000 },
+    );
+    worker.on('error', () => {});
+
+    try {
+      await waitFor(async () => {
+        const state = await job.getState();
+        return state === 'completed' || state === 'failed' || state === 'waiting-children';
+      }, 4000, 50);
+      expect(await job.getState()).toBe('completed');
+    } finally {
+      await worker.close(true);
+      await queue.close();
+    }
+  }, 15000);
+});

--- a/tests/waiting-children-empty.test.ts
+++ b/tests/waiting-children-empty.test.ts
@@ -51,10 +51,14 @@ describeEachMode('moveToWaitingChildren with zero deps', (CONNECTION) => {
     worker.on('error', () => {});
 
     try {
-      await waitFor(async () => {
-        const state = await job.getState();
-        return state === 'completed' || state === 'failed' || state === 'waiting-children';
-      }, 4000, 50);
+      await waitFor(
+        async () => {
+          const state = await job.getState();
+          return state === 'completed' || state === 'failed' || state === 'waiting-children';
+        },
+        4000,
+        50,
+      );
       expect(await job.getState()).toBe('completed');
     } finally {
       await worker.close(true);


### PR DESCRIPTION
Companion review PR for empty-deps waiting-children parking.

## Summary
- `moveToWaitingChildren` only self-unblocked when `SCARD(deps) > 0`
- a processor that waited before registering children parked the job forever
- treat zero deps as already complete and requeue (`LIBRARY_VERSION` 121)

Note: this shares `LIBRARY_VERSION` 121 with the token-bucket idle-refill PR. The second of those to merge needs 122.

## Red-first proof
The first commit is test-only. Against its parent, `moveToWaitingChildren()` with no children left the job in `waiting-children`.

## Test plan
- [x] `npx vitest run tests/waiting-children-empty.test.ts`
- [x] `npx vitest run tests/waiting-children.test.ts`


Made with [Cursor](https://cursor.com)