### PR TITLE
chore: release v0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+---
+
+## [0.15.5] - 2026-08-29
+
 ### Fixed
 
 - **Reconnect rebuilt Scheduler without lockDuration**: after a connection error, stall reclaim fell back to 30s while heartbeats still used the worker lock, so healthy long jobs were redispatched.
@@ -19,6 +23,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Job removal and revocation scan the FIFO stream only when the waiting job was absent from both list-backed sources, avoiding unnecessary O(stream-length) work without orphaning stream entries whose legacy source fields are stale.
 - **Queue pause now expires suspended jobs**: `Queue.pause()` immediately sweeps suspended jobs whose timeouts have elapsed, so pausing does not leave expired human-in-the-loop jobs pending until the background sweep.
 - **Nested and DAG cross-queue parents could remain in `waiting-children`**: parent wiring now avoids cross-slot FCALLs, preserves nested parent hash fields, retries idempotent notifications from the child slot, reconciles removed children without recreating hashes, and ignores stale notifications for deleted parents. Completion returns newly queued cross-queue edges for eager delivery while deduplicating overlapping tree and DAG metadata.
+- Reconnected workers and workflow helpers retain live clients for the lifetime of returned jobs without leaking helper-owned connections.
+- List-job delay, suspend, resume, discard, explicit failure, and unrecoverable-error transitions now preserve terminal intent and the correct claim identity across chained resumes.
+- Token-bucket refill uses the Redis server clock consistently and normalizes legacy future timestamps, preventing idle buckets from remaining underfilled after caller-clock skew.
+- `TestWorker` partial batches flush after their timeout even when the batch never reaches its configured size.
+- Empty dependency sets no longer leave jobs stranded in `waiting-children`.
 
 ---
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -8,7 +8,7 @@
 - **Revoke/timeout safety**: revoked active jobs cannot complete; each batch job owns its abort signal, and timeouts remain retryable.
 - **Coverage CI**: fuzzer exclusion is quoted and integration/Lua uploads use Codecov OIDC (`id-token: write`, `use_oidc: true`).
 - **Pause sweep**: `Queue.pause()` immediately expires suspended jobs whose timeouts elapsed.
-- **Version**: 0.15.4 tagged and released on GitHub; npm publish is pending npm auth.
+- **Version**: 0.15.5 release candidate on `release/v0.15.5`; GitHub tag and npm publish pending merge.
 - **CI**: green across all six fork/upstream stack PRs after the 2026-08-22 packaging update.
 - **Ordered-group recovery**: retained rate-limit slots are tracked per job and released on terminal paths; oversized token-bucket heads are cleaned iteratively through bounded sweeps.
 - **Local branches**: `refactor/extract-lua-library` -> `ci/ts-coverage` -> `ci/lua-coverage`.
@@ -22,6 +22,8 @@
 ## What Was Done (0.15.x series since 0.14.0)
 
 ### Released
+
+- **0.15.5**: queue correctness and lifecycle fixes accumulated since 0.15.4, including pause/revoke/reclaim behavior, cross-queue parent completion, reconnect client lifetime, list-job resume semantics, token-bucket clock consistency, partial test-worker batch flushing, and empty-dependency waiting-children handling. `LIBRARY_VERSION` 122.
 
 - **0.15.0** (#192, #205): HTTP proxy parity expansion (queue events SSE, per-job lifecycle SSE, `jobs/wait`, workers, metrics, scheduler CRUD, rolling usage summary, broadcast publish/SSE, DLQ inspection/replay, suspended-job inspection, revoke, queue global rate-limit HTTP management). Flow HTTP API: `POST /flows`, `GET /flows/:id`, `GET /flows/:id/tree`, `DELETE /flows/:id` for tree flows and DAGs. `queue.getUsageSummary()` plus `/usage/summary`.
 - **0.15.1** (#206): debounce + ordering.key deadlock fix via lightweight skip markers. `LIBRARY_VERSION` 81.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glide-mq",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glide-mq",
-      "version": "0.15.4",
+      "version": "0.15.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@glidemq/speedkey": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glide-mq",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "High-performance message queue for Node.js with AI-native primitives - built on Valkey/Redis with Rust NAPI bindings",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- release accumulated queue correctness and lifecycle fixes as v0.15.5
- document the merged reconnect, workflow-helper, list-resume, token-bucket, batch-flush, and waiting-children fixes
- update package metadata and handover state

## Verification

- `npm ci`
- `npm run lint`
- `npm run build`
- `npm pack --dry-run`
- production dependency audit: 0 vulnerabilities
- pre-push fuzzer seed `1787955760`: TestMode 145 rounds, standalone 44 rounds, cluster 28 rounds

Note: the configured deslop CLI attempted to request an external API key and could not run non-interactively. This release-only diff was manually checked and contains only version, changelog, and handover metadata.