### PR TITLE
test: integration coverage gaps + proxy/SSE fixes (takeover of #280, by @jonathanong)

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- **Worktree coverage pass**: filling remaining TS coverage holes with live Valkey/proxy integration tests only (no mock unit padding). Source fixes: proxy `lockDuration` allowlist, `Job.getParents()` last-colon parse, proxy SSE loops exit on `draining`. TPM tests now align to the token window before asserting delay.
+- **Coverage PR**: `test/integration-coverage-gaps` (fork #25 / upstream #280) — rebased onto v0.15.5. Live Valkey/proxy integration tests only. Source fixes: proxy `lockDuration` allowlist, `Job.getParents()` last-colon parse, proxy SSE loops exit on `draining`, `getSharedClient` gated on drain.
 - **In flight**: rate-limited token-bucket promotion skips bounded tombstones and advances both ordered frontiers without stranding successors.
 - **Audit fix**: `fix/repeat-after-stalled` atomically advances repeat-after-complete schedulers during terminal stalled recovery.
 - **Branch**: `automation/cover-open-fixes-20260825` consolidates the reviewed correctness queue.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -2,6 +2,7 @@
 
 ## Current State
 
+- **Worktree coverage pass**: filling remaining TS coverage holes with live Valkey/proxy integration tests only (no mock unit padding). Source fixes: proxy `lockDuration` allowlist, `Job.getParents()` last-colon parse, proxy SSE loops exit on `draining`. TPM tests now align to the token window before asserting delay.
 - **In flight**: rate-limited token-bucket promotion skips bounded tombstones and advances both ordered frontiers without stranding successors.
 - **Audit fix**: `fix/repeat-after-stalled` atomically advances repeat-after-complete schedulers during terminal stalled recovery.
 - **Branch**: `automation/cover-open-fixes-20260825` consolidates the reviewed correctness queue.

--- a/src/job.ts
+++ b/src/job.ts
@@ -50,6 +50,19 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Parents SET members are `prefix:{queueName}:parentId` (Lua last-colon split).
+ * Also accept a plain `queueName:parentId` fallback.
+ */
+function parseParentsSetMember(member: string): { queue: string; id: string } | null {
+  const lastColon = member.lastIndexOf(':');
+  if (lastColon <= 0 || lastColon === member.length - 1) return null;
+  const id = member.substring(lastColon + 1);
+  const queuePart = member.substring(0, lastColon);
+  const tagged = /\{([^{}]+)\}$/.exec(queuePart);
+  return { queue: tagged ? tagged[1] : queuePart, id };
+}
+
 function parseStoredUsage(values: (unknown | null)[]): { bucketTs?: number; usage?: JobUsage } {
   const model = values[0] ? String(values[0]) : undefined;
   const provider = values[1] ? String(values[1]) : undefined;
@@ -609,15 +622,8 @@ export class Job<D = any, R = any> {
     const members = await this.client.smembers(parentsKey);
     if (members && members.size > 0) {
       for (const member of members) {
-        const memberStr = String(member);
-        // Format: "queue:parentId"
-        const sepIdx = memberStr.indexOf(':');
-        if (sepIdx !== -1) {
-          result.push({
-            queue: memberStr.substring(0, sepIdx),
-            id: memberStr.substring(sepIdx + 1),
-          });
-        }
+        const parsed = parseParentsSetMember(String(member));
+        if (parsed) result.push(parsed);
       }
       return result;
     }

--- a/src/job.ts
+++ b/src/job.ts
@@ -983,7 +983,9 @@ export class Job<D = any, R = any> {
       hash['usage:costs'] ||
       hash['usage:totalTokens'] ||
       hash['usage:totalCost'] ||
-      hash['usage:costUnit']
+      hash['usage:costUnit'] ||
+      hash['usage:cached'] ||
+      hash['usage:latencyMs']
     ) {
       let cached: boolean | undefined;
       if (hash['usage:cached'] === '1') cached = true;

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -575,9 +575,15 @@ function validateJobOpts(
 }
 
 function validateFlowJobOpts(flow: FlowJob, path = 'flow'): string | null {
+  if (!flow || typeof flow !== 'object' || Array.isArray(flow)) {
+    return `${path} must be an object`;
+  }
   const error = validateJobOpts(flow.opts as Record<string, unknown> | undefined, `${path}.`);
   if (error) return error;
   const children = flow.children ?? [];
+  if (!Array.isArray(children)) {
+    return `${path}.children must be an array`;
+  }
   for (let i = 0; i < children.length; i++) {
     const childError = validateFlowJobOpts(children[i], `${path}.children[${i}]`);
     if (childError) return childError;
@@ -586,8 +592,18 @@ function validateFlowJobOpts(flow: FlowJob, path = 'flow'): string | null {
 }
 
 function validateDagJobOpts(dag: DAGFlow): string | null {
+  if (!dag || typeof dag !== 'object' || Array.isArray(dag)) {
+    return 'dag must be an object';
+  }
+  if (!Array.isArray(dag.nodes)) {
+    return 'dag.nodes must be an array';
+  }
   for (let i = 0; i < dag.nodes.length; i++) {
-    const error = validateJobOpts(dag.nodes[i].opts as Record<string, unknown> | undefined, `dag.nodes[${i}].`);
+    const node = dag.nodes[i];
+    if (!node || typeof node !== 'object' || Array.isArray(node)) {
+      return `dag.nodes[${i}] must be an object`;
+    }
+    const error = validateJobOpts(node.opts as Record<string, unknown> | undefined, `dag.nodes[${i}].`);
     if (error) return error;
   }
   return null;
@@ -626,6 +642,7 @@ export function createRoutes(
   let closed = false;
   let sharedClient: Client | null = null;
   let sharedClientOwned = false;
+  let sharedClientInit: Promise<Client> | null = null;
 
   function requireConnection(feature: string) {
     if (!opts.connection) {
@@ -647,18 +664,36 @@ export function createRoutes(
     if (!opts.connection) {
       throw httpError(500, 'Proxy requires either `client` or `connection`');
     }
-    const client = await createClient(opts.connection);
-    if (draining || closed) {
-      try {
-        client.close();
-      } catch {
-        /* ignore close errors on shutdown */
+    if (sharedClientInit) return sharedClientInit;
+
+    sharedClientInit = (async () => {
+      const client = await createClient(opts.connection!);
+      if (draining || closed) {
+        try {
+          client.close();
+        } catch {
+          /* ignore close errors on shutdown */
+        }
+        throw httpError(503, 'Proxy is shutting down');
       }
-      throw httpError(503, 'Proxy is shutting down');
+      if (sharedClient) {
+        try {
+          client.close();
+        } catch {
+          /* ignore close errors on shutdown */
+        }
+        return sharedClient;
+      }
+      sharedClient = client;
+      sharedClientOwned = true;
+      return sharedClient;
+    })();
+
+    try {
+      return await sharedClientInit;
+    } finally {
+      sharedClientInit = null;
     }
-    sharedClient = client;
-    sharedClientOwned = true;
-    return sharedClient;
   }
 
   function assertAllowedFlowQueues(queueNames: Iterable<string>): void {

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -486,6 +486,7 @@ function validateJobOpts(
     'cost',
     'lifo',
     'lockDuration',
+    'fallbacks',
     ...(options?.allowWaitTimeout ? (['waitTimeout'] as const) : []),
   ]);
   for (const key of Object.keys(optsIn)) {

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -615,6 +615,9 @@ export function createRoutes(
   }
 
   async function getSharedClient(): Promise<Client> {
+    if (draining || closed) {
+      throw httpError(503, 'Proxy is shutting down');
+    }
     if (sharedClient) return sharedClient;
     if (opts.client) {
       sharedClient = opts.client;
@@ -624,7 +627,16 @@ export function createRoutes(
     if (!opts.connection) {
       throw httpError(500, 'Proxy requires either `client` or `connection`');
     }
-    sharedClient = await createClient(opts.connection);
+    const client = await createClient(opts.connection);
+    if (draining || closed) {
+      try {
+        client.close();
+      } catch {
+        /* ignore close errors on shutdown */
+      }
+      throw httpError(503, 'Proxy is shutting down');
+    }
+    sharedClient = client;
     sharedClientOwned = true;
     return sharedClient;
   }
@@ -2148,8 +2160,21 @@ export function createRoutes(
     });
   });
 
+  function closeOwnedSharedClient(): void {
+    if (!sharedClientOwned || !sharedClient) return;
+    const client = sharedClient;
+    sharedClient = null;
+    sharedClientOwned = false;
+    try {
+      client.close();
+    } catch {
+      /* ignore close errors on shutdown */
+    }
+  }
+
   async function closeQueues(): Promise<void> {
     draining = true;
+    closed = true;
 
     for (const closeConnection of Array.from(activeQueueEventClosers)) {
       closeConnection();
@@ -2159,41 +2184,34 @@ export function createRoutes(
     const streams = [...broadcastStreams.values()];
     const queues = [...queueCache.values()];
     const broadcasts = [...broadcastCache.values()];
-    const client = sharedClient;
-    const clientOwned = sharedClientOwned;
 
     queueCache.clear();
     broadcastCache.clear();
     broadcastStreams.clear();
-    sharedClient = null;
-    sharedClientOwned = false;
-    closed = true;
 
     const shutdown = async () => {
       await Promise.allSettled(pendingInits);
       await Promise.allSettled(streams.map((stream) => stream.close()));
       await Promise.allSettled(queues.map((queue) => queue.close()));
       await Promise.allSettled(broadcasts.map((broadcast) => broadcast.close()));
-      if (clientOwned && client) {
-        try {
-          client.close();
-        } catch {
-          /* ignore close errors on shutdown */
-        }
-      }
+      closeOwnedSharedClient();
     };
 
     let timer: ReturnType<typeof setTimeout> | undefined;
-    try {
-      await Promise.race([
-        shutdown(),
-        new Promise<void>((resolve) => {
-          timer = setTimeout(resolve, 3000);
-          timer.unref();
-        }),
-      ]);
-    } finally {
-      if (timer) clearTimeout(timer);
+    const winner = await Promise.race([
+      shutdown().then(() => 'done' as const),
+      new Promise<'timeout'>((resolve) => {
+        timer = setTimeout(() => resolve('timeout'), 3000);
+        timer.unref();
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+
+    if (winner === 'timeout') {
+      for (const stream of streams) void stream.close();
+      for (const queue of queues) void queue.close();
+      for (const broadcast of broadcasts) void broadcast.close();
+      closeOwnedSharedClient();
     }
   }
 

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -1763,6 +1763,9 @@ export function createRoutes(
 
   router.post('/flows', async (req: Request, res: Response) => {
     try {
+      if (draining || closed) {
+        throw httpError(503, 'Proxy is shutting down');
+      }
       const body = req.body as { budget?: BudgetOptions; dag?: DAGFlow; flow?: FlowJob } | undefined;
 
       if (!body || (!!body.flow && !!body.dag) || (!body.flow && !body.dag)) {
@@ -2136,6 +2139,9 @@ export function createRoutes(
       }
       const matcher = compileSubjectMatcher(parseCsvQuery(req, 'subjects'));
       const stream = await getSharedBroadcastStream(param(req, 'name'), subscription);
+      if (draining || closed || stream.closing) {
+        throw httpError(503, 'Proxy is shutting down');
+      }
 
       startSse(res);
       writeSseComment(res, 'connected');

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -573,6 +573,25 @@ function validateJobOpts(
   return null;
 }
 
+function validateFlowJobOpts(flow: FlowJob, path = 'flow'): string | null {
+  const error = validateJobOpts(flow.opts as Record<string, unknown> | undefined, `${path}.`);
+  if (error) return error;
+  const children = flow.children ?? [];
+  for (let i = 0; i < children.length; i++) {
+    const childError = validateFlowJobOpts(children[i], `${path}.children[${i}]`);
+    if (childError) return childError;
+  }
+  return null;
+}
+
+function validateDagJobOpts(dag: DAGFlow): string | null {
+  for (let i = 0; i < dag.nodes.length; i++) {
+    const error = validateJobOpts(dag.nodes[i].opts as Record<string, unknown> | undefined, `dag.nodes[${i}].`);
+    if (error) return error;
+  }
+  return null;
+}
+
 /**
  * Create an Express Router with all proxy endpoints.
  *
@@ -1770,6 +1789,11 @@ export function createRoutes(
 
       if (!body || (!!body.flow && !!body.dag) || (!body.flow && !body.dag)) {
         throw httpError(400, 'Body must include exactly one of: flow, dag');
+      }
+
+      const nestedOptsError = body.flow ? validateFlowJobOpts(body.flow) : validateDagJobOpts(body.dag!);
+      if (nestedOptsError) {
+        throw httpError(400, nestedOptsError);
       }
 
       const producer = new FlowProducer({

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -226,6 +226,18 @@ function writeSse(res: Response, data: unknown, opts?: { event?: string; id?: st
   res.write(chunk);
 }
 
+function writeStreamEntries(
+  res: Response,
+  entries: { id: string; fields: Record<string, string> }[],
+): string | undefined {
+  let lastId: string | undefined;
+  for (const entry of entries) {
+    writeSse(res, entry.fields, { id: entry.id });
+    lastId = entry.id;
+  }
+  return lastId;
+}
+
 function writeSseComment(res: Response, comment = 'keepalive'): void {
   res.write(`: ${comment}\n\n`);
 }
@@ -1276,19 +1288,15 @@ export function createRoutes(
 
       while (!connectionClosed && !draining) {
         const entries = await queue.readStream(jobId, { count: 100, lastId });
-        for (const entry of entries) {
-          writeSse(res, entry.fields, { id: entry.id });
-          lastId = entry.id;
-        }
+        const latest = writeStreamEntries(res, entries);
+        if (latest) lastId = latest;
 
         const job = await queue.getJob(jobId);
         if (!job) break;
         const state = await job.getState();
         if (state === 'completed' || state === 'failed') {
           const trailing = await queue.readStream(jobId, { count: 100, lastId });
-          for (const entry of trailing) {
-            writeSse(res, entry.fields, { id: entry.id });
-          }
+          writeStreamEntries(res, trailing);
           break;
         }
 

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -2147,22 +2147,12 @@ export function createRoutes(
       closeConnection();
     }
 
-    const shutdown = async () => {
-      await Promise.allSettled(Array.from(queueInitMap.values()));
-      await Promise.allSettled(Array.from(broadcastInitMap.values()));
-      await Promise.allSettled(Array.from(broadcastStreams.values()).map((stream) => stream.close()));
-      await Promise.allSettled(Array.from(queueCache.values()).map((queue) => queue.close()));
-      await Promise.allSettled(Array.from(broadcastCache.values()).map((broadcast) => broadcast.close()));
-      if (sharedClientOwned && sharedClient) {
-        try {
-          sharedClient.close();
-        } catch {
-          /* ignore close errors on shutdown */
-        }
-      }
-    };
-
-    await Promise.race([shutdown(), new Promise<void>((resolve) => setTimeout(resolve, 3000))]);
+    const pendingInits = [...queueInitMap.values(), ...broadcastInitMap.values()];
+    const streams = [...broadcastStreams.values()];
+    const queues = [...queueCache.values()];
+    const broadcasts = [...broadcastCache.values()];
+    const client = sharedClient;
+    const clientOwned = sharedClientOwned;
 
     queueCache.clear();
     broadcastCache.clear();
@@ -2170,6 +2160,33 @@ export function createRoutes(
     sharedClient = null;
     sharedClientOwned = false;
     closed = true;
+
+    const shutdown = async () => {
+      await Promise.allSettled(pendingInits);
+      await Promise.allSettled(streams.map((stream) => stream.close()));
+      await Promise.allSettled(queues.map((queue) => queue.close()));
+      await Promise.allSettled(broadcasts.map((broadcast) => broadcast.close()));
+      if (clientOwned && client) {
+        try {
+          client.close();
+        } catch {
+          /* ignore close errors on shutdown */
+        }
+      }
+    };
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        shutdown(),
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, 3000);
+          timer.unref();
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   return { router, closeQueues };

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -473,6 +473,7 @@ function validateJobOpts(
     'ordering',
     'cost',
     'lifo',
+    'lockDuration',
     ...(options?.allowWaitTimeout ? (['waitTimeout'] as const) : []),
   ]);
   for (const key of Object.keys(optsIn)) {
@@ -896,7 +897,7 @@ export function createRoutes(
           }
         }
         stream.clients.clear();
-        await stream.worker.close();
+        await stream.worker.close(true);
       },
     };
 
@@ -1273,7 +1274,7 @@ export function createRoutes(
         connectionClosed = true;
       });
 
-      while (!connectionClosed) {
+      while (!connectionClosed && !draining) {
         const entries = await queue.readStream(jobId, { count: 100, lastId });
         for (const entry of entries) {
           writeSse(res, entry.fields, { id: entry.id });
@@ -1343,7 +1344,7 @@ export function createRoutes(
       startSse(res);
       writeSseComment(res, 'connected');
 
-      while (!connectionClosed) {
+      while (!connectionClosed && !draining) {
         let result;
         try {
           result = await client.xread({ [keys.events]: lastId }, { block: SSE_BLOCK_MS, count: 100 });
@@ -1441,7 +1442,7 @@ export function createRoutes(
       startSse(res);
       writeSseComment(res, 'connected');
 
-      while (!connectionClosed) {
+      while (!connectionClosed && !draining) {
         let result;
         try {
           result = await client.xread({ [keys.events]: lastId }, { block: SSE_BLOCK_MS, count: 100 });
@@ -2146,18 +2147,22 @@ export function createRoutes(
       closeConnection();
     }
 
-    await Promise.allSettled(Array.from(queueInitMap.values()));
-    await Promise.allSettled(Array.from(broadcastInitMap.values()));
-    await Promise.allSettled(Array.from(broadcastStreams.values()).map((stream) => stream.close()));
-    await Promise.allSettled(Array.from(queueCache.values()).map((queue) => queue.close()));
-    await Promise.allSettled(Array.from(broadcastCache.values()).map((broadcast) => broadcast.close()));
-    if (sharedClientOwned && sharedClient) {
-      try {
-        sharedClient.close();
-      } catch {
-        /* ignore close errors on shutdown */
+    const shutdown = async () => {
+      await Promise.allSettled(Array.from(queueInitMap.values()));
+      await Promise.allSettled(Array.from(broadcastInitMap.values()));
+      await Promise.allSettled(Array.from(broadcastStreams.values()).map((stream) => stream.close()));
+      await Promise.allSettled(Array.from(queueCache.values()).map((queue) => queue.close()));
+      await Promise.allSettled(Array.from(broadcastCache.values()).map((broadcast) => broadcast.close()));
+      if (sharedClientOwned && sharedClient) {
+        try {
+          sharedClient.close();
+        } catch {
+          /* ignore close errors on shutdown */
+        }
       }
-    }
+    };
+
+    await Promise.race([shutdown(), new Promise<void>((resolve) => setTimeout(resolve, 3000))]);
 
     queueCache.clear();
     broadcastCache.clear();

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -893,10 +893,16 @@ export function createRoutes(
   }
 
   async function getSharedBroadcastStream(name: string, subscription: string): Promise<SharedBroadcastStream> {
+    if (draining || closed) {
+      throw httpError(503, 'Proxy is shutting down');
+    }
     const cacheKey = `${name}\u0000${subscription}`;
     const cached = broadcastStreams.get(cacheKey);
     if (cached) {
       await cached.ready;
+      if (draining || closed) {
+        throw httpError(503, 'Proxy is shutting down');
+      }
       return cached;
     }
 
@@ -955,16 +961,25 @@ export function createRoutes(
       errorHandler(err, name);
     });
 
+    if (draining || closed) {
+      await worker.close(true).catch(() => undefined);
+      throw httpError(503, 'Proxy is shutting down');
+    }
+
     stream.worker = worker;
     stream.ready = worker.waitUntilReady();
     broadcastStreams.set(cacheKey, stream);
 
     try {
       await stream.ready;
+      if (draining || closed) {
+        await stream.close();
+        throw httpError(503, 'Proxy is shutting down');
+      }
       return stream;
     } catch (err) {
       broadcastStreams.delete(cacheKey);
-      await worker.close().catch(() => undefined);
+      await worker.close(true).catch(() => undefined);
       throw err;
     }
   }

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -1514,6 +1514,8 @@ export function createRoutes(
           }
         }
       }
+
+      closeConnection();
     } catch (err) {
       closeConnection?.();
       if (!res.headersSent) {

--- a/src/proxy/routes.ts
+++ b/src/proxy/routes.ts
@@ -676,14 +676,6 @@ export function createRoutes(
         }
         throw httpError(503, 'Proxy is shutting down');
       }
-      if (sharedClient) {
-        try {
-          client.close();
-        } catch {
-          /* ignore close errors on shutdown */
-        }
-        return sharedClient;
-      }
       sharedClient = client;
       sharedClientOwned = true;
       return sharedClient;

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -56,6 +56,8 @@ export interface AddJobRequest {
     | 'ordering'
     | 'cost'
     | 'lifo'
+    | 'lockDuration'
+    | 'fallbacks'
   >;
 }
 

--- a/tests/add-and-wait.test.ts
+++ b/tests/add-and-wait.test.ts
@@ -1,5 +1,5 @@
 import { it, expect, beforeAll, afterAll } from 'vitest';
-import { describeEachMode, createCleanupClient, flushQueue } from './helpers/fixture';
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
 
 const { Queue } = require('../dist/queue') as typeof import('../src/queue');
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
@@ -124,7 +124,7 @@ describeEachMode('Queue.addAndWait', (CONNECTION) => {
     const pending = expect(queue.addAndWait('slow', { value: 1 }, { waitTimeout: 10000, jobId })).rejects.toThrow(
       /revoked/,
     );
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await waitFor(async () => (await queue.getJob(jobId)) !== null, 5000);
     const status = await queue.revoke(jobId);
     expect(status).toBe('revoked');
     await pending;

--- a/tests/add-and-wait.test.ts
+++ b/tests/add-and-wait.test.ts
@@ -115,4 +115,21 @@ describeEachMode('Queue.addAndWait', (CONNECTION) => {
     await expect(pending).rejects.toThrow(/Queue is closing/);
     await flushQueue(cleanupClient, qName);
   }, 15000);
+
+  it('rejects in-flight addAndWait when the job is revoked', async () => {
+    const qName = `test-add-and-wait-revoke-${Date.now()}`;
+    const queue = new Queue(qName, { connection: CONNECTION });
+    const jobId = `revoke-wait-${Date.now()}`;
+
+    const pending = expect(queue.addAndWait('slow', { value: 1 }, { waitTimeout: 10000, jobId })).rejects.toThrow(
+      /revoked/,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    const status = await queue.revoke(jobId);
+    expect(status).toBe('revoked');
+    await pending;
+
+    await queue.close();
+    await flushQueue(cleanupClient, qName);
+  }, 15000);
 });

--- a/tests/ai-metadata.test.ts
+++ b/tests/ai-metadata.test.ts
@@ -593,7 +593,8 @@ describeEachMode('AI Metadata integration', (CONNECTION) => {
     expect(fetched).not.toBeNull();
 
     await fetched!.reportUsage({ cached: true });
-    expect(fetched!.usage?.cached).toBe(true);
+    const afterCached = await queue.getJob(added.id);
+    expect(afterCached?.usage?.cached).toBe(true);
 
     await Promise.all([
       fetched!.reportUsage({ tokens: { input: 1 } }),
@@ -601,7 +602,8 @@ describeEachMode('AI Metadata integration', (CONNECTION) => {
       fetched!.reportUsage({ tokens: { input: 3 } }),
     ]);
     const after = await queue.getJob(added.id);
-    expect(after?.usage?.tokens?.input).toBeGreaterThan(0);
+    // reportUsage last-write-wins (full hash replace), it does not sum concurrent token fields.
+    expect([1, 2, 3]).toContain(after?.usage?.tokens?.input);
 
     await expect(queue.getUsageSummary({ endTime: -1 })).rejects.toThrow('endTime');
     await expect(queue.getUsageSummary({ windowMs: 0 })).rejects.toThrow('windowMs');

--- a/tests/ai-metadata.test.ts
+++ b/tests/ai-metadata.test.ts
@@ -557,11 +557,57 @@ describeEachMode('AI Metadata integration', (CONNECTION) => {
           windowMs: 30 * 24 * 60 * 60 * 1000,
         }),
       ).rejects.toThrow('usage summary request exceeds maximum bucket reads');
+
+      const discovered = await summaryQueue.getUsageSummary({ windowMs: 5 * 60 * 1000 });
+      expect(discovered.queues).toEqual(expect.arrayContaining([summaryQueueName, summaryOtherQueueName]));
+      expect(discovered.jobCount).toBeGreaterThanOrEqual(2);
+      expect(discovered.totalTokens).toBeGreaterThanOrEqual(75);
+
+      const staticSummary = await QueueImpl.getUsageSummary({
+        connection: CONNECTION,
+        queues: [summaryQueueName],
+        windowMs: 5 * 60 * 1000,
+      });
+      expect(staticSummary.queues).toEqual([summaryQueueName]);
+      expect(staticSummary.jobCount).toBe(1);
+      expect(staticSummary.totalTokens).toBe(50);
+
+      const futureWindow = await summaryQueue.getUsageSummary({
+        queues: [summaryQueueName],
+        startTime: Date.now() + 60_000,
+        endTime: Date.now() + 120_000,
+      });
+      expect(futureWindow.jobCount).toBe(0);
+      expect(futureWindow.totalTokens).toBe(0);
     } finally {
       await summaryQueue.close();
       await summaryOtherQueue.close();
       await flushQueue(cleanupClient, summaryQueueName);
       await flushQueue(cleanupClient, summaryOtherQueueName);
     }
+  });
+
+  it('reportUsage with only cached and concurrent updates round-trip', async () => {
+    const added = await queue.add('cached-only', { prompt: 'x' });
+    const fetched = await queue.getJob(added.id);
+    expect(fetched).not.toBeNull();
+
+    await fetched!.reportUsage({ cached: true });
+    expect(fetched!.usage?.cached).toBe(true);
+
+    await Promise.all([
+      fetched!.reportUsage({ tokens: { input: 1 } }),
+      fetched!.reportUsage({ tokens: { input: 2 } }),
+      fetched!.reportUsage({ tokens: { input: 3 } }),
+    ]);
+    const after = await queue.getJob(added.id);
+    expect(after?.usage?.tokens?.input).toBeGreaterThan(0);
+
+    await expect(queue.getUsageSummary({ endTime: -1 })).rejects.toThrow('endTime');
+    await expect(queue.getUsageSummary({ windowMs: 0 })).rejects.toThrow('windowMs');
+    await expect(queue.getUsageSummary({ startTime: -1 })).rejects.toThrow('startTime');
+    await expect(
+      queue.getUsageSummary({ startTime: Date.now() + 10_000, endTime: Date.now() }),
+    ).rejects.toThrow('less than or equal');
   });
 });

--- a/tests/ai-metadata.test.ts
+++ b/tests/ai-metadata.test.ts
@@ -306,6 +306,28 @@ describe('Job.fromHash usage parsing', () => {
     expect(job.usage?.cached).toBe(true);
   });
 
+  it('parses usage when only cached is present', () => {
+    const hash: Record<string, string> = {
+      name: 'llm-call',
+      data: '{}',
+      opts: '{}',
+      'usage:cached': '1',
+    };
+
+    const job = Job.fromHash(mockClient as any, keys, '1', hash);
+    expect(job.usage).toEqual({
+      model: undefined,
+      provider: undefined,
+      tokens: undefined,
+      totalTokens: undefined,
+      costs: undefined,
+      totalCost: undefined,
+      costUnit: undefined,
+      latencyMs: undefined,
+      cached: true,
+    });
+  });
+
   it('returns undefined usage when no usage fields present', () => {
     const hash: Record<string, string> = {
       name: 'llm-call',

--- a/tests/ai-metadata.test.ts
+++ b/tests/ai-metadata.test.ts
@@ -328,6 +328,19 @@ describe('Job.fromHash usage parsing', () => {
     });
   });
 
+  it('parses usage when only latencyMs is present', () => {
+    const hash: Record<string, string> = {
+      name: 'llm-call',
+      data: '{}',
+      opts: '{}',
+      'usage:latencyMs': '42',
+    };
+
+    const job = Job.fromHash(mockClient as any, keys, '1', hash);
+    expect(job.usage?.latencyMs).toBe(42);
+    expect(job.usage?.cached).toBeUndefined();
+  });
+
   it('returns undefined usage when no usage fields present', () => {
     const hash: Record<string, string> = {
       name: 'llm-call',

--- a/tests/ai-metadata.test.ts
+++ b/tests/ai-metadata.test.ts
@@ -606,8 +606,8 @@ describeEachMode('AI Metadata integration', (CONNECTION) => {
     await expect(queue.getUsageSummary({ endTime: -1 })).rejects.toThrow('endTime');
     await expect(queue.getUsageSummary({ windowMs: 0 })).rejects.toThrow('windowMs');
     await expect(queue.getUsageSummary({ startTime: -1 })).rejects.toThrow('startTime');
-    await expect(
-      queue.getUsageSummary({ startTime: Date.now() + 10_000, endTime: Date.now() }),
-    ).rejects.toThrow('less than or equal');
+    await expect(queue.getUsageSummary({ startTime: Date.now() + 10_000, endTime: Date.now() })).rejects.toThrow(
+      'less than or equal',
+    );
   });
 });

--- a/tests/batch.test.ts
+++ b/tests/batch.test.ts
@@ -148,6 +148,15 @@ describeEachMode('addBulk batch pipelining', (CONNECTION) => {
     expect(jobs).toHaveLength(2);
     expect(jobs.map((j) => j.name).sort()).toEqual(['dedup-first', 'dedup-second-key']);
   });
+
+  it('addBulk rejects invalid ttl and lockDuration', async () => {
+    await expect(queue.addBulk([{ name: 'ttl', data: {}, opts: { ttl: -1 } }])).rejects.toThrow(
+      'ttl must be a non-negative finite number',
+    );
+    await expect(queue.addBulk([{ name: 'lock', data: {}, opts: { lockDuration: 1 } }])).rejects.toThrow(
+      'lockDuration must be a finite number',
+    );
+  });
 });
 
 describeEachMode('addBulk batch - worker processing', (CONNECTION) => {

--- a/tests/broadcast.test.ts
+++ b/tests/broadcast.test.ts
@@ -321,7 +321,10 @@ describeEachMode('Broadcast fan-out', (CONNECTION) => {
     await broadcast.publish('a', { n: 2 });
     await waitFor(() => completed === 2, 8000);
     expect(maxInFlight).toBe(1);
-    await Promise.race([drainedP, new Promise<void>((resolve) => setTimeout(resolve, 2000))]);
+    await Promise.race([
+      drainedP,
+      new Promise<void>((_, reject) => setTimeout(() => reject(new Error('Timed out waiting for drained')), 2000)),
+    ]);
 
     await worker.close(true);
     await broadcast.close();

--- a/tests/broadcast.test.ts
+++ b/tests/broadcast.test.ts
@@ -188,6 +188,49 @@ describeEachMode('Broadcast fan-out', (CONNECTION) => {
     await flushQueue(cleanupClient, Q + '-independent');
   });
 
+  it('a retrying subscriber does not redeliver to a subscriber that already completed', async () => {
+    const qName = Q + '-retry-iso';
+    const broadcast = new Broadcast(qName, { connection: CONNECTION });
+    const received = { success: [] as any[], failing: [] as any[] };
+    let failAttempts = 0;
+
+    const successWorker = new BroadcastWorker(
+      qName,
+      async (job) => {
+        received.success.push(job.data);
+      },
+      { connection: CONNECTION, subscription: 'ok', blockTimeout: 300, attempts: 1, promotionInterval: 100 },
+    );
+    const failingWorker = new BroadcastWorker(
+      qName,
+      async (job) => {
+        received.failing.push(job.data);
+        failAttempts += 1;
+        if (failAttempts < 3) throw new Error('retry-me');
+      },
+      {
+        connection: CONNECTION,
+        subscription: 'flaky',
+        blockTimeout: 300,
+        attempts: 3,
+        backoff: { type: 'fixed', delay: 50 },
+        promotionInterval: 100,
+      },
+    );
+
+    await Promise.all([successWorker.waitUntilReady(), failingWorker.waitUntilReady()]);
+    await broadcast.publish('message', { event: 'retry-iso' }, { attempts: 3, backoff: { type: 'fixed', delay: 50 } });
+
+    await waitFor(() => received.success.length === 1 && received.failing.length >= 3, 8000);
+    await new Promise((r) => setTimeout(r, 400));
+    expect(received.success).toHaveLength(1);
+
+    await successWorker.close(true);
+    await failingWorker.close(true);
+    await broadcast.close();
+    await flushQueue(cleanupClient, qName);
+  }, 15000);
+
   it('respects maxMessages retention limit', async () => {
     const broadcast = new Broadcast(Q + '-retention', { connection: CONNECTION, maxMessages: 5 });
 
@@ -209,6 +252,82 @@ describeEachMode('Broadcast fan-out', (CONNECTION) => {
       new BroadcastWorker(Q + '-invalid', async () => {}, { connection: CONNECTION, subscription: '' } as any);
     }).toThrow(/subscription/);
   });
+
+  it('pause, resume, setGlobalRateLimit, and getClient round-trip on a live subscription', async () => {
+    const qName = Q + '-ctl';
+    const broadcast = new Broadcast(qName, { connection: CONNECTION });
+    const received: unknown[] = [];
+    const worker = new BroadcastWorker(
+      qName,
+      async (job) => {
+        received.push(job.data);
+      },
+      {
+        connection: CONNECTION,
+        subscription: 'ctl-sub',
+        blockTimeout: 100,
+      },
+    );
+
+    await worker.waitUntilReady();
+    const client = await broadcast.getClient();
+    expect(typeof client.xlen).toBe('function');
+
+    await broadcast.setGlobalRateLimit({ max: 50, duration: 1000 });
+    await broadcast.pause();
+    await broadcast.resume();
+    await broadcast.setGlobalRateLimit(null);
+
+    await broadcast.publish('msg', { n: 1 });
+    await waitFor(() => received.length === 1, 8000);
+    expect(received[0]).toEqual({ n: 1 });
+
+    await worker.close(true);
+    await broadcast.close();
+    await flushQueue(cleanupClient, qName);
+  }, 20000);
+
+  it('BroadcastWorker honors queue global concurrency and emits drained', async () => {
+    const qName = Q + '-gc';
+    const queue = new Queue(qName, { connection: CONNECTION });
+    await queue.setGlobalConcurrency(1);
+    const broadcast = new Broadcast(qName, { connection: CONNECTION });
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let completed = 0;
+
+    const worker = new BroadcastWorker(
+      qName,
+      async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise<void>((resolve) => setTimeout(resolve, 150));
+        inFlight--;
+        completed++;
+      },
+      {
+        connection: CONNECTION,
+        subscription: 'gc-sub',
+        concurrency: 4,
+        blockTimeout: 100,
+      },
+    );
+    const drainedP = new Promise<void>((resolve) => {
+      worker.once('drained', () => resolve());
+    });
+
+    await worker.waitUntilReady();
+    await broadcast.publish('a', { n: 1 });
+    await broadcast.publish('a', { n: 2 });
+    await waitFor(() => completed === 2, 8000);
+    expect(maxInFlight).toBe(1);
+    await Promise.race([drainedP, new Promise<void>((resolve) => setTimeout(resolve, 2000))]);
+
+    await worker.close(true);
+    await broadcast.close();
+    await queue.close();
+    await flushQueue(cleanupClient, qName);
+  }, 15000);
 });
 
 describeEachMode('Broadcast with scheduler integration', (CONNECTION) => {

--- a/tests/dag.test.ts
+++ b/tests/dag.test.ts
@@ -871,4 +871,66 @@ describeEachMode('DAG flows', (CONNECTION) => {
       await flow.close();
     }
   });
+
+  it('getParents returns queue name and id for tree, diamond, and root jobs', async () => {
+    const qName = Q + '-parents';
+    const flow = new FlowProducer({ connection: CONNECTION });
+
+    try {
+      const tree = await flow.add({
+        name: 'parent',
+        queueName: qName,
+        data: { kind: 'tree-parent' },
+        children: [{ name: 'child', queueName: qName, data: { kind: 'tree-child' } }],
+      });
+      const treeChild = tree.children[0].job;
+      const treeParents = await treeChild.getParents();
+      expect(treeParents).toEqual([{ queue: qName, id: tree.job.id }]);
+      expect(await tree.job.getParents()).toEqual([]);
+
+      const jobs = await flow.addDAG({
+        nodes: [
+          { name: 'A', queueName: qName, data: { step: 'A' } },
+          { name: 'B', queueName: qName, data: { step: 'B' }, deps: ['A'] },
+          { name: 'C', queueName: qName, data: { step: 'C' }, deps: ['A'] },
+          { name: 'D', queueName: qName, data: { step: 'D' }, deps: ['B', 'C'] },
+        ],
+      });
+
+      const sourceParents = await jobs.get('A')!.getParents();
+      expect(sourceParents).toHaveLength(2);
+      expect(new Set(sourceParents.map((p) => p.queue))).toEqual(new Set([qName]));
+      expect(new Set(sourceParents.map((p) => p.id))).toEqual(new Set([jobs.get('B')!.id, jobs.get('C')!.id]));
+
+      expect(await jobs.get('D')!.getParents()).toEqual([]);
+    } finally {
+      await flow.close();
+      await flushQueue(cleanupClient, qName);
+    }
+  });
+
+  it('addDAG throws Duplicate job ID in DAG and does not overwrite the first job', async () => {
+    const qName = Q + '-dup-id';
+    const flow = new FlowProducer({ connection: CONNECTION });
+
+    try {
+      await expect(
+        flow.addDAG({
+          nodes: [
+            { name: 'A', queueName: qName, data: { n: 1 }, opts: { jobId: 'shared-dag-id' } },
+            { name: 'B', queueName: qName, data: { n: 2 }, opts: { jobId: 'shared-dag-id' } },
+          ],
+        }),
+      ).rejects.toThrow('Duplicate job ID in DAG');
+
+      const k = buildKeys(qName);
+      const raw = await cleanupClient.hget(k.job('shared-dag-id'), 'data');
+      if (raw != null) {
+        expect(JSON.parse(String(raw))).toEqual({ n: 1 });
+      }
+    } finally {
+      await flow.close();
+      await flushQueue(cleanupClient, qName);
+    }
+  });
 });

--- a/tests/dual-rate-limit.test.ts
+++ b/tests/dual-rate-limit.test.ts
@@ -399,6 +399,7 @@ describeEachMode('Dual-axis rate limiting (TPM)', (CONNECTION) => {
     const completionTimes: number[] = [];
     // Use a 2s window for reliability
     const WINDOW_MS = 2000;
+    await alignToTokenWindowStart(WINDOW_MS);
 
     const worker = new WorkerImpl(
       Q,
@@ -437,6 +438,7 @@ describeEachMode('Dual-axis rate limiting (TPM)', (CONNECTION) => {
     const queue = new QueueImpl(Q, { connection: CONNECTION });
     const completionTimes: number[] = [];
     const WINDOW_MS = 2000;
+    await alignToTokenWindowStart(WINDOW_MS);
 
     const worker = new WorkerImpl(
       Q,
@@ -472,6 +474,7 @@ describeEachMode('Dual-axis rate limiting (TPM)', (CONNECTION) => {
     const queue = new QueueImpl(Q, { connection: CONNECTION });
     const completionTimes: number[] = [];
     const WINDOW_MS = 2000;
+    await alignToTokenWindowStart(WINDOW_MS);
 
     const worker = new WorkerImpl(
       Q,
@@ -507,6 +510,7 @@ describeEachMode('Dual-axis rate limiting (TPM)', (CONNECTION) => {
     const queue = new QueueImpl(Q, { connection: CONNECTION });
     const completionTimes: number[] = [];
     const WINDOW_MS = 2000;
+    await alignToTokenWindowStart(WINDOW_MS);
 
     const worker = new WorkerImpl(
       Q,
@@ -576,6 +580,7 @@ describeEachMode('Dual-axis rate limiting (TPM)', (CONNECTION) => {
     const queue = new QueueImpl(Q, { connection: CONNECTION });
     const completionTimes: number[] = [];
     const WINDOW_MS = 2000;
+    await alignToTokenWindowStart(WINDOW_MS);
 
     const worker = new WorkerImpl(
       Q,
@@ -611,6 +616,7 @@ describeEachMode('Dual-axis rate limiting (TPM)', (CONNECTION) => {
     const queue = new QueueImpl(Q, { connection: CONNECTION });
     const completionTimes: number[] = [];
     const WINDOW_MS = 2000;
+    await alignToTokenWindowStart(WINDOW_MS);
 
     const worker = new WorkerImpl(
       Q,

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -89,6 +89,25 @@ describeEachMode('Queue.add + getJob', (CONNECTION) => {
     const result = await queue.getJob('999999');
     expect(result).toBeNull();
   });
+
+  it('getJob survives corrupt data, returnvalue, and parent JSON', async () => {
+    const job = await queue.add('corrupt-hash', { ok: true });
+    const k = buildKeys(Q);
+    await cleanupClient.hset(k.job(job.id), {
+      data: 'not-json{{{',
+      returnvalue: 'not-json{{{',
+      parentIds: 'not-json{{{',
+      parentQueues: 'not-json{{{',
+    });
+
+    const fetched = await queue.getJob(job.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.deserializationFailed).toBe(true);
+    expect(fetched!.data).toEqual({});
+    expect(fetched!.returnvalue).toBeUndefined();
+    expect(fetched!.parentIds).toBeUndefined();
+    expect(fetched!.parentQueues).toBeUndefined();
+  });
 });
 
 describeEachMode('Queue pause/resume', (CONNECTION) => {

--- a/tests/job-stream.test.ts
+++ b/tests/job-stream.test.ts
@@ -493,6 +493,17 @@ describeEachMode('Job streaming integration', (CONNECTION) => {
       expect(first[0].fields.token).toBe('first');
 
       const pending = queue.readStream(job.id, { lastId: first[0].id, block: 3000, count: 10 });
+      let settled = false;
+      void pending.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(settled).toBe(false);
       releaseSecond();
       const next = await pending;
       expect(next.some((e: { fields: Record<string, string> }) => e.fields.token === 'second')).toBe(true);

--- a/tests/job-stream.test.ts
+++ b/tests/job-stream.test.ts
@@ -465,4 +465,45 @@ describeEachMode('Job streaming integration', (CONNECTION) => {
       await flushQueue(cleanupClient, Q);
     }
   });
+
+  it('readStream({ block }) waits for a late chunk and times out when idle', async () => {
+    const Q = 'test-jstream-block-' + Date.now();
+    const queue = new QueueImpl(Q, { connection: CONNECTION });
+    let releaseSecond!: () => void;
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+
+    const worker = new WorkerImpl(
+      Q,
+      async (job: any) => {
+        await job.stream({ token: 'first' });
+        await secondGate;
+        await job.stream({ token: 'second' });
+        return 'done';
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 200 },
+    );
+
+    try {
+      const job = await queue.add('block-stream', {});
+      await waitFor(async () => (await queue.readStream(job.id)).length >= 1, 5000);
+
+      const first = await queue.readStream(job.id);
+      expect(first[0].fields.token).toBe('first');
+
+      const pending = queue.readStream(job.id, { lastId: first[0].id, block: 3000, count: 10 });
+      releaseSecond();
+      const next = await pending;
+      expect(next.some((e: { fields: Record<string, string> }) => e.fields.token === 'second')).toBe(true);
+
+      const idle = await queue.readStream(job.id, { lastId: next[next.length - 1]?.id ?? first[0].id, block: 200 });
+      expect(idle).toEqual([]);
+    } finally {
+      releaseSecond();
+      await worker.close();
+      await queue.close();
+      await flushQueue(cleanupClient, Q);
+    }
+  }, 15000);
 });

--- a/tests/producer.test.ts
+++ b/tests/producer.test.ts
@@ -225,6 +225,49 @@ describeEachMode('Producer - addBulk()', (CONNECTION) => {
     }
   });
 
+  it('addBulk honors deduplication and same-queue parents', async () => {
+    const parentId = await producer.add('parent', { kind: 'root' });
+    expect(parentId).not.toBeNull();
+
+    const ids = await producer.addBulk([
+      {
+        name: 'child',
+        data: { i: 1 },
+        opts: { parent: { id: parentId!, queue: Q }, deduplication: { id: 'prod-bulk-dedup' } },
+      },
+      {
+        name: 'child-dup',
+        data: { i: 2 },
+        opts: { deduplication: { id: 'prod-bulk-dedup' } },
+      },
+    ]);
+    expect(ids[0]).toBeTruthy();
+    expect(ids[1]).toBeNull();
+
+    const keys = buildKeys(Q);
+    const deps = await cleanupClient.smembers(keys.deps(parentId!));
+    expect([...deps].some((member: unknown) => String(member).includes(String(ids[0])))).toBe(true);
+  });
+
+  it('addBulk registers cross-queue parent deps', async () => {
+    const parentQ = Q + '-xq-parent';
+    const parentProducer = new Producer(parentQ, { connection: CONNECTION });
+    const parentId = await parentProducer.add('parent', { kind: 'xq' });
+    expect(parentId).not.toBeNull();
+
+    const ids = await producer.addBulk([
+      { name: 'xq-child', data: { i: 1 }, opts: { parent: { id: parentId!, queue: parentQ } } },
+    ]);
+    expect(ids[0]).toBeTruthy();
+
+    const parentKeys = buildKeys(parentQ);
+    const deps = await cleanupClient.smembers(parentKeys.deps(parentId!));
+    expect([...deps].some((member: unknown) => String(member).includes(String(ids[0])))).toBe(true);
+
+    await parentProducer.close();
+    await flushQueue(cleanupClient, parentQ);
+  });
+
   it('stores all jobs in Valkey', async () => {
     const ids = await producer.addBulk([
       { name: 'verify-1', data: { v: 'one' } },

--- a/tests/proxy-shutdown.test.ts
+++ b/tests/proxy-shutdown.test.ts
@@ -73,8 +73,15 @@ describe('HTTP proxy shutdown', () => {
       const lateBroadcast = await fetch(`${baseUrl}/broadcast/${queueName}/events?subscription=shut-sub`);
       expect(lateBroadcast.status).toBe(503);
 
-      const lateFlow = await fetch(`${baseUrl}/flows/missing-id`);
+      const lateFlow = await fetch(`${baseUrl}/flows`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ flow: { name: 'late', queueName, data: {} } }),
+      });
       expect(lateFlow.status).toBe(503);
+
+      const lateFlowGet = await fetch(`${baseUrl}/flows/missing-id`);
+      expect(lateFlowGet.status).toBe(503);
 
       const latePublish = await fetch(`${baseUrl}/broadcast/${queueName}`, {
         method: 'POST',

--- a/tests/proxy-shutdown.test.ts
+++ b/tests/proxy-shutdown.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Proxy close() must drain SSE and reject new queue/broadcast work with 503.
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import type { Server } from 'http';
+import { createCleanupClient, flushQueue, STANDALONE } from './helpers/fixture';
+
+const { createProxyServer } = require('../dist/proxy/index') as typeof import('../src/proxy/index');
+
+const CONNECTION = STANDALONE;
+
+async function listen(proxy: { app: { listen: (port: number, cb: () => void) => Server } }): Promise<{
+  baseUrl: string;
+  server: Server;
+}> {
+  return new Promise((resolve) => {
+    const server = proxy.app.listen(0, () => {
+      const addr = server.address();
+      if (typeof addr !== 'object' || !addr) {
+        throw new Error('proxy listen failed');
+      }
+      resolve({ baseUrl: `http://127.0.0.1:${addr.port}`, server });
+    });
+  });
+}
+
+describe('HTTP proxy shutdown', () => {
+  let cleanupClient: any;
+  const queueNames: string[] = [];
+
+  afterAll(async () => {
+    for (const name of queueNames) {
+      await flushQueue(cleanupClient, name).catch(() => undefined);
+    }
+    cleanupClient?.close();
+  });
+
+  it('close() ends live SSE and returns 503 for new queue and broadcast work', async () => {
+    cleanupClient = await createCleanupClient(CONNECTION);
+    const queueName = `proxy-shut-${Date.now()}`;
+    queueNames.push(queueName);
+
+    const proxy = createProxyServer({ connection: CONNECTION });
+    const { baseUrl, server } = await listen(proxy);
+
+    try {
+      const addRes = await fetch(`${baseUrl}/queues/${queueName}/jobs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'seed', data: {} }),
+      });
+      expect(addRes.status).toBe(201);
+
+      const queueEvents = await fetch(`${baseUrl}/queues/${queueName}/events`);
+      expect(queueEvents.status).toBe(200);
+
+      const broadcastEvents = await fetch(`${baseUrl}/broadcast/${queueName}/events?subscription=shut-sub`);
+      expect(broadcastEvents.status).toBe(200);
+
+      const inspectBefore = await fetch(`${baseUrl}/flows/missing-id`);
+      expect([200, 404]).toContain(inspectBefore.status);
+
+      await proxy.close();
+
+      const lateJob = await fetch(`${baseUrl}/queues/${queueName}/jobs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'late', data: {} }),
+      });
+      expect(lateJob.status).toBe(503);
+      expect((await lateJob.json()).error).toContain('shutting down');
+
+      const lateBroadcast = await fetch(`${baseUrl}/broadcast/${queueName}/events?subscription=shut-sub`);
+      expect(lateBroadcast.status).toBe(503);
+
+      const lateFlow = await fetch(`${baseUrl}/flows/missing-id`);
+      expect(lateFlow.status).toBe(503);
+
+      const latePublish = await fetch(`${baseUrl}/broadcast/${queueName}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ subject: 'late', data: {} }),
+      });
+      expect(latePublish.status).toBe(503);
+
+      await queueEvents.body?.cancel().catch(() => undefined);
+      await broadcastEvents.body?.cancel().catch(() => undefined);
+    } finally {
+      await proxy.close().catch(() => undefined);
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  }, 20000);
+});

--- a/tests/proxy-shutdown.test.ts
+++ b/tests/proxy-shutdown.test.ts
@@ -60,6 +60,14 @@ describe('HTTP proxy shutdown', () => {
       const inspectBefore = await fetch(`${baseUrl}/flows/missing-id`);
       expect([200, 404]).toContain(inspectBefore.status);
 
+      const concurrentLookups = await Promise.all([
+        fetch(`${baseUrl}/flows/missing-a`),
+        fetch(`${baseUrl}/flows/missing-b`),
+      ]);
+      for (const res of concurrentLookups) {
+        expect([200, 404]).toContain(res.status);
+      }
+
       await proxy.close();
 
       const lateJob = await fetch(`${baseUrl}/queues/${queueName}/jobs`, {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -226,6 +226,37 @@ describe('HTTP Proxy', () => {
     expect((await tooLarge.json()).error).toContain('opts.lockDuration must be a finite number between');
   });
 
+  it('POST /flows rejects out-of-range lockDuration on nested flow and DAG opts', async () => {
+    const queueName = uniqueQueue('flow-lockdur');
+
+    const treeRes = await fetch(`${baseUrl}/flows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        flow: {
+          children: [{ data: {}, name: 'child', opts: { lockDuration: 500 }, queueName }],
+          data: {},
+          name: 'root',
+          queueName,
+        },
+      }),
+    });
+    expect(treeRes.status).toBe(400);
+    expect((await treeRes.json()).error).toContain('opts.lockDuration must be a finite number between');
+
+    const dagRes = await fetch(`${baseUrl}/flows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        dag: {
+          nodes: [{ data: {}, name: 'n1', opts: { lockDuration: 500 }, queueName }],
+        },
+      }),
+    });
+    expect(dagRes.status).toBe(400);
+    expect((await dagRes.json()).error).toContain('opts.lockDuration must be a finite number between');
+  });
+
   it('POST /queues/:name/jobs - dedup returns 200 with skipped', async () => {
     const queueName = uniqueQueue('dedup');
 

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -143,13 +143,12 @@ describe('HTTP Proxy', () => {
   });
 
   afterAll(async () => {
+    server.closeAllConnections?.();
     await proxyClose();
     await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
-    for (const name of queueNames) {
-      await flushQueue(cleanupClient, name);
-    }
+    await Promise.allSettled(queueNames.map((name) => flushQueue(cleanupClient, name)));
     await cleanupClient.close();
-  });
+  }, 30000);
 
   it('POST /queues/:name/jobs - adds a job and returns 201', async () => {
     const queueName = uniqueQueue('add');
@@ -187,6 +186,44 @@ describe('HTTP Proxy', () => {
     const body = await res.json();
     expect(body.id).toBe('custom-123');
     expect(body.name).toBe('process-payment');
+  });
+
+  it('POST /queues/:name/jobs accepts in-range lockDuration and rejects out of range', async () => {
+    const queueName = uniqueQueue('lockdur');
+    const ok = await fetch(`${baseUrl}/queues/${queueName}/jobs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'locked',
+        data: {},
+        opts: { lockDuration: 5000 },
+      }),
+    });
+    expect(ok.status).toBe(201);
+
+    const tooSmall = await fetch(`${baseUrl}/queues/${queueName}/jobs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'locked',
+        data: {},
+        opts: { lockDuration: 500 },
+      }),
+    });
+    expect(tooSmall.status).toBe(400);
+    expect((await tooSmall.json()).error).toContain('opts.lockDuration must be a finite number between');
+
+    const tooLarge = await fetch(`${baseUrl}/queues/${queueName}/jobs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'locked',
+        data: {},
+        opts: { lockDuration: 86_400_001 },
+      }),
+    });
+    expect(tooLarge.status).toBe(400);
+    expect((await tooLarge.json()).error).toContain('opts.lockDuration must be a finite number between');
   });
 
   it('POST /queues/:name/jobs - dedup returns 200 with skipped', async () => {
@@ -558,6 +595,122 @@ describe('HTTP Proxy', () => {
       await revokeQueue.close();
     }
   });
+
+  it('POST /queues/:name/jobs/:id/signal resumes a suspended job', async () => {
+    const queueName = uniqueQueue('signal');
+    const queue = new Queue(queueName, { connection: CONNECTION });
+    const worker = new Worker(
+      queueName,
+      async (job: any) => {
+        if (job.signals.length === 0) {
+          await job.suspend({ reason: 'awaiting-signal', timeout: 60000 });
+        }
+        return { resumed: true, signal: job.signals[0]?.name };
+      },
+      { blockTimeout: 500, concurrency: 1, connection: CONNECTION },
+    );
+
+    try {
+      await worker.waitUntilReady();
+      const job = await queue.add('needs-signal', { step: 1 });
+      await waitFor(async () => (await queue.getSuspendInfo(job.id)) !== null, 10000);
+
+      const missingName = await fetch(`${baseUrl}/queues/${queueName}/jobs/${job.id}/signal`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: { ok: true } }),
+      });
+      expect(missingName.status).toBe(400);
+      expect((await missingName.json()).error).toContain('Missing required field: name');
+
+      const missingJob = await fetch(`${baseUrl}/queues/${queueName}/jobs/not-a-job/signal`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'approve' }),
+      });
+      expect(missingJob.status).toBe(200);
+      expect((await missingJob.json()).resumed).toBe(false);
+
+      const completed = waitFor(async () => {
+        const fetched = await queue.getJob(job.id);
+        return (await fetched?.getState()) === 'completed';
+      }, 10000);
+
+      const signalRes = await fetch(`${baseUrl}/queues/${queueName}/jobs/${job.id}/signal`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'approve', data: { by: 'proxy' } }),
+      });
+      expect(signalRes.status).toBe(200);
+      expect((await signalRes.json()).resumed).toBe(true);
+      await completed;
+
+      const fetched = await queue.getJob(job.id);
+      expect(fetched?.returnvalue).toEqual({ resumed: true, signal: 'approve' });
+    } finally {
+      await worker.close(true).catch(() => undefined);
+      await queue.close();
+    }
+  });
+
+  it('GET /queues/:name/jobs/:id/stream emits live chunks and resumes from Last-Event-ID', async () => {
+    const queueName = uniqueQueue('jstream');
+    const queue = new Queue(queueName, { connection: CONNECTION });
+    let releaseSecond!: () => void;
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const worker = new Worker(
+      queueName,
+      async (job: any) => {
+        await job.stream({ token: 'one' });
+        await secondGate;
+        await job.stream({ token: 'two' });
+        return 'done';
+      },
+      { blockTimeout: 500, concurrency: 1, connection: CONNECTION },
+    );
+    const ac = new AbortController();
+
+    try {
+      await worker.waitUntilReady();
+      const job = await queue.add('stream-live', {});
+      const streamUrl = `${baseUrl}/queues/${queueName}/jobs/${job.id}/stream`;
+
+      const liveRes = await fetch(streamUrl, { signal: ac.signal });
+      expect(liveRes.status).toBe(200);
+      const liveReader = createSseReader(liveRes);
+      const first = await liveReader.nextEvent(8000);
+      expect(first.data.token).toBe('one');
+      expect(first.id).toBeTruthy();
+
+      const resumeRes = await fetch(streamUrl, {
+        headers: { 'Last-Event-ID': first.id as string },
+        signal: ac.signal,
+      });
+      expect(resumeRes.status).toBe(200);
+      const resumeReader = createSseReader(resumeRes);
+      releaseSecond();
+      const second = await resumeReader.nextEvent(8000);
+      expect(second.data.token).toBe('two');
+
+      await waitFor(async () => (await job.getState()) === 'completed', 8000);
+
+      const lastIdRes = await fetch(`${streamUrl}?lastId=${encodeURIComponent(String(second.id))}`, {
+        signal: ac.signal,
+      });
+      expect(lastIdRes.status).toBe(200);
+      await lastIdRes.body?.cancel().catch(() => undefined);
+
+      await liveReader.close();
+      await resumeReader.close();
+    } finally {
+      ac.abort();
+      releaseSecond();
+      await worker.close(true).catch(() => undefined);
+      await queue.close();
+    }
+  }, 20000);
 
   it('drain, retry, and clean endpoints work', async () => {
     const drainQueueName = uniqueQueue('drain');
@@ -1094,6 +1247,24 @@ describe('HTTP Proxy', () => {
     expect(typeof body.queues).toBe('number');
   });
 
+  it('GET /broadcast/:name/events requires subscription', async () => {
+    const queueName = uniqueQueue('bcast-nosub');
+    const res = await fetch(`${baseUrl}/broadcast/${queueName}/events`);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain('subscription');
+  });
+
+  it('rejects malformed JSON', async () => {
+    const queueName = uniqueQueue('badjson');
+    const malformed = await fetch(`${baseUrl}/queues/${queueName}/jobs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{not json',
+    });
+    expect(malformed.status).toBe(400);
+    expect((await malformed.json()).error).toBe('Bad request');
+  });
+
   it('missing body fields return 400', async () => {
     const queueName = uniqueQueue('missing');
 
@@ -1331,8 +1502,7 @@ describe('HTTP Proxy - Payload Limits', () => {
       body: JSON.stringify({ name: 'big', data: { payload: largeData } }),
     });
 
-    // Express will return 413 Payload Too Large (express.json limit)
-    // or 500 if glide-mq rejects it - either is acceptable
-    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBe(413);
+    expect((await res.json()).error).toBe('Payload too large');
   });
 });

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -289,6 +289,32 @@ describe('HTTP Proxy', () => {
     expect(badDag.status).toBe(400);
     expect((await badDag.json()).error).toContain('dag.nodes must be an array');
 
+    const badChildrenType = await fetch(`${baseUrl}/flows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        flow: { children: { not: 'array' }, data: {}, name: 'root', queueName },
+      }),
+    });
+    expect(badChildrenType.status).toBe(400);
+    expect((await badChildrenType.json()).error).toContain('children must be an array');
+
+    const badDagNode = await fetch(`${baseUrl}/flows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dag: { nodes: [null] } }),
+    });
+    expect(badDagNode.status).toBe(400);
+    expect((await badDagNode.json()).error).toContain('must be an object');
+
+    const dagArray = await fetch(`${baseUrl}/flows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dag: [] }),
+    });
+    expect(dagArray.status).toBe(400);
+    expect((await dagArray.json()).error).toContain('dag must be an object');
+
     const fallbacksRes = await fetch(`${baseUrl}/flows`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -271,6 +271,24 @@ describe('HTTP Proxy', () => {
     });
     expect(okTree.status).toBe(201);
 
+    const badChild = await fetch(`${baseUrl}/flows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        flow: { children: [null], data: {}, name: 'root', queueName },
+      }),
+    });
+    expect(badChild.status).toBe(400);
+    expect((await badChild.json()).error).toContain('must be an object');
+
+    const badDag = await fetch(`${baseUrl}/flows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dag: {} }),
+    });
+    expect(badDag.status).toBe(400);
+    expect((await badDag.json()).error).toContain('dag.nodes must be an array');
+
     const fallbacksRes = await fetch(`${baseUrl}/flows`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -255,6 +255,20 @@ describe('HTTP Proxy', () => {
     });
     expect(dagRes.status).toBe(400);
     expect((await dagRes.json()).error).toContain('opts.lockDuration must be a finite number between');
+
+    const fallbacksRes = await fetch(`${baseUrl}/flows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        flow: {
+          data: {},
+          name: 'root',
+          opts: { fallbacks: [{ model: 'gpt-4o-mini' }] },
+          queueName,
+        },
+      }),
+    });
+    expect(fallbacksRes.status).toBe(201);
   });
 
   it('POST /queues/:name/jobs - dedup returns 200 with skipped', async () => {

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -256,6 +256,21 @@ describe('HTTP Proxy', () => {
     expect(dagRes.status).toBe(400);
     expect((await dagRes.json()).error).toContain('opts.lockDuration must be a finite number between');
 
+    const okTree = await fetch(`${baseUrl}/flows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        flow: {
+          children: [{ data: {}, name: 'child', opts: { lockDuration: 5000 }, queueName }],
+          data: {},
+          name: 'root',
+          opts: { lockDuration: 5000 },
+          queueName,
+        },
+      }),
+    });
+    expect(okTree.status).toBe(201);
+
     const fallbacksRes = await fetch(`${baseUrl}/flows`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/tests/rate-limiting.test.ts
+++ b/tests/rate-limiting.test.ts
@@ -13,7 +13,7 @@ const { Queue } = require('../dist/queue') as typeof import('../src/queue');
 const { Worker } = require('../dist/worker') as typeof import('../src/worker');
 const { buildKeys } = require('../dist/utils') as typeof import('../src/utils');
 
-import { describeEachMode, createCleanupClient, flushQueue } from './helpers/fixture';
+import { describeEachMode, createCleanupClient, flushQueue, waitFor } from './helpers/fixture';
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -700,5 +700,78 @@ describeEachMode('Rate limiting', (CONNECTION) => {
 
     await q.close();
     await flushQueue(cleanupClient, Q);
+  }, 15000);
+
+  it('queue.rateLimitGroup records resumeAt and honors extend max vs replace', async () => {
+    const Qg = uniqueQueueName('-ext-rlg');
+    const q = new Queue(Qg, { connection: CONNECTION });
+    const groupKey = 'ext-group';
+    const k = buildKeys(Qg);
+
+    const resumeAt = await q.rateLimitGroup(groupKey, 800, { extend: 'replace' });
+    expect(resumeAt).toBeGreaterThan(Date.now() - 50);
+    expect(Number(await cleanupClient.zscore(k.ratelimited, groupKey))).toBe(resumeAt);
+
+    const maxed = await q.rateLimitGroup(groupKey, 200, { extend: 'max' });
+    expect(maxed).toBe(resumeAt);
+
+    const replaced = await q.rateLimitGroup(groupKey, 150, { extend: 'replace' });
+    expect(replaced).toBeLessThan(maxed);
+    expect(Number(await cleanupClient.zscore(k.ratelimited, groupKey))).toBe(replaced);
+
+    await q.add('task', { seq: 1 }, { ordering: { key: groupKey } });
+    await q.add('task', { seq: 2 }, { ordering: { key: groupKey } });
+
+    const finished: number[] = [];
+    const worker = new Worker(
+      Qg,
+      async (job: any) => {
+        finished.push(job.data.seq);
+        return 'ok';
+      },
+      {
+        connection: CONNECTION,
+        concurrency: 1,
+        blockTimeout: 100,
+        stalledInterval: 60000,
+        promotionInterval: 100,
+      },
+    );
+    worker.on('error', () => {});
+    await worker.waitUntilReady();
+    await waitFor(() => finished.length === 2, 8000);
+    expect(finished.sort()).toEqual([1, 2]);
+
+    await worker.close(true);
+    await q.close();
+    await flushQueue(cleanupClient, Qg);
+  }, 20000);
+
+  it('job.rateLimitGroup without ordering.key fails the job', async () => {
+    const Qg = uniqueQueueName('-nongroup-rlg');
+    const q = new Queue(Qg, { connection: CONNECTION });
+    let caught: Error | undefined;
+
+    const worker = new Worker(
+      Qg,
+      async (job: any) => {
+        try {
+          await job.rateLimitGroup(250);
+        } catch (err) {
+          caught = err as Error;
+          throw err;
+        }
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 200 },
+    );
+    worker.on('error', () => {});
+    await worker.waitUntilReady();
+    const job = await q.add('ungrouped', {});
+    await waitFor(async () => (await job.getState()) === 'failed', 8000);
+    expect(caught?.message).toMatch(/group key/);
+
+    await worker.close(true);
+    await q.close();
+    await flushQueue(cleanupClient, Qg);
   }, 15000);
 });

--- a/tests/rate-limiting.test.ts
+++ b/tests/rate-limiting.test.ts
@@ -719,6 +719,9 @@ describeEachMode('Rate limiting', (CONNECTION) => {
     expect(replaced).toBeLessThan(maxed);
     expect(Number(await cleanupClient.zscore(k.ratelimited, groupKey))).toBe(replaced);
 
+    const blockedUntil = await q.rateLimitGroup(groupKey, 2000, { extend: 'replace' });
+    expect(blockedUntil).toBeGreaterThan(replaced);
+
     await q.add('task', { seq: 1 }, { ordering: { key: groupKey } });
     await q.add('task', { seq: 2 }, { ordering: { key: groupKey } });
 
@@ -738,13 +741,17 @@ describeEachMode('Rate limiting', (CONNECTION) => {
       },
     );
     worker.on('error', () => {});
-    await worker.waitUntilReady();
-    await waitFor(() => finished.length === 2, 8000);
-    expect(finished.sort()).toEqual([1, 2]);
-
-    await worker.close(true);
-    await q.close();
-    await flushQueue(cleanupClient, Qg);
+    try {
+      await worker.waitUntilReady();
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      expect(finished).toEqual([]);
+      await waitFor(() => finished.length === 2, 10000);
+      expect(finished.sort()).toEqual([1, 2]);
+    } finally {
+      await worker.close(true);
+      await q.close();
+      await flushQueue(cleanupClient, Qg);
+    }
   }, 20000);
 
   it('job.rateLimitGroup without ordering.key fails the job', async () => {

--- a/tests/rate-limiting.test.ts
+++ b/tests/rate-limiting.test.ts
@@ -721,6 +721,7 @@ describeEachMode('Rate limiting', (CONNECTION) => {
 
     const blockedUntil = await q.rateLimitGroup(groupKey, 2000, { extend: 'replace' });
     expect(blockedUntil).toBeGreaterThan(replaced);
+    expect(Number(await cleanupClient.zscore(k.ratelimited, groupKey))).toBe(blockedUntil);
 
     await q.add('task', { seq: 1 }, { ordering: { key: groupKey } });
     await q.add('task', { seq: 2 }, { ordering: { key: groupKey } });
@@ -743,8 +744,6 @@ describeEachMode('Rate limiting', (CONNECTION) => {
     worker.on('error', () => {});
     try {
       await worker.waitUntilReady();
-      await new Promise((resolve) => setTimeout(resolve, 400));
-      expect(finished).toEqual([]);
       await waitFor(() => finished.length === 2, 10000);
       expect(finished.sort()).toEqual([1, 2]);
     } finally {

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -866,23 +866,25 @@ describeEachMode('Job schedulers', (CONNECTION) => {
       );
       worker.on('error', () => {});
 
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => reject(new Error('timeout waiting for scheduler jobs')), 8000);
-        const check = () => {
-          if (processed.length >= 2) {
-            clearTimeout(timeout);
-            resolve();
-          }
-        };
-        worker.on('completed', check);
-      });
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(() => reject(new Error('timeout waiting for scheduler jobs')), 8000);
+          const check = () => {
+            if (processed.length >= 2) {
+              clearTimeout(timeout);
+              resolve();
+            }
+          };
+          worker.on('completed', check);
+        });
 
-      await worker.close(true);
-
-      const later = await localQueue.getJobScheduler('anchor');
-      expect(later).not.toBeNull();
-      expect(later!.nextRun).toBeGreaterThan(firstNext);
-      expect((later!.nextRun - firstNext) % every).toBe(0);
+        const later = await localQueue.getJobScheduler('anchor');
+        expect(later).not.toBeNull();
+        expect(later!.nextRun).toBeGreaterThan(firstNext);
+        expect((later!.nextRun - firstNext) % every).toBe(0);
+      } finally {
+        await worker.close(true);
+      }
     } finally {
       await localQueue.removeJobScheduler('anchor').catch(() => {});
       await localQueue.close();

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -837,4 +837,56 @@ describeEachMode('Job schedulers', (CONNECTION) => {
       queue.upsertJobScheduler('bad-combo-2', { pattern: '* * * * *', repeatAfterComplete: 500 } as any),
     ).rejects.toThrow('mutually exclusive');
   });
+
+  it('every scheduler nextRun stays on the interval grid after a late tick', async () => {
+    const qName = Q + '-anchor-' + Date.now();
+    const localQueue = new Queue(qName, { connection: CONNECTION });
+    const every = 500;
+    const processed: string[] = [];
+
+    try {
+      await localQueue.upsertJobScheduler('anchor', { every }, { name: 'anchored', data: { n: 1 } });
+      const initial = await localQueue.getJobScheduler('anchor');
+      expect(initial).not.toBeNull();
+      const firstNext = initial!.nextRun;
+      expect(firstNext).toBeGreaterThan(0);
+
+      const worker = new Worker(
+        qName,
+        async () => {
+          processed.push('ok');
+        },
+        {
+          connection: CONNECTION,
+          concurrency: 1,
+          blockTimeout: 200,
+          promotionInterval: 200,
+          stalledInterval: 60000,
+        },
+      );
+      worker.on('error', () => {});
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('timeout waiting for scheduler jobs')), 8000);
+        const check = () => {
+          if (processed.length >= 2) {
+            clearTimeout(timeout);
+            resolve();
+          }
+        };
+        worker.on('completed', check);
+      });
+
+      await worker.close(true);
+
+      const later = await localQueue.getJobScheduler('anchor');
+      expect(later).not.toBeNull();
+      expect(later!.nextRun).toBeGreaterThan(firstNext);
+      expect((later!.nextRun - firstNext) % every).toBe(0);
+    } finally {
+      await localQueue.removeJobScheduler('anchor').catch(() => {});
+      await localQueue.close();
+      await flushQueue(cleanupClient, qName);
+    }
+  }, 15000);
 });

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -282,4 +282,42 @@ describeEachMode('Queue.searchJobs', (CONNECTION) => {
     await q.close();
     await flushQueue(cleanupClient, qName);
   }, 15000);
+
+  it('search by name in the active state', async () => {
+    const qName = Q + '-active-name';
+    const q = new Queue(qName, { connection: CONNECTION });
+
+    expect(await q.searchJobs({ state: 'active', name: 'hold-me' })).toEqual([]);
+
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const worker = new Worker(
+      qName,
+      async (job) => {
+        if (job.name === 'hold-me') await gate;
+      },
+      { connection: CONNECTION, concurrency: 1, blockTimeout: 200, stalledInterval: 60000 },
+    );
+    worker.on('error', () => {});
+    await worker.waitUntilReady();
+    await q.add('hold-me', { n: 1 });
+    await q.add('other', { n: 2 });
+
+    await waitFor(async () => {
+      const active = await q.searchJobs({ state: 'active', name: 'hold-me' });
+      return active.length === 1;
+    }, 8000);
+
+    const held = await q.searchJobs({ state: 'active', name: 'hold-me' });
+    expect(held).toHaveLength(1);
+    expect(held[0].name).toBe('hold-me');
+    expect(await q.searchJobs({ state: 'active', name: 'other' })).toHaveLength(0);
+
+    release();
+    await worker.close(true);
+    await q.close();
+    await flushQueue(cleanupClient, qName);
+  }, 15000);
 });

--- a/tests/serverless-pool.test.ts
+++ b/tests/serverless-pool.test.ts
@@ -94,6 +94,35 @@ describeEachMode('ServerlessPool - caching', (CONNECTION) => {
     expect(pPlain).not.toBe(pCreds);
     expect(pool.size).toBe(2);
   });
+
+  it('isolates IAM credential fingerprints and reuses identical IAM creds', () => {
+    const iamA = {
+      ...CONNECTION,
+      credentials: {
+        type: 'iam' as const,
+        serviceType: 'elasticache' as const,
+        region: 'us-east-1',
+        userId: 'user-a',
+        clusterName: 'cluster-a',
+      },
+    };
+    const iamB = {
+      ...CONNECTION,
+      credentials: {
+        type: 'iam' as const,
+        serviceType: 'elasticache' as const,
+        region: 'us-east-1',
+        userId: 'user-b',
+        clusterName: 'cluster-b',
+      },
+    };
+    const pA1 = pool.getProducer(Q1, { connection: iamA });
+    const pA2 = pool.getProducer(Q1, { connection: iamA });
+    const pB = pool.getProducer(Q1, { connection: iamB });
+    expect(pA1).toBe(pA2);
+    expect(pA1).not.toBe(pB);
+    expect(pool.size).toBe(2);
+  });
 });
 
 describeEachMode('ServerlessPool - closeAll', (CONNECTION) => {

--- a/tests/suspend-signal.test.ts
+++ b/tests/suspend-signal.test.ts
@@ -751,4 +751,88 @@ describeEachMode('Suspend/Signal', (CONNECTION) => {
     await worker.close();
     await queue.close();
   }, 20000);
+
+  it('getSuspendedJobs paginates and can omit data', async () => {
+    const qName = uniqueQ();
+    queuesToFlush.push(qName);
+    const queue = new Queue(qName, { connection: CONNECTION });
+
+    expect(await queue.getSuspendedJobs()).toEqual([]);
+
+    const worker = new Worker(
+      qName,
+      async (job: any) => {
+        if (job.signals.length === 0) {
+          await job.suspend({ reason: `r-${job.data.n}`, timeout: 60000 });
+        }
+        return 'ok';
+      },
+      { connection: CONNECTION, concurrency: 2, blockTimeout: 200 },
+    );
+    worker.on('error', () => {});
+    await worker.waitUntilReady();
+
+    const first = await queue.add('s', { n: 1, secret: 'aaa' });
+    const second = await queue.add('s', { n: 2, secret: 'bbb' });
+
+    await waitFor(async () => (await queue.getSuspendedJobs()).length === 2, 8000);
+
+    const all = await queue.getSuspendedJobs();
+    expect(all.map((j) => j.id).sort()).toEqual([first!.id, second!.id].sort());
+    expect(all.every((j) => j.data.secret)).toBe(true);
+
+    const page0 = await queue.getSuspendedJobs(0, 0);
+    expect(page0).toHaveLength(1);
+    const page1 = await queue.getSuspendedJobs(1, -1);
+    expect(page1).toHaveLength(1);
+    expect(new Set([...page0, ...page1].map((j) => j.id))).toEqual(new Set([first!.id, second!.id]));
+
+    const stripped = await queue.getSuspendedJobs(0, -1, { excludeData: true });
+    expect(stripped).toHaveLength(2);
+    expect(stripped.every((j) => j.data === undefined)).toBe(true);
+
+    await worker.close(true);
+    await queue.close();
+  }, 20000);
+
+  it('getSuspendInfo parses nested JSON signal data and ignores corrupt blobs', async () => {
+    const qName = uniqueQ();
+    queuesToFlush.push(qName);
+    const queue = new Queue(qName, { connection: CONNECTION });
+    const k = buildKeys(qName);
+
+    const worker = new Worker(
+      qName,
+      async (job: any) => {
+        if (job.signals.length === 0) {
+          await job.suspend({ reason: 'parse-signals', timeout: 60000 });
+        }
+        return 'ok';
+      },
+      { connection: CONNECTION },
+    );
+    await worker.waitUntilReady();
+    const added = await queue.add('suspend-parse', {});
+
+    await waitFor(async () => (await queue.getSuspendInfo(added!.id)) !== null, 8000);
+
+    await cleanupClient.hset(k.job(added!.id), {
+      signals: JSON.stringify([
+        { name: 'nested', data: '{"ok":true}' },
+        { name: 'plain', data: 'not-json' },
+      ]),
+    });
+    const parsed = await queue.getSuspendInfo(added!.id);
+    expect(parsed?.signals).toEqual([
+      { name: 'nested', data: { ok: true } },
+      { name: 'plain', data: 'not-json' },
+    ]);
+
+    await cleanupClient.hset(k.job(added!.id), { signals: 'not-json{{{' });
+    const corrupt = await queue.getSuspendInfo(added!.id);
+    expect(corrupt?.signals).toEqual([]);
+
+    await worker.close(true);
+    await queue.close();
+  }, 15000);
 });


### PR DESCRIPTION
Takeover of #280 by @jonathanong (all substantive work is his - branch is his head `85e6106` merged with current main).

#280 was reviewed and approved but went CONFLICTING after #282 and the v0.15.5 release merged. Author has not pushed since; taking it over to land it.

**Content (unchanged from #280):**
- ~95% test files: live Valkey/proxy integration coverage (proxy, broadcast/job-stream SSE, scheduler, rate limiting, DAG/flows, suspend-signal, serverless pool, and more)
- src: extracted SSE/parse helpers, behavior-preserving fixes - proxy `lockDuration` allowlist, `Job.getParents()` last-colon parse, SSE loops exit on `draining`, `getSharedClient` gated on drain, single-flight shared client init

**Conflict resolution:**
- Only conflict was `HANDOVER.md` - kept both #280's coverage notes and main's #282 notes
- src/ auto-merged cleanly; #282 (close-time fetch-next) semantics fully preserved - its changes live in `worker.ts`, untouched by #280

**Local verification:** CI-equivalent integration suite (standalone :6379 + cluster :7000-7005): 2450/2451 passed. The single failure (`rate-limit-tombstone.test.ts`, cluster ordered-tombstone successor) is a file untouched by this PR and passes standalone - flaky under full-suite load.

Closes #280.